### PR TITLE
docs(agents): improve AGENTS.md for multi-model consumption

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,10 @@
 
 ## Overview
 
-Unified MCP Server is a Go application that aggregates multiple third-party integrations (GitHub, Datadog, Linear, Sentry, Slack, Metabase) behind a single [Model Context Protocol](https://modelcontextprotocol.io/) endpoint. AI clients connect via HTTP (streamable HTTP transport) and get access to all configured integrations through just two tools: **search** and **execute**. A web config UI is served on the same port.
-
-The server follows a **hexagonal architecture** (ports and adapters) and uses the **search/execute pattern** inspired by [Cloudflare's Code Mode MCP](https://blog.cloudflare.com/code-mode-mcp/) — instead of exposing dozens of individual MCP tools, the server exposes only two meta-tools that allow progressive discovery and execution of any underlying integration operation.
+- Go MCP server aggregating GitHub, Datadog, Linear, Sentry, Slack, Metabase behind one endpoint
+- Two meta-tools only: **search** (discover operations) and **execute** (run them)
+- Hexagonal architecture (ports and adapters)
+- HTTP transport (streamable) + web config UI on same port
 
 ## Commands
 
@@ -38,26 +39,38 @@ goreleaser release --snapshot --clean
 git tag -a v0.1.0 -m "v0.1.0"
 git push origin v0.1.0
 # CI (or manually): goreleaser release --clean
+
+# Generate templ templates (required after editing .templ files in web/templates/)
+templ generate
 ```
 
-**Release tooling**: [GoReleaser](https://goreleaser.com/) is configured via `.goreleaser.yml`. It builds cross-platform binaries (darwin/linux/windows, amd64/arm64), produces `.deb`, `.rpm`, `.apk`, and `.archlinux` packages, and publishes to Homebrew (`daltoniam/homebrew-tap`), Scoop (`daltoniam/scoop-bucket`), and AUR (`switchboard-bin`). Version info is injected via ldflags (`main.version`, `main.commit`, `main.date`). The `--version` flag prints build metadata.
-
-**Testing**: Uses [`github.com/stretchr/testify`](https://github.com/stretchr/testify) for assertions and test helpers. Tests exist for every package.
-
-**Linting**: [golangci-lint](https://golangci-lint.run/) is configured via `.golangci.yml` with errcheck, govet, ineffassign, staticcheck, and unused linters enabled.
-
-**CI/CD**: GitHub Actions workflow at `.github/workflows/ci.yml` runs on PRs and pushes to `main`. Jobs: build, test (with race detection), golangci-lint, gosec (security scanner), and govulncheck (vulnerability checker). All must pass before merging.
-
-Go 1.25 with `github.com/modelcontextprotocol/go-sdk`, `github.com/google/go-github/v68`, `github.com/slack-go/slack`, `github.com/a-h/templ`, and `github.com/stretchr/testify` as direct dependencies.
+- **Templ**: `web/templates/*.templ` → run `templ generate` after edits. **Never edit `*_templ.go`** (generated)
+- **Release**: GoReleaser via `.goreleaser.yml`. Ldflags: `main.version`, `main.commit`, `main.date`
+- **Testing**: `stretchr/testify` assertions. Tests in every package
+- **Linting**: `.golangci.yml` — errcheck, govet, ineffassign, staticcheck, unused
+- **CI**: `.github/workflows/ci.yml` — build, test (race), golangci-lint, gosec, govulncheck
+- **Go 1.25** — deps: `go-sdk`, `go-github/v68`, `slack-go/slack`, `a-h/templ`, `testify`
 
 ## Requirements Before Completing Code Changes
 
-All of the following **must pass** before any code change is considered complete:
+1. **Build**: `go build -o switchboard ./cmd/server` — no errors
+2. **Tests**: `go test ./...` all green. `go test -race ./...` for race detection
+3. **Lint**: `golangci-lint run` — no errors
+4. **New code must include tests**
 
-1. **Build**: `go build -o switchboard ./cmd/server` must succeed with no errors.
-2. **Tests**: `go test ./...` must pass with all tests green. Run `go test -race ./...` to check for race conditions.
-3. **Lint**: `golangci-lint run` must pass with no errors.
-4. **New code must include tests**: Any new feature, integration, or bug fix must include corresponding test coverage.
+## Git Workflow
+
+- Branch from `main` for all changes
+- CI runs on PRs to `main`: build, test (race detection), lint, gosec, govulncheck — all must pass
+- Commit messages: descriptive subject line, imperative mood (e.g., "Add Linear OAuth flow", "Fix token refresh race condition")
+- PRs should include tests for new functionality
+
+## Commit Attribution
+
+AI commits MUST include:
+```
+Co-Authored-By: <agent model name> <noreply@anthropic.com>
+```
 
 ## Project Structure
 
@@ -78,6 +91,7 @@ github/
   actions.go                 Actions workflows, runs, jobs, secrets, checks handlers
   search.go                  Search (code, issues, users, commits) handlers
   extras.go                  Gists, activity, code/secret/dependabot scanning, copilot handlers
+  oauth.go                   GitHub Device Flow OAuth (device code grant, polling, token exchange)
 datadog/
   datadog.go                 Datadog integration adapter (core, dispatch, SDK client, helpers)
   tools.go                   Datadog tool definitions (~60 tools)
@@ -97,6 +111,7 @@ linear/
   extras.go                  Cycles, labels, workflow states, documents, initiatives,
                              favorites, webhooks, notifications, templates, org,
                              custom views, rate limit handlers
+  oauth.go                   Linear OAuth (PKCE authorization code flow, token exchange)
 sentry/
   sentry.go                  Sentry integration adapter (core, dispatch, HTTP helpers)
   tools.go                   Sentry tool definitions (~55 tools)
@@ -104,6 +119,7 @@ sentry/
   issues.go                  Projects, issues, events, tags, stats handlers
   releases.go                Releases, deploys, commits, files handlers
   extras.go                  Alerts, monitors (cron), discover, replays handlers
+  oauth.go                   Sentry Device Flow OAuth (device code grant, polling)
 slack/
   slack.go                   Slack integration adapter (core, dispatch, cookie transport, mutex-protected client)
   tokens.go                  Token store (persistence, Chrome disk-read extraction via LevelDB+SQLite+AES, background refresh)
@@ -113,6 +129,8 @@ slack/
   users.go                   Users, user groups, presence handlers
   extras.go                  Files, bookmarks, reminders, emoji, team info, auth handlers
   extract.go                 Exported helpers for web UI token extraction (Chrome, manual, snippet)
+  oauth.go                   Slack OAuth v2 (authorization code flow, callback handling)
+  refresh.go                 Cookie-based token refresh (fetches fresh xoxc via xoxd cookie HTTP request)
 metabase/
   metabase.go                Metabase integration adapter (core, dispatch, HTTP helpers)
   tools.go                   Metabase tool definitions (~22 tools)
@@ -122,51 +140,64 @@ metabase/
   collections.go             Collection CRUD, search handlers
 web/
   web.go                     Web UI HTTP server for config dashboard + Slack token setup routes
-  templates/                 Templ-based component templates (layouts, pages, components, slack_setup)
+  templates/                 Templ-based templates — do not edit *_templ.go (generated)
+    layouts/                 Base layout templates
+    pages/                   dashboard, integrations_list, integration detail,
+                             github_setup, linear_setup, sentry_setup, slack_setup
+    components/              Shared UI components
 ```
 
 ## Architecture
 
 ### Hexagonal Pattern
 
-The root package (`mcp.go`) defines all domain types and port interfaces. Adapter packages satisfy those interfaces. Nothing in the core depends on infrastructure — dependencies point inward.
+The root package is `package mcp` (not `switchboard`, despite the module name). Import as:
+```go
+mcp "github.com/daltoniam/switchboard"
+```
 
+Defines domain types and port interfaces. Adapters satisfy interfaces. Dependencies point inward.
+
+```mermaid
+graph BT
+    subgraph "Adapters"
+        GH["github/"] & DD["datadog/"] & LN["linear/"]
+        SN["sentry/"] & SL["slack/"] & MB["metabase/"]
+        CF["config/"] & RG["registry/"]
+    end
+
+    GH & DD & LN & SN & SL & MB -->|implements\nIntegration| Core
+    CF -->|implements\nConfigService| Core
+    RG -->|implements\nRegistry| Core
+
+    Core["mcp.go\n(types + port interfaces)"]
+
+    SRV["server/"] & WEB["web/"] -->|consumes| DI["Services\n(DI container)"]
+    DI --> Core
 ```
-                    ┌─────────────────────────┐
-                    │      mcp.go (core)       │
-                    │                          │
-                    │  Types:                  │
-                    │    Config, Credentials   │
-                    │    ToolDefinition        │
-                    │    ToolResult            │
-                    │                          │
-                    │  Ports (interfaces):     │
-                    │    Integration           │
-                    │    ConfigService         │
-                    │    Registry              │
-                    │    Services (DI struct)   │
-                    └────────┬────────────────┘
-                             │ implements
-          ┌──────────┬───────┼───────┬──────────┐
-          │          │       │       │          │
-      github/    datadog/ linear/ sentry/  slack/   config/
-      (adapter)  (adapter) (adapter) (adapter) (adapter) (adapter)
-```
+
+**Core (`mcp.go`)**:
+- Types: `Config`, `Credentials`, `IntegrationConfig`, `ToolDefinition`, `ToolResult`, `HealthStatus`
+- Port interfaces: `Integration`, `ConfigService`, `Registry`
+- DI container: `Services` struct
+
+**Adapters** (each implements a port interface):
+- `github/`, `datadog/`, `linear/`, `sentry/`, `slack/`, `metabase/` → `Integration`
+- `config/` → `ConfigService`
+- `registry/` → `Registry`
+- `server/` → MCP server (consumes `Services`)
+- `web/` → Web UI server (consumes `Services`)
 
 ### Search/Execute Pattern
 
-Instead of registering every integration tool as a separate MCP tool (which bloats the AI's context window), the server exposes exactly **two tools**:
-
 | MCP Tool | Purpose |
 |----------|---------|
-| `search` | Discover available tools across all enabled integrations. Filter by name, integration, or keyword. Returns tool definitions with parameters. |
-| `execute` | Run a discovered tool by name with arguments. Routes to the correct integration adapter. |
+| `search` | Discover tools across enabled integrations. Filter by name, integration, keyword. Returns `ToolDefinition`s |
+| `execute` | Run a tool by name with arguments. Routes to correct adapter |
 
 **Flow:**
-1. AI calls `search({"query": "github issues"})` → gets tool definitions with parameter schemas
-2. AI calls `execute({"tool_name": "github_list_issues", "arguments": {"owner": "golang", "repo": "go"}})` → gets results
-
-This keeps the MCP tool count fixed at 2 regardless of how many integrations or operations are added.
+1. `search({"query": "github issues"})` → tool definitions with parameter schemas
+2. `execute({"tool_name": "github_list_issues", "arguments": {"owner": "golang", "repo": "go"}})` → results
 
 ## Key Interface: `Integration`
 
@@ -211,8 +242,6 @@ type Registry interface {
 
 ## Services Struct (DI Container)
 
-Following the chapterchamp pattern, a single struct aggregates all ports:
-
 ```go
 type Services struct {
     Config   ConfigService
@@ -235,11 +264,22 @@ Constructed in `cmd/server/main.go` and passed to both `server.New()` and `web.N
 ## Conventions and Patterns
 
 ### Unexported Structs, Exported Constructors
-Following hexagonal convention, adapter types are unexported. Constructors return the domain interface:
 ```go
 type github struct { ... }           // unexported
 func New() mcp.Integration { ... }   // returns interface
 ```
+
+### Import Aliases
+
+Only `slack` requires an alias to avoid collision with the package name. Other packages are imported directly.
+
+| Package | Alias | Used In |
+|---------|-------|---------|
+| `github.com/daltoniam/switchboard` | `mcp` | All consumers |
+| `.../switchboard/slack` | `slackInt` | `cmd/server/main.go`, `web/web.go` |
+| `.../switchboard/github` | `ghInt` | `web/web.go` |
+| `.../switchboard/linear` | `linearInt` | `web/web.go` |
+| `.../switchboard/sentry` | `sentryInt` | `web/web.go` |
 
 ### Tool Naming
 Tools are prefixed with integration name: `github_search_repos`, `datadog_search_logs`, `linear_list_issues`, `sentry_list_issues`.
@@ -253,6 +293,15 @@ func argStr(args map[string]any, key string) string {
 }
 ```
 
+### Dispatch Map Test Parity
+
+Every adapter **must** have two tests enforcing bidirectional parity between `Tools()` definitions and the `dispatch` map:
+
+- `TestDispatchMap_AllToolsCovered` — every tool returned by `Tools()` has a handler in `dispatch`
+- `TestDispatchMap_NoOrphanHandlers` — every key in `dispatch` has a corresponding `ToolDefinition`
+
+When adding a new tool: add both the `ToolDefinition` in `tools.go` **and** the handler entry in the `dispatch` map. Tests will fail if either is missing.
+
 ### Error Handling
 - Integration errors: return `&mcp.ToolResult{Data: err.Error(), IsError: true}, nil`
 - Only return a non-nil Go error for truly exceptional failures
@@ -264,7 +313,12 @@ Each adapter uses either a typed SDK or raw HTTP. Auth varies:
 - **Datadog**: `DataDog/datadog-api-client-go/v2` typed SDK. Auth via `context.WithValue(ctx, datadog.ContextAPIKeys, ...)`. Site via `ContextServerVariables`. SDK has V1 and V2 API packages (`datadogV1`, `datadogV2`). Incidents API requires `cfg.SetUnstableOperationEnabled("v2.XxxIncident", true)`.
 - **Linear**: Hand-rolled GraphQL over `net/http`. Auth via `Authorization: <api_key>` (no Bearer prefix).
 - **Sentry**: Hand-rolled REST over `net/http` (no typed Go SDK for Sentry management API — `getsentry/sentry-go` is for error capture only). Auth via `Authorization: Bearer <auth_token>`. Base URL defaults to `https://sentry.io/api/0`. Organization slug configured once and injected into paths via `org(args)` helper.
-- **Slack**: `slack-go/slack` typed SDK with **session token auth** (`xoxc-*` token + `xoxd-*` cookie). Auth uses a custom `cookieTransport` (`http.RoundTripper`) that injects `Cookie: d=<xoxd-cookie>` on every request, passed via `slack.OptionHTTPClient()`. Token loading priority: (1) config credentials, (2) persistent file `~/.slack-mcp-tokens.json`, (3) Chrome disk-read extraction (macOS only). Auto-extraction reads the `xoxc-*` token from Chrome's LevelDB localStorage (via `goleveldb`) and the `xoxd-*` cookie from Chrome's encrypted SQLite cookie DB (via `go-sqlite/sqlite3` for reading + AES-128-CBC decryption with Chrome Safe Storage password from macOS Keychain). No AppleScript or "Allow JavaScript from Apple Events" setting required. All Chrome profiles are scanned (`Default`, `Profile 1`, etc.). Background goroutine refreshes tokens every 4 hours. Client is mutex-protected (`s.getClient()`) since it gets rebuilt on refresh. Import aliased as `slackInt` in `cmd/server/main.go` to avoid collision with the package name.
+- **Slack**: `slack-go/slack` typed SDK with **session token auth** (`xoxc-*` token + `xoxd-*` cookie)
+  - `cookieTransport` (`http.RoundTripper`) injects `Cookie: d=<xoxd-cookie>`
+  - Token priority: (1) config, (2) `~/.slack-mcp-tokens.json`, (3) Chrome disk-read (macOS)
+  - Chrome extraction: LevelDB (`xoxc-*`) + encrypted SQLite cookies (`xoxd-*`, AES-128-CBC via Keychain)
+  - Background refresh every 4h (`refresh.go`). Mutex-protected client (`s.getClient()`)
+  - OAuth v2 flow (`oauth.go`) for web UI setup
 
 ### Config
 - File: `~/.config/switchboard/config.json`
@@ -274,27 +328,24 @@ Each adapter uses either a typed SDK or raw HTTP. Auth varies:
 - File permissions: dir `0700`, file `0600`
 
 ### Web UI
-- Embedded HTML string in `web/html.go`
+- Templ templates in `web/templates/` (see Commands section for generate workflow)
 - Default port: 3847
-- Go 1.22+ method-pattern routing (`"GET /api/config"`, `"PUT /api/integrations/{name}"`)
-- Slack setup page at `/integrations/slack/setup` — guided token extraction flow with:
-  - **macOS auto-extract**: POST `/api/slack/extract-chrome` triggers AppleScript Chrome extraction server-side
-  - **Manual browser extraction**: JavaScript snippet users run in their browser console, paste JSON result back
-  - **Direct token entry**: Paste `xoxc-*` token and `xoxd-*` cookie manually
-  - All methods save to `~/.slack-mcp-tokens.json` and update config simultaneously
-  - Linked from the Slack integration detail page via "Setup Session Token" button
+- Go 1.22+ method-pattern routing (`"GET /integrations/{name}"`, `"POST /api/slack/save-tokens"`)
+- Routes:
+  - `GET /` — Dashboard with integration health status
+  - `GET /integrations` — Integration list
+  - `GET /integrations/{name}` — Integration detail + credential form
+  - `POST /integrations/{name}` — Save integration credentials
+- **OAuth/Setup pages** (guided credential flows):
+  - `GET /integrations/github/setup` — GitHub Device Flow OAuth
+  - `GET /integrations/linear/setup` — Linear OAuth (PKCE)
+  - `GET /integrations/sentry/setup` — Sentry Device Flow OAuth
+  - `GET /integrations/slack/setup` — Slack token extraction (Chrome auto-extract, manual browser snippet, direct entry)
+- All setup pages save credentials to both the integration config and any external token files
 
 ## Gotchas
 
-- **`argStr` is duplicated** in every adapter package rather than shared. Follow this pattern for consistency. The GitHub adapter additionally has `argInt`, `argInt64`, `argBool`, `argStrSlice` helpers.
-- **All six integrations use dispatch maps** (`var dispatch map[string]handlerFunc`) instead of switch statements for routing tool execution. GitHub ~100, Datadog ~60, Linear ~60, Sentry ~55, Slack ~40, Metabase ~22 tools.
-- **Linear uses GraphQL** while all other adapters use REST. It has a `gql()` helper that handles query+variables, error parsing, and returns `json.RawMessage`. Auth is `Authorization: <api_key>` (no Bearer prefix). Handlers use `rawResult(data)` / `errResult(err)`. Entity resolution helpers (`resolveTeamID`, `resolveIssueID`) convert names/identifiers to UUIDs. GraphQL field fragments are defined as constants (`issueFields`, `projectFields`) and interpolated with `fmt.Sprintf`.
-- **Datadog adapter uses `DataDog/datadog-api-client-go/v2`** — the official typed Go SDK. ~60 tools covering logs, metrics, monitors, dashboards, events, hosts, tags, SLOs, downtimes, incidents, synthetics, notebooks, users, spans, software catalog, and IP ranges. Uses both V1 and V2 SDK packages. Handlers are split across domain-specific files. Auth is injected per-request via `ctx()` helper using `datadog.ContextAPIKeys`.
-- **Metabase adapter uses hand-rolled REST HTTP** (no typed Go SDK). ~22 tools covering databases, tables, fields, native SQL query execution, cards (saved questions) CRUD, dashboards CRUD, collections, and cross-content search. Auth via `x-api-key` header. Requires `url` (Metabase instance base URL) and `api_key` credentials.
-- **Web UI uses templ templates** in `web/templates/`. Run `templ generate` after editing `.templ` files.
-- **GitHub adapter uses `google/go-github/v68`** — the official typed Go client. ~100 tools covering repos, issues, PRs, actions, checks, releases, gists, search, orgs, teams, security scanning, copilot, and more. Handlers are split across domain-specific files.
-- **Linear adapter uses hand-rolled GraphQL** (no SDK — no mature Go client exists). ~60 tools covering issues, projects, cycles, teams, users, labels, workflow states, documents, initiatives, favorites, webhooks, notifications, templates, organization, custom views, and rate limits. Handlers are split across domain-specific files.
-- **Sentry adapter uses hand-rolled REST HTTP** (no typed Go SDK for the management API). ~55 tools covering organizations, projects, teams, issues, events, releases, alerts, cron monitors, discover queries, and replays. Uses `doRequest` helper for all HTTP methods. `queryEncode` builds optional query parameters. `org(args)` defaults to configured organization slug with per-request override.
-- **Slack adapter uses `slack-go/slack`** — a mature typed Go client. ~42 tools covering conversations (channels/DMs), message CRUD, search, reactions, pins, scheduled messages, users, user groups, files, bookmarks, reminders, emoji, team info, and token management (`slack_token_status`, `slack_refresh_tokens`). Uses session token scraping (`xoxc-*`/`xoxd-*`) instead of bot tokens — ported from [jtalk22/slack-mcp-server](https://github.com/jtalk22/slack-mcp-server) (Node.js) and expanded. `tokens.go` handles Chrome disk-read extraction (LevelDB via `goleveldb` for token, encrypted SQLite via `go-sqlite/sqlite3` + AES-CBC decryption for cookie — no AppleScript needed), file persistence (`~/.slack-mcp-tokens.json`), and background refresh (4h ticker). Extraction scans all Chrome profiles. `extract.go` exports helpers (`ExtractFromChromeForWeb`, `SaveTokensForWeb`, `GetTokenInfoForWeb`, `ExtractionSnippet`) for the web UI setup page. All handler functions use `s.getClient()` (read-locked) since the client is rebuilt on token refresh under a write lock. Handlers are split across domain-specific files.
-- **The search tool returns ToolDefinition metadata**, not raw API specs. If an integration adds many tools, consider adding categories or tags to `ToolDefinition`.
-- **Go 1.25** is specified in `go.mod`. Uses Go 1.22+ features (method-pattern routing).
+- **Arg helpers are duplicated** per adapter — intentional. All have `argStr`, `argInt`, `argBool`. GitHub/Datadog also have `argInt64`, `argStrSlice`
+- **All six adapters use dispatch maps** (`var dispatch map[string]handlerFunc`). Tool counts: GitHub ~100, Datadog ~60, Linear ~60, Sentry ~55, Slack ~40, Metabase ~22
+- **Linear is the only GraphQL adapter**. `gql()` helper, entity resolution (`resolveTeamID`, `resolveIssueID`), field fragment constants (`issueFields`, `projectFields`)
+- **`search` returns `ToolDefinition` metadata**, not raw API specs


### PR DESCRIPTION
TL;DR: Cleaned up agent file. Open to feedback if you think anything should be put back in.

Fix 4 stale claims, add 6 missing conventions, restructure verbose sections for parseability across diverse AI coding models.

Fixes:
- Remove nonexistent "chapterchamp" reference
- Remove nonexistent "web/html.go" reference
- Fix "AppleScript" claim (uses LevelDB disk reads, not AppleScript)
- Fix argInt/argBool exclusivity claim (all adapters have them)

Additions:
- templ generate as build prerequisite + "never edit *_templ.go"
- Root package is "mcp" (not "switchboard") with import example
- Import alias convention table (slackInt, ghInt, linearInt, sentryInt)
- Dispatch-map test parity requirement
- Missing files: oauth.go (4 adapters), slack/refresh.go
- Git workflow section (branch strategy, PR expectations)

Restructures:
- Break 847-char Slack run-on sentence into structured bullets
- Replace ASCII hex diagram with structured bullet text
- Deduplicate HTTP Client section vs Gotchas adapter entries
- Update Web UI section with all 4 OAuth/setup pages