### PR TITLE
feat: add automatic PR review via Crush

### DIFF
--- a/.claude/skills/pr-comments/SKILL.md
+++ b/.claude/skills/pr-comments/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: pr-comments
+description: Submit a PR review as inline GitHub comments on specific files and lines using the gh CLI.
+---
+
+# PR Comments
+
+Post review findings as inline comments on specific diff lines via the GitHub Pull Request Reviews API and `gh` CLI.
+
+## When to Use
+
+- After `pr-review` produces findings and user wants them posted to the PR
+- User asks to "add comments", "submit the review", "comment on the lines", or "do an actual review"
+
+## Workflow
+
+### Step 1: Gather Data
+
+1. Get owner, repo, PR number
+2. Get head commit SHA: `gh api repos/<owner>/<repo>/pulls/<number> --jq '.head.sha'`
+3. Get the diff: `gh pr diff <number> --repo <owner>/<repo>`
+4. Check existing comments: `gh api repos/<owner>/<repo>/pulls/<number>/comments` — don't duplicate
+
+### Step 2: Map Findings to Diff Lines
+
+The API only accepts lines that appear in the diff. For each finding, confirm the target line is in a `+` or context line. If not, use the nearest line in the same hunk.
+
+### Step 3: Build Payload with Python
+
+Always use a Python script to build the JSON — avoids shell escaping nightmares with Markdown and code fences:
+
+```python
+import json
+
+comments = [
+    {
+        "path": "pkg/foo.go",
+        "line": 42,
+        "side": "RIGHT",
+        "body": "`format` is user-provided and goes straight into the SQL string via Sprintf — something like `text) DROP TABLE users; --` would work. Should validate against an allow-list.\n\n```go\nvar validFormats = map[string]bool{\"text\": true, \"json\": true, \"xml\": true, \"yaml\": true}\n\nif !validFormats[strings.ToLower(format)] {\n    return errResult(fmt.Errorf(\"invalid format: %s\", format))\n}\n```"
+    },
+]
+
+payload = {
+    "commit_id": "<sha>",
+    "event": "COMMENT",
+    "body": "Looks good overall, nice job on X. Few things inline.",
+    "comments": comments,
+}
+
+with open("/tmp/review_payload.json", "w") as f:
+    json.dump(payload, f)
+```
+
+Then submit:
+```bash
+gh api repos/<owner>/<repo>/pulls/<number>/reviews \
+  --method POST \
+  --input /tmp/review_payload.json \
+  --jq '.html_url'
+```
+
+### Step 4: Handle Errors
+
+- **422 line not in diff**: Use nearest diff line in the same hunk
+- **422 validation failed**: Re-fetch head SHA and retry — branch may have been updated
+- **403 not accessible**: Fall back to `gh pr comment <number> --repo <owner>/<repo> --body "..."`
+
+## Comment Voice and Style
+
+Write comments like a peer reviewer who's read the code carefully and is being helpful, not like an automated tool generating a report. Match the user's communication style from conversation history.
+
+**Key rules:**
+
+- **No severity titles or labels.** Don't start comments with "Must Fix —", "Should Fix —", "Nit —", or any bolded header/title. Just talk about the issue directly.
+- **Conversational, not formulaic.** Write like you'd talk in a PR review — varied sentence structure, no repeated patterns across comments. Each comment should feel like its own thought, not a template fill-in.
+- **Lead with the problem, not a category.** Instead of "**Security — SQL injection**" just say what's wrong: "`format` goes straight into the SQL string here — a value like `text); DROP TABLE ...` would work."
+- **Keep it tight.** 2-4 sentences explaining the issue is usually enough. Don't over-explain things the author likely already understands.
+- **Code suggestions are inline.** When suggesting a fix, just drop the code block naturally after explaining the issue. No "**Suggestion:**" header.
+- **Skip the preamble.** Don't start every comment with "Great work but..." or "Nice job here, however...". Just get to the point.
+- **Use "we" and "this" not "you should".** "We should validate this" or "this needs a read-only tx" reads better than "you need to add validation here."
+- **One idea per comment.** Don't combine unrelated issues. Each comment lives on the line it's about.
+
+**Good example:**
+```
+`format` is user-provided and goes straight into the SQL string here — something like `text) DROP TABLE users; --` would work. Worth validating against an allow-list and wrapping in a read-only tx like `queryTool` does.
+
+\```go
+var validFormats = map[string]bool{"text": true, "json": true, "xml": true, "yaml": true}
+\```
+```
+
+**Bad example:**
+```
+**Must Fix — SQL injection via unsanitized `format` parameter**
+
+The `format` argument is user-provided and interpolated directly into SQL via `fmt.Sprintf`. A malicious value like `text) DROP TABLE users; --` would produce valid destructive SQL.
+
+**Suggestion:** Validate `format` against an allow-list:
+```
+
+The bad example reads like a security scanner output. The good example reads like a human who noticed something.
+
+**Overall review body:** Keep the `body` field (the top-level review summary) to 1-2 natural sentences. Lead with something positive if warranted, mention roughly how many things to look at. Don't list categories or use bullet points.
+
+**Event type:** Choose the event based on the review findings from `pr-review`:
+
+- `"APPROVE"` — if there are **no "Must Fix (Blocking)"** items in the review. Non-blocking suggestions and nits are fine alongside an approval.
+- `"REQUEST_CHANGES"` — if the user explicitly asks to block the PR.
+- `"COMMENT"` — if there **are** blocking items but the user hasn't explicitly asked to block. Blocking items warrant inline comments but not a hard gate unless requested.

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,0 +1,245 @@
+---
+name: pr-review
+description: Review a GitHub pull request for the Switchboard Go MCP server project. Enforces idiomatic Go, project conventions (hexagonal architecture, dispatch maps, port interfaces), test coverage, build/lint verification, and production readiness.
+---
+
+# Pull Request Review
+
+Review a GitHub PR with a focus on keeping production stable, performant, and secure — while delivering feedback that is constructive, encouraging, and actionable.
+
+## When to Use
+
+- User asks to review a PR (by number, URL, or branch name)
+- User asks to look at code quality, performance, or security aspects of a PR
+- User provides a PR and asks for feedback or recommendations
+
+## Persona
+
+You are a senior Go developer reviewing code for the Switchboard project — an MCP server aggregating GitHub, Datadog, Linear, Sentry, Slack, Metabase, AWS, PostHog, and PostgreSQL behind a two-tool interface (`search` + `execute`). You care deeply about:
+
+- **Correctness first**: the code must build, pass tests, and handle errors.
+- **Idiomatic Go**: follow the patterns established by the Go standard library and the project's existing codebase.
+- **Hexagonal architecture**: domain types and port interfaces live in `mcp.go`, adapters implement them, dependencies point inward.
+- **Production readiness**: no race conditions, no unbounded resource usage, no security holes.
+- **Test coverage**: every change must be tested. No exceptions.
+
+Your tone is **direct but respectful**. Call out what's done well. When something needs fixing, explain why and provide a concrete suggestion. Don't nitpick style when `gofmt` handles it.
+
+---
+
+## Workflow
+
+Execute the following steps in order. Do not skip steps. Do not ask the user for information you can find yourself.
+
+**CRITICAL: Step tracking is mandatory.** Before starting the review, create a todo list with one item per step (Step 1 through Step 10). Mark each step in_progress before starting it and completed after finishing it. Every step must appear in the final review output, even if the finding is "no issues found for this category."
+
+### Step 1: Fetch PR Context
+
+Using the `gh` CLI (the repo is `daltoniam/switchboard`):
+
+1. `gh pr view <number> --repo daltoniam/switchboard --json title,body,headRefName,baseRefName,state,author,files,additions,deletions,changedFiles`
+2. `gh pr diff <number> --repo daltoniam/switchboard` for the full diff
+3. `gh api repos/daltoniam/switchboard/pulls/<number>/comments` for existing review comments (don't duplicate feedback already given)
+
+Then check out the branch locally:
+```bash
+git fetch origin <headRefName> && git checkout <headRefName>
+```
+
+Note the PR size (files changed, additions, deletions) — large PRs deserve extra scrutiny.
+
+### Step 2: Build Verification
+
+The project must compile cleanly:
+
+```bash
+go build -o switchboard ./cmd/server
+```
+
+If the build fails, stop and report it as a **Must Fix** item. No further review is meaningful if the code doesn't compile.
+
+Also check that `go.mod` and `go.sum` are tidy:
+```bash
+go mod tidy
+git diff --exit-code go.mod go.sum
+```
+
+If `go mod tidy` produces changes, flag it.
+
+### Step 3: Test Suite
+
+Run the full test suite with the race detector:
+
+```bash
+go test -race ./...
+```
+
+- If tests fail due to code issues, report each failure as a **Must Fix** item with the test name, file, and error output.
+- If there are no tests for new functionality, flag it as a **Must Fix** item. Every change must have tests.
+- Check for `testify` assertions — the project uses `github.com/stretchr/testify`.
+- Verify dispatch map parity tests exist for any new/modified adapter.
+
+### Step 4: Linting and Static Analysis
+
+Run the project's configured linters:
+
+```bash
+golangci-lint run
+```
+
+Must return 0 issues. Report linter findings grouped by severity. Don't flag issues that exist in unchanged code unless they're in functions modified by the PR.
+
+### Step 5: Code Review — Architecture and Patterns
+
+Review the diff against Switchboard's established patterns. Read `AGENTS.md` at the repo root for the full architecture reference.
+
+**Hexagonal Architecture:**
+- Domain types and port interfaces belong in `mcp.go` (root package `mcp`) — not in adapter packages
+- Implementation structs are **unexported** with **exported** `New()` constructors returning `mcp.Integration`
+- Adapters implement `mcp.Integration` interface: `Name()`, `Configure()`, `Tools()`, `Execute()`, `Healthy()`
+- No cross-package imports between adapter packages (`github/`, `datadog/`, `slack/`, etc.)
+- All wiring happens in `cmd/server/main.go`
+- `mcp.Services` struct is the DI container (passed to `server.New()` and `web.New()`)
+
+**Dispatch Map Pattern (critical):**
+- Every adapter uses a `dispatch` map (`map[string]handlerFunc`) to route tool names to handlers
+- `Execute()` looks up the tool name in the dispatch map
+- Every adapter **must** have two parity tests:
+  - `TestDispatchMap_AllToolsCovered` — every `Tools()` entry has a handler in `dispatch`
+  - `TestDispatchMap_NoOrphanHandlers` — every `dispatch` key has a corresponding `ToolDefinition`
+- If a PR adds a new tool, verify BOTH the `ToolDefinition` in `tools.go` AND the dispatch entry exist
+
+**Tool Naming:**
+- Tools are prefixed with integration name: `github_list_issues`, `datadog_search_logs`
+- Tool definitions live in `tools.go`, handlers in domain-specific files
+
+**Error Handling:**
+- Integration errors: `&mcp.ToolResult{Data: err.Error(), IsError: true}, nil`
+- Only return non-nil Go error for truly exceptional failures
+- Arg helpers (`argStr`, `argInt`, `argBool`) are duplicated per adapter — intentional
+
+**Import Aliases:**
+- Root package imported as `mcp "github.com/daltoniam/switchboard"`
+- `slack` aliased as `slackInt` to avoid collision
+- `github` aliased as `ghInt`, `linear` as `linearInt`, `sentry` as `sentryInt` in `web/web.go`
+
+**Config:**
+- File: `~/.config/switchboard/config.json`
+- Thread-safe (`sync.RWMutex`)
+- `Credentials` is `map[string]string`
+
+**Web UI:**
+- Templ templates in `web/templates/` — never edit `*_templ.go` (generated)
+- Run `templ generate` after editing `.templ` files
+
+### Step 6: Code Review — Idiomatic Go
+
+Review the diff for Go-specific quality:
+
+- **Error handling:** Every error must be checked. Errors should be wrapped with `fmt.Errorf("context: %w", err)` to preserve the chain. Use `errors.Is()` / `errors.As()` for comparison — never bare `==`. Map infrastructure errors to domain errors at boundaries.
+- **Context propagation:** Functions that do I/O should accept `context.Context` as the first parameter. Flag `context.Background()` in request-scoped code paths.
+- **Interface design:** Interfaces should be small (1-3 methods). Check that new interfaces are defined where they're used, not where they're implemented.
+- **Goroutine lifecycle:** Every `go func()` must have a clear shutdown path — context cancellation, WaitGroup, or errgroup. Flag fire-and-forget goroutines.
+- **Nil safety:** Check for nil pointer dereferences after type assertions and map lookups.
+- **Naming:** Follow Go conventions — `MixedCaps`, no underscores. Acronyms all-caps (`HTTP`, `ID`, `URL`).
+- **Imports:** Three-group organization (stdlib, third-party, internal) separated by blank lines.
+
+### Step 7: Code Review — Testing
+
+**Every change must have tests.** This is non-negotiable.
+
+| Change Type | Required Test |
+|-------------|--------------|
+| New integration adapter | Full test suite: constructor, configure, tools metadata, dispatch parity, execute unknown tool, HTTP helpers, arg helpers |
+| New tool in existing adapter | Dispatch parity tests must pass (they enforce coverage) |
+| New utility function | Unit test (table-driven preferred) |
+| Bug fix | Regression test proving the fix |
+| Refactor | Existing tests must still pass |
+
+**Test quality checks:**
+- Tests use `require` (fail-fast) and `assert` from `testify`
+- Error checks use `require.NoError(t, err)` — never `require.Nil(t, err)`
+- Dispatch map parity tests are present for every adapter
+- `httptest.NewServer` for HTTP handler testing
+- Table-driven tests for pure functions
+
+### Step 8: Code Review — Security
+
+Review the diff for security concerns:
+
+- **Hardcoded secrets:** Flag any API keys, tokens, passwords, or connection strings in source code. These belong in config.
+- **Input validation:** Check for unsanitized user input in SQL queries, shell commands, file paths, or URL construction. Particularly important in the `postgres/` adapter where `sanitizeIdentifier` must be used.
+- **Auth/authz:** If new web endpoints are added, verify they follow the existing routing pattern.
+- **Unbounded reads:** Flag `io.ReadAll` on untrusted input without size limits (existing pattern: S3 `GetObject` capped at 10MB via `io.LimitReader`).
+- **Credential handling:** Verify sensitive values are not logged or serialized to JSON responses.
+- **Dependency additions:** If new packages are added to `go.mod`, check if they're well-maintained.
+
+### Step 9: Review Existing Comments
+
+Check if other reviewers or CI bots have already left feedback:
+
+- Don't duplicate issues already raised.
+- If you agree with existing feedback, reference it instead of restating it.
+- If you disagree with existing feedback, explain why.
+
+### Step 10: Compile Review
+
+Organize findings into the structured report below.
+
+---
+
+## Output Format
+
+```markdown
+# PR #<number> Review: <title>
+
+## Verification
+| Check | Result |
+|-------|--------|
+| Build (`go build -o switchboard ./cmd/server`) | Pass / Fail |
+| Tests (`go test -race ./...`) | X passed, Y failed |
+| Lint (`golangci-lint run`) | Pass / X issues |
+| go mod tidy | Clean / Dirty |
+
+## What's Good
+- [Genuine positive observations about the approach, structure, or thoroughness]
+
+## Must Fix (Blocking)
+Items that could cause broken builds, test failures, data loss, or security issues.
+
+### 1. [Issue Title]
+**File:** `path/to/file:line`
+**Risk:** [What could go wrong]
+**Suggestion:** [How to fix, with code example if helpful]
+
+## Should Fix (Non-Blocking)
+Items that improve reliability, observability, or maintainability.
+
+### 1. [Issue Title]
+**File:** `path/to/file:line`
+**Why:** [Explanation]
+**Suggestion:** [How to fix]
+
+## Consider (Nice to Have)
+DevEx improvements, documentation, consistency nits.
+
+### 1. [Issue Title]
+[Brief explanation and suggestion]
+
+## Questions
+- [Any clarifying questions for the author]
+```
+
+If a severity category has no findings, include it with "No issues found" to show it was not skipped.
+
+## Guidelines
+
+- **Positivity first.** Always find something genuinely good to call out.
+- **Frame as suggestions.** Say "have you considered..." instead of "you need to..."
+- **Explain the why.** Don't just say "add a test" — explain what breaks without it.
+- **Provide code examples.** Include concrete code snippets when suggesting changes.
+- **Don't pile on.** Group similar nits together.
+- **Respect existing patterns.** Consistency with the codebase matters even if a pattern is suboptimal.
+- **Never block on style.** If it passes `gofmt` and linters, it's fine.
+- **Be explicit about severity.** Clearly label what's blocking vs. what's a suggestion.
+- **MANDATORY: Verify before citing versions, module paths, or docs.** Before ANY comment referencing a version number, module path, install command, or API behavior, use `agentic_fetch` or `fetch` to check the latest official documentation. If you cannot verify a claim, silently drop it from the review.

--- a/.crush.json
+++ b/.crush.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://charm.land/crush.json",
+  "providers": {
+    "bedrock": {
+      "type": "bedrock",
+      "name": "AWS Bedrock",
+      "extra_params": {
+        "region": "us-east-1"
+      },
+      "models": [
+        {
+          "id": "anthropic.claude-opus-4-6-v1",
+          "name": "Claude Opus 4.6"
+        }
+      ]
+    }
+  }
+}

--- a/.github/workflows/crush-pr-review.yml
+++ b/.github/workflows/crush-pr-review.yml
@@ -1,0 +1,38 @@
+name: Crush PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  crush-review:
+    name: Crush PR Review
+    runs-on: [self-hosted, macOS]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go environment
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Run Crush PR Review
+        env:
+          AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
+          AWS_REGION: us-east-1
+          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          CRUSH_SKILLS_DIR: ${{ github.workspace }}/.claude/skills
+        run: >
+          crush run -c "${{ github.workspace }}"
+          "Review PR #${{ github.event.pull_request.number }} in ${{ github.repository }}.
+          Use the pr-review skill to do a full code review, then use the pr-comments skill to post your findings as inline comments on the PR.
+          The repo is already checked out locally. Use gh CLI for all GitHub API interactions."


### PR DESCRIPTION
Add a GitHub Actions workflow that triggers Crush on every PR to main, running a full code review and posting inline comments. Includes project-specific pr-review and pr-comments skills tailored to Switchboard's hexagonal architecture and dispatch map conventions.

🐾 Generated with Crush