### PR TITLE
Add pganalyze integration

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/daltoniam/switchboard/integrations/github"
 	"github.com/daltoniam/switchboard/integrations/linear"
 	"github.com/daltoniam/switchboard/integrations/metabase"
+	"github.com/daltoniam/switchboard/integrations/pganalyze"
 	"github.com/daltoniam/switchboard/integrations/posthog"
 	"github.com/daltoniam/switchboard/integrations/postgres"
 	"github.com/daltoniam/switchboard/integrations/sentry"
@@ -175,6 +176,7 @@ func runServer(stdioMode bool, port int) {
 		posthog.New(),
 		postgres.New(),
 		clickhouse.New(),
+		pganalyze.New(),
 	} {
 		if err := reg.Register(i); err != nil {
 			log.Fatalf("Failed to register integration: %v", err)

--- a/config/config.go
+++ b/config/config.go
@@ -85,6 +85,10 @@ func defaultConfig() *mcp.Config {
 				Enabled:     false,
 				Credentials: mcp.Credentials{"host": "", "port": "", "username": "", "password": "", "database": "", "secure": "", "skip_verify": ""},
 			},
+			"pganalyze": {
+				Enabled:     false,
+				Credentials: mcp.Credentials{"api_key": "", "base_url": "", "organization_slug": ""},
+			},
 		},
 	}
 }
@@ -106,8 +110,27 @@ func (m *manager) Load() error {
 	if err := json.Unmarshal(data, &cfg); err != nil {
 		return fmt.Errorf("parse config: %w", err)
 	}
-	m.cfg = &cfg
+	m.cfg = mergeWithDefaults(&cfg)
 	return nil
+}
+
+func mergeWithDefaults(file *mcp.Config) *mcp.Config {
+	cfg := defaultConfig()
+	if file.Integrations == nil {
+		return cfg
+	}
+	for name, fileIC := range file.Integrations {
+		defIC, ok := cfg.Integrations[name]
+		if !ok {
+			cfg.Integrations[name] = fileIC
+			continue
+		}
+		defIC.Enabled = fileIC.Enabled
+		for k, v := range fileIC.Credentials {
+			defIC.Credentials[k] = v
+		}
+	}
+	return cfg
 }
 
 func (m *manager) Save() error {
@@ -170,4 +193,17 @@ func (m *manager) EnabledIntegrations() []string {
 		}
 	}
 	return names
+}
+
+func (m *manager) DefaultCredentialKeys(name string) []string {
+	def := defaultConfig()
+	ic, ok := def.Integrations[name]
+	if !ok {
+		return nil
+	}
+	keys := make([]string, 0, len(ic.Credentials))
+	for k := range ic.Credentials {
+		keys = append(keys, k)
+	}
+	return keys
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -30,8 +30,8 @@ func TestLoad_CreatesDefaultWhenMissing(t *testing.T) {
 	_, err = os.Stat(path)
 	assert.NoError(t, err)
 
-	assert.Len(t, m.cfg.Integrations, 10)
-	for _, name := range []string{"github", "datadog", "linear", "sentry", "slack", "metabase", "aws", "posthog", "postgres", "clickhouse"} {
+	assert.Len(t, m.cfg.Integrations, 11)
+	for _, name := range []string{"github", "datadog", "linear", "sentry", "slack", "metabase", "aws", "posthog", "postgres", "clickhouse", "pganalyze"} {
 		ic, ok := m.cfg.Integrations[name]
 		assert.True(t, ok, "missing default integration: %s", name)
 		assert.False(t, ic.Enabled)
@@ -57,6 +57,36 @@ func TestLoad_ParsesExistingFile(t *testing.T) {
 	assert.Equal(t, "abc", m.cfg.Integrations["github"].Credentials["token"])
 }
 
+func TestLoad_BackfillsMissingIntegrations(t *testing.T) {
+	m, path := newTestManager(t)
+
+	cfg := &mcp.Config{
+		Integrations: map[string]*mcp.IntegrationConfig{
+			"github": {Enabled: true, Credentials: mcp.Credentials{"token": "abc"}},
+		},
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0700))
+	require.NoError(t, os.WriteFile(path, data, 0600))
+
+	err = m.Load()
+	require.NoError(t, err)
+
+	assert.True(t, m.cfg.Integrations["github"].Enabled)
+	assert.Equal(t, "abc", m.cfg.Integrations["github"].Credentials["token"])
+
+	for name := range defaultConfig().Integrations {
+		_, ok := m.cfg.Integrations[name]
+		assert.True(t, ok, "missing backfilled integration: %s", name)
+	}
+
+	for _, key := range []string{"token", "client_id", "token_source"} {
+		_, ok := m.cfg.Integrations["github"].Credentials[key]
+		assert.True(t, ok, "missing default credential key %q for github", key)
+	}
+}
+
 func TestLoad_InvalidJSON(t *testing.T) {
 	m, path := newTestManager(t)
 
@@ -80,7 +110,7 @@ func TestSave(t *testing.T) {
 
 	var cfg mcp.Config
 	require.NoError(t, json.Unmarshal(data, &cfg))
-	assert.Len(t, cfg.Integrations, 10)
+	assert.Len(t, cfg.Integrations, 11)
 }
 
 func TestGet(t *testing.T) {
@@ -89,7 +119,7 @@ func TestGet(t *testing.T) {
 
 	cfg := m.Get()
 	assert.NotNil(t, cfg)
-	assert.Len(t, cfg.Integrations, 10)
+	assert.Len(t, cfg.Integrations, 11)
 }
 
 func TestUpdate(t *testing.T) {
@@ -199,7 +229,7 @@ func TestEnabledIntegrations_Multiple(t *testing.T) {
 func TestDefaultConfig(t *testing.T) {
 	cfg := defaultConfig()
 	require.NotNil(t, cfg)
-	assert.Len(t, cfg.Integrations, 10)
+	assert.Len(t, cfg.Integrations, 11)
 
 	expected := map[string][]string{
 		"github":     {"token", "client_id", "token_source"},
@@ -212,6 +242,7 @@ func TestDefaultConfig(t *testing.T) {
 		"posthog":    {"api_key", "project_id", "base_url"},
 		"postgres":   {"connection_string", "host", "user", "read_only"},
 		"clickhouse": {"host", "port", "username", "password", "database", "secure", "skip_verify"},
+		"pganalyze":  {"api_key", "base_url", "organization_slug"},
 	}
 
 	for name, keys := range expected {
@@ -236,4 +267,20 @@ func TestSave_FilePermissions(t *testing.T) {
 	require.NoError(t, err)
 	// File should be readable/writable by owner only.
 	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+}
+
+func TestDefaultCredentialKeys(t *testing.T) {
+	m, _ := newTestManager(t)
+	require.NoError(t, m.Load())
+
+	keys := m.DefaultCredentialKeys("pganalyze")
+	assert.ElementsMatch(t, []string{"api_key", "base_url", "organization_slug"}, keys)
+}
+
+func TestDefaultCredentialKeys_Unknown(t *testing.T) {
+	m, _ := newTestManager(t)
+	require.NoError(t, m.Load())
+
+	keys := m.DefaultCredentialKeys("nonexistent")
+	assert.Nil(t, keys)
 }

--- a/integrations/pganalyze/compact_specs.go
+++ b/integrations/pganalyze/compact_specs.go
@@ -1,0 +1,37 @@
+package pganalyze
+
+import (
+	"fmt"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+var rawFieldCompactionSpecs = map[string][]string{
+	"pganalyze_get_servers": {
+		"id", "name", "humanId", "lastSnapshotAt",
+		"databases[].id", "databases[].datname", "databases[].displayName",
+	},
+	"pganalyze_get_issues": {
+		"id", "checkGroupAndName", "severity", "state",
+		"description", "createdAt", "updatedAt",
+		"references[].kind", "references[].name", "references[].url",
+	},
+	"pganalyze_get_query_stats": {
+		"queryId", "truncatedQuery", "queryUrl", "statementTypes",
+		"totalCalls", "avgTime", "bufferHitRatio", "pctOfTotal", "callsPerMinute",
+	},
+}
+
+var fieldCompactionSpecs = mustBuildFieldCompactionSpecs(rawFieldCompactionSpecs)
+
+func mustBuildFieldCompactionSpecs(raw map[string][]string) map[string][]mcp.CompactField {
+	parsed := make(map[string][]mcp.CompactField, len(raw))
+	for tool, specs := range raw {
+		fields, err := mcp.ParseCompactSpecs(specs)
+		if err != nil {
+			panic(fmt.Sprintf("pganalyze: invalid field compaction spec for %q: %v", tool, err))
+		}
+		parsed[tool] = fields
+	}
+	return parsed
+}

--- a/integrations/pganalyze/compact_specs_test.go
+++ b/integrations/pganalyze/compact_specs_test.go
@@ -1,0 +1,36 @@
+package pganalyze
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFieldCompactionSpecs_AllParse(t *testing.T) {
+	require.NotEmpty(t, fieldCompactionSpecs, "fieldCompactionSpecs should not be empty")
+}
+
+func TestFieldCompactionSpecs_NoDuplicateTools(t *testing.T) {
+	assert.Equal(t, len(rawFieldCompactionSpecs), len(fieldCompactionSpecs))
+}
+
+func TestFieldCompactionSpecs_NoOrphanSpecs(t *testing.T) {
+	for toolName := range fieldCompactionSpecs {
+		_, ok := dispatch[toolName]
+		assert.True(t, ok, "field compaction spec for %q has no dispatch handler", toolName)
+	}
+}
+
+func TestFieldCompactionSpec_ReturnsFieldsForListTool(t *testing.T) {
+	p := &pganalyze{}
+	fields, ok := p.CompactSpec("pganalyze_get_servers")
+	require.True(t, ok, "pganalyze_get_servers should have field compaction spec")
+	assert.NotEmpty(t, fields)
+}
+
+func TestFieldCompactionSpec_ReturnsFalseForUnknownTool(t *testing.T) {
+	p := &pganalyze{}
+	_, ok := p.CompactSpec("pganalyze_nonexistent")
+	assert.False(t, ok, "unknown tools should return false")
+}

--- a/integrations/pganalyze/issues.go
+++ b/integrations/pganalyze/issues.go
@@ -1,0 +1,73 @@
+package pganalyze
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+func getIssues(ctx context.Context, p *pganalyze, args map[string]any) (*mcp.ToolResult, error) {
+	query := `
+		query GetIssues($organizationSlug: ID, $serverId: ID, $databaseId: ID, $state: String) {
+			getIssues(organizationSlug: $organizationSlug, serverId: $serverId, databaseId: $databaseId, state: $state) {
+				id
+				checkGroupAndName
+				description
+				severity
+				state
+				createdAt
+				updatedAt
+				references {
+					kind
+					name
+					url
+					resolvedAt
+				}
+			}
+		}
+	`
+
+	variables := make(map[string]any)
+	if v := p.orgSlug(args); v != "" {
+		variables["organizationSlug"] = v
+	}
+	if v := argStr(args, "server_id"); v != "" {
+		variables["serverId"] = v
+	}
+	if v := argStr(args, "database_id"); v != "" {
+		variables["databaseId"] = v
+	}
+	if !argBool(args, "include_resolved") {
+		variables["state"] = "open"
+	}
+
+	data, err := p.gql(ctx, query, variables)
+	if err != nil {
+		return errResult(err)
+	}
+
+	var resp struct {
+		GetIssues json.RawMessage `json:"getIssues"`
+	}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return errResult(err)
+	}
+
+	if severity := argStr(args, "severity"); severity != "" {
+		var issues []map[string]any
+		if err := json.Unmarshal(resp.GetIssues, &issues); err != nil {
+			return errResult(err)
+		}
+		filtered := make([]map[string]any, 0, len(issues))
+		for _, issue := range issues {
+			if s, ok := issue["severity"].(string); ok && strings.EqualFold(s, severity) {
+				filtered = append(filtered, issue)
+			}
+		}
+		return jsonResult(filtered)
+	}
+
+	return rawResult(resp.GetIssues)
+}

--- a/integrations/pganalyze/pganalyze.go
+++ b/integrations/pganalyze/pganalyze.go
@@ -1,0 +1,202 @@
+package pganalyze
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+const defaultGraphQLURL = "https://app.pganalyze.com/graphql"
+
+var (
+	_ mcp.Integration                = (*pganalyze)(nil)
+	_ mcp.FieldCompactionIntegration = (*pganalyze)(nil)
+	_ mcp.PlainTextCredentials       = (*pganalyze)(nil)
+)
+
+type pganalyze struct {
+	apiKey           string
+	graphqlURL       string
+	organizationSlug string
+	client           *http.Client
+}
+
+func New() mcp.Integration {
+	return &pganalyze{client: &http.Client{}}
+}
+
+func (p *pganalyze) Name() string { return "pganalyze" }
+
+func (p *pganalyze) Configure(creds mcp.Credentials) error {
+	p.apiKey = creds["api_key"]
+	if p.apiKey == "" {
+		return fmt.Errorf("pganalyze: api_key is required")
+	}
+	p.graphqlURL = defaultGraphQLURL
+	if v := creds["base_url"]; v != "" {
+		v = strings.TrimRight(v, "/")
+		if strings.HasSuffix(v, "/graphql") {
+			p.graphqlURL = v
+		} else {
+			p.graphqlURL = v + "/graphql"
+		}
+	}
+	p.organizationSlug = creds["organization_slug"]
+	return nil
+}
+
+func (p *pganalyze) Healthy(ctx context.Context) bool {
+	if p.apiKey == "" {
+		return false
+	}
+	_, err := p.gql(ctx, `{ __typename }`, nil)
+	return err == nil
+}
+
+func (p *pganalyze) Tools() []mcp.ToolDefinition {
+	return tools
+}
+
+func (p *pganalyze) CompactSpec(toolName string) ([]mcp.CompactField, bool) {
+	fields, ok := fieldCompactionSpecs[toolName]
+	return fields, ok
+}
+
+func (p *pganalyze) PlainTextKeys() []string {
+	return []string{"base_url", "organization_slug"}
+}
+
+func (p *pganalyze) orgSlug(args map[string]any) string {
+	if v := argStr(args, "organization_slug"); v != "" {
+		return v
+	}
+	return p.organizationSlug
+}
+
+func (p *pganalyze) Execute(ctx context.Context, toolName string, args map[string]any) (*mcp.ToolResult, error) {
+	fn, ok := dispatch[toolName]
+	if !ok {
+		return &mcp.ToolResult{Data: fmt.Sprintf("unknown tool: %s", toolName), IsError: true}, nil
+	}
+	return fn(ctx, p, args)
+}
+
+// --- GraphQL helpers ---
+
+type gqlResponse struct {
+	Data   json.RawMessage `json:"data"`
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors"`
+}
+
+func (p *pganalyze) gql(ctx context.Context, query string, variables map[string]any) (json.RawMessage, error) {
+	body := map[string]any{"query": query}
+	if variables != nil {
+		body["variables"] = variables
+	}
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", p.graphqlURL, bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Token "+p.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("pganalyze API error (%d): %s", resp.StatusCode, string(data))
+	}
+
+	var gqlResp gqlResponse
+	if err := json.Unmarshal(data, &gqlResp); err != nil {
+		return data, nil
+	}
+	if len(gqlResp.Errors) > 0 {
+		msgs := make([]string, len(gqlResp.Errors))
+		for i, e := range gqlResp.Errors {
+			msgs[i] = e.Message
+		}
+		return nil, fmt.Errorf("graphql errors: %s", strings.Join(msgs, "; "))
+	}
+	return gqlResp.Data, nil
+}
+
+func rawResult(data json.RawMessage) (*mcp.ToolResult, error) {
+	return &mcp.ToolResult{Data: string(data)}, nil
+}
+
+func errResult(err error) (*mcp.ToolResult, error) {
+	return &mcp.ToolResult{Data: err.Error(), IsError: true}, nil
+}
+
+func jsonResult(v any) (*mcp.ToolResult, error) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return &mcp.ToolResult{Data: err.Error(), IsError: true}, nil
+	}
+	return &mcp.ToolResult{Data: string(data)}, nil
+}
+
+// --- Argument helpers ---
+
+func argStr(args map[string]any, key string) string {
+	v, _ := args[key].(string)
+	return v
+}
+
+func argInt(args map[string]any, key string) int {
+	switch v := args[key].(type) {
+	case float64:
+		return int(v)
+	case int:
+		return v
+	case string:
+		n, _ := strconv.Atoi(v)
+		return n
+	}
+	return 0
+}
+
+func argBool(args map[string]any, key string) bool {
+	switch v := args[key].(type) {
+	case bool:
+		return v
+	case string:
+		return v == "true"
+	}
+	return false
+}
+
+type handlerFunc func(ctx context.Context, p *pganalyze, args map[string]any) (*mcp.ToolResult, error)
+
+var dispatch = map[string]handlerFunc{
+	// Servers
+	"pganalyze_get_servers": getServers,
+
+	// Issues
+	"pganalyze_get_issues": getIssues,
+
+	// Query Stats
+	"pganalyze_get_query_stats": getQueryStats,
+}

--- a/integrations/pganalyze/pganalyze_test.go
+++ b/integrations/pganalyze/pganalyze_test.go
@@ -1,0 +1,237 @@
+package pganalyze
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	i := New()
+	require.NotNil(t, i)
+	assert.Equal(t, "pganalyze", i.Name())
+}
+
+func TestConfigure_Success(t *testing.T) {
+	i := New()
+	err := i.Configure(mcp.Credentials{"api_key": "test-token-123"})
+	assert.NoError(t, err)
+}
+
+func TestConfigure_MissingAPIKey(t *testing.T) {
+	i := New()
+	err := i.Configure(mcp.Credentials{"api_key": ""})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "api_key is required")
+}
+
+func TestConfigure_EmptyCredentials(t *testing.T) {
+	i := New()
+	err := i.Configure(mcp.Credentials{})
+	assert.Error(t, err)
+}
+
+func TestConfigure_CustomBaseURL(t *testing.T) {
+	p := &pganalyze{client: &http.Client{}}
+	err := p.Configure(mcp.Credentials{"api_key": "key", "base_url": "https://pganalyze.example.com/"})
+	assert.NoError(t, err)
+	assert.Equal(t, "https://pganalyze.example.com/graphql", p.graphqlURL)
+}
+
+func TestConfigure_DefaultBaseURL(t *testing.T) {
+	p := &pganalyze{client: &http.Client{}}
+	err := p.Configure(mcp.Credentials{"api_key": "key"})
+	assert.NoError(t, err)
+	assert.Equal(t, defaultGraphQLURL, p.graphqlURL)
+}
+
+func TestConfigure_BaseURLWithGraphQLSuffix(t *testing.T) {
+	p := &pganalyze{client: &http.Client{}}
+	err := p.Configure(mcp.Credentials{"api_key": "key", "base_url": "https://app.pganalyze.com/graphql"})
+	assert.NoError(t, err)
+	assert.Equal(t, "https://app.pganalyze.com/graphql", p.graphqlURL)
+}
+
+func TestTools(t *testing.T) {
+	i := New()
+	tools := i.Tools()
+	assert.NotEmpty(t, tools)
+
+	for _, tool := range tools {
+		assert.NotEmpty(t, tool.Name, "tool has empty name")
+		assert.NotEmpty(t, tool.Description, "tool %s has empty description", tool.Name)
+	}
+}
+
+func TestTools_AllHavePganalyzePrefix(t *testing.T) {
+	i := New()
+	for _, tool := range i.Tools() {
+		assert.Contains(t, tool.Name, "pganalyze_", "tool %s missing pganalyze_ prefix", tool.Name)
+	}
+}
+
+func TestTools_NoDuplicateNames(t *testing.T) {
+	i := New()
+	seen := make(map[string]bool)
+	for _, tool := range i.Tools() {
+		assert.False(t, seen[tool.Name], "duplicate tool name: %s", tool.Name)
+		seen[tool.Name] = true
+	}
+}
+
+func TestExecute_UnknownTool(t *testing.T) {
+	p := &pganalyze{apiKey: "key", graphqlURL: "http://localhost", client: &http.Client{}}
+	result, err := p.Execute(context.Background(), "pganalyze_nonexistent", nil)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "unknown tool")
+}
+
+func TestDispatchMap_AllToolsCovered(t *testing.T) {
+	i := New()
+	for _, tool := range i.Tools() {
+		_, ok := dispatch[tool.Name]
+		assert.True(t, ok, "tool %s has no dispatch handler", tool.Name)
+	}
+}
+
+func TestDispatchMap_NoOrphanHandlers(t *testing.T) {
+	i := New()
+	toolNames := make(map[string]bool)
+	for _, tool := range i.Tools() {
+		toolNames[tool.Name] = true
+	}
+	for name := range dispatch {
+		assert.True(t, toolNames[name], "dispatch handler %s has no tool definition", name)
+	}
+}
+
+// --- GQL helper tests ---
+
+func TestGQL_Success(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "Token test-key", r.Header.Get("Authorization"))
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{"getServers": []map[string]string{{"id": "srv-123"}}},
+		})
+	}))
+	defer ts.Close()
+
+	p := &pganalyze{apiKey: "test-key", graphqlURL: ts.URL, client: ts.Client()}
+	data, err := p.gql(context.Background(), `{ getServers { id } }`, nil)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "srv-123")
+}
+
+func TestGQL_APIError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(401)
+		w.Write([]byte(`{"error":"unauthorized"}`))
+	}))
+	defer ts.Close()
+
+	p := &pganalyze{apiKey: "bad-key", graphqlURL: ts.URL, client: ts.Client()}
+	_, err := p.gql(context.Background(), `{ bad }`, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "pganalyze API error (401)")
+}
+
+func TestGQL_GraphQLErrors(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"errors": []map[string]string{{"message": "field not found"}},
+		})
+	}))
+	defer ts.Close()
+
+	p := &pganalyze{apiKey: "test-key", graphqlURL: ts.URL, client: ts.Client()}
+	_, err := p.gql(context.Background(), `{ bad }`, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "field not found")
+}
+
+// --- Arg helper tests ---
+
+func TestArgStr(t *testing.T) {
+	assert.Equal(t, "val", argStr(map[string]any{"k": "val"}, "k"))
+	assert.Empty(t, argStr(map[string]any{}, "k"))
+}
+
+func TestArgInt(t *testing.T) {
+	assert.Equal(t, 42, argInt(map[string]any{"n": float64(42)}, "n"))
+	assert.Equal(t, 42, argInt(map[string]any{"n": 42}, "n"))
+	assert.Equal(t, 42, argInt(map[string]any{"n": "42"}, "n"))
+	assert.Equal(t, 0, argInt(map[string]any{}, "n"))
+}
+
+func TestArgBool(t *testing.T) {
+	assert.True(t, argBool(map[string]any{"b": true}, "b"))
+	assert.False(t, argBool(map[string]any{"b": false}, "b"))
+	assert.True(t, argBool(map[string]any{"b": "true"}, "b"))
+	assert.False(t, argBool(map[string]any{}, "b"))
+}
+
+// --- Result helper tests ---
+
+func TestRawResult(t *testing.T) {
+	data := json.RawMessage(`{"key":"value"}`)
+	result, err := rawResult(data)
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Equal(t, `{"key":"value"}`, result.Data)
+}
+
+func TestErrResult(t *testing.T) {
+	result, err := errResult(fmt.Errorf("test error"))
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Equal(t, "test error", result.Data)
+}
+
+func TestJsonResult(t *testing.T) {
+	result, err := jsonResult(map[string]string{"key": "value"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, `"key":"value"`)
+}
+
+func TestPlainTextKeys(t *testing.T) {
+	p := New()
+	ptc, ok := p.(mcp.PlainTextCredentials)
+	require.True(t, ok, "pganalyze must implement PlainTextCredentials")
+	keys := ptc.PlainTextKeys()
+	assert.Contains(t, keys, "base_url")
+	assert.Contains(t, keys, "organization_slug")
+}
+
+func TestConfigure_OrganizationSlug(t *testing.T) {
+	p := &pganalyze{client: &http.Client{}}
+	err := p.Configure(mcp.Credentials{"api_key": "key", "organization_slug": "my-org"})
+	assert.NoError(t, err)
+	assert.Equal(t, "my-org", p.organizationSlug)
+}
+
+func TestOrgSlug_ArgOverridesConfig(t *testing.T) {
+	p := &pganalyze{organizationSlug: "default-org"}
+	assert.Equal(t, "override-org", p.orgSlug(map[string]any{"organization_slug": "override-org"}))
+}
+
+func TestOrgSlug_FallsBackToConfig(t *testing.T) {
+	p := &pganalyze{organizationSlug: "default-org"}
+	assert.Equal(t, "default-org", p.orgSlug(map[string]any{}))
+}
+
+func TestOrgSlug_EmptyWhenNeitherSet(t *testing.T) {
+	p := &pganalyze{}
+	assert.Empty(t, p.orgSlug(map[string]any{}))
+}

--- a/integrations/pganalyze/queries.go
+++ b/integrations/pganalyze/queries.go
@@ -1,0 +1,58 @@
+package pganalyze
+
+import (
+	"context"
+	"encoding/json"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+func getQueryStats(ctx context.Context, p *pganalyze, args map[string]any) (*mcp.ToolResult, error) {
+	query := `
+		query GetQueryStats($databaseId: ID!, $startTs: Int, $endTs: Int, $limit: Int) {
+			getQueryStats(databaseId: $databaseId, startTs: $startTs, endTs: $endTs, limit: $limit) {
+				id
+				queryId
+				queryUrl
+				normalizedQuery
+				truncatedQuery
+				queryComment
+				statementTypes
+				totalCalls
+				avgTime
+				avgIoTime
+				bufferHitRatio
+				pctOfTotal
+				callsPerMinute
+			}
+		}
+	`
+
+	variables := map[string]any{
+		"databaseId": argStr(args, "database_id"),
+	}
+	if v := argInt(args, "start_ts"); v > 0 {
+		variables["startTs"] = v
+	}
+	if v := argInt(args, "end_ts"); v > 0 {
+		variables["endTs"] = v
+	}
+	limit := argInt(args, "limit")
+	if limit <= 0 {
+		limit = 20
+	}
+	variables["limit"] = limit
+
+	data, err := p.gql(ctx, query, variables)
+	if err != nil {
+		return errResult(err)
+	}
+
+	var resp struct {
+		GetQueryStats json.RawMessage `json:"getQueryStats"`
+	}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return errResult(err)
+	}
+	return rawResult(resp.GetQueryStats)
+}

--- a/integrations/pganalyze/servers.go
+++ b/integrations/pganalyze/servers.go
@@ -1,0 +1,44 @@
+package pganalyze
+
+import (
+	"context"
+	"encoding/json"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+func getServers(ctx context.Context, p *pganalyze, args map[string]any) (*mcp.ToolResult, error) {
+	query := `
+		query GetServers($organizationSlug: ID) {
+			getServers(organizationSlug: $organizationSlug) {
+				id
+				name
+				humanId
+				lastSnapshotAt
+				databases {
+					id
+					datname
+					displayName
+				}
+			}
+		}
+	`
+
+	variables := make(map[string]any)
+	if v := p.orgSlug(args); v != "" {
+		variables["organizationSlug"] = v
+	}
+
+	data, err := p.gql(ctx, query, variables)
+	if err != nil {
+		return errResult(err)
+	}
+
+	var resp struct {
+		GetServers json.RawMessage `json:"getServers"`
+	}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return errResult(err)
+	}
+	return rawResult(resp.GetServers)
+}

--- a/integrations/pganalyze/tools.go
+++ b/integrations/pganalyze/tools.go
@@ -1,0 +1,40 @@
+package pganalyze
+
+import mcp "github.com/daltoniam/switchboard"
+
+var tools = []mcp.ToolDefinition{
+	// --- Servers ---
+	{
+		Name:        "pganalyze_get_servers",
+		Description: "List all monitored PostgreSQL servers and their databases from pganalyze",
+		Parameters: map[string]string{
+			"organization_slug": "Organization slug to filter servers (e.g. 'my-org')",
+		},
+	},
+
+	// --- Issues ---
+	{
+		Name:        "pganalyze_get_issues",
+		Description: "Get check-up issues and performance alerts for monitored databases. Returns open issues by default.",
+		Parameters: map[string]string{
+			"organization_slug": "Organization slug to filter issues",
+			"server_id":         "Server ID to filter issues (from pganalyze_get_servers)",
+			"database_id":       "Database ID to filter issues (from pganalyze_get_servers)",
+			"severity":          "Filter by severity: info, warning, critical",
+			"include_resolved":  "Include resolved issues (default: false)",
+		},
+	},
+
+	// --- Query Stats ---
+	{
+		Name:        "pganalyze_get_query_stats",
+		Description: "Get query performance statistics for a database, sorted by impact. Shows top queries by total runtime.",
+		Parameters: map[string]string{
+			"database_id": "Database ID (use pganalyze_get_servers to find this)",
+			"start_ts":    "Start Unix timestamp in seconds (defaults to 24 hours ago)",
+			"end_ts":      "End Unix timestamp in seconds (defaults to now)",
+			"limit":       "Number of queries to return (default: 20)",
+		},
+		Required: []string{"database_id"},
+	},
+}

--- a/mcp.go
+++ b/mcp.go
@@ -79,6 +79,13 @@ type FieldCompactionIntegration interface {
 	CompactSpec(toolName string) ([]CompactField, bool)
 }
 
+// PlainTextCredentials is an optional interface that integrations can implement
+// to declare which credential keys should be rendered as plain text inputs
+// instead of password fields in the web UI.
+type PlainTextCredentials interface {
+	PlainTextKeys() []string
+}
+
 // ConfigService manages loading and saving configuration.
 type ConfigService interface {
 	Load() error
@@ -88,6 +95,7 @@ type ConfigService interface {
 	GetIntegration(name string) (*IntegrationConfig, bool)
 	SetIntegration(name string, ic *IntegrationConfig) error
 	EnabledIntegrations() []string
+	DefaultCredentialKeys(name string) []string
 }
 
 // Registry holds all registered integrations and provides lookup.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -43,6 +43,7 @@ func (m *mockConfigService) EnabledIntegrations() []string {
 	}
 	return names
 }
+func (m *mockConfigService) DefaultCredentialKeys(_ string) []string { return nil }
 
 type mockIntegration struct {
 	name      string

--- a/web/templates/pages/integration.templ
+++ b/web/templates/pages/integration.templ
@@ -6,11 +6,19 @@ import (
 )
 
 type IntegrationDetailData struct {
-	Name        string
-	Enabled     bool
-	Healthy     bool
-	Credentials map[string]string
-	Tools       []string
+	Name          string
+	Enabled       bool
+	Healthy       bool
+	Credentials   map[string]string
+	PlainTextKeys map[string]bool
+	Tools         []string
+}
+
+func credInputType(key string, plainTextKeys map[string]bool) string {
+	if plainTextKeys[key] {
+		return "text"
+	}
+	return "password"
 }
 
 templ IntegrationDetail(page layouts.PageData, data IntegrationDetailData) {
@@ -28,7 +36,7 @@ templ IntegrationDetail(page layouts.PageData, data IntegrationDetailData) {
 				</div>
 				<div>
 					for key, val := range data.Credentials {
-						@components.FormGroup(key, "cred_" + key, "password", val, "Enter " + key)
+						@components.FormGroup(key, "cred_" + key, credInputType(key, data.PlainTextKeys), val, "Enter " + key)
 					}
 				</div>
 			</div>

--- a/web/templates/pages/integration_templ.go
+++ b/web/templates/pages/integration_templ.go
@@ -14,11 +14,19 @@ import (
 )
 
 type IntegrationDetailData struct {
-	Name        string
-	Enabled     bool
-	Healthy     bool
-	Credentials map[string]string
-	Tools       []string
+	Name          string
+	Enabled       bool
+	Healthy       bool
+	Credentials   map[string]string
+	PlainTextKeys map[string]bool
+	Tools         []string
+}
+
+func credInputType(key string, plainTextKeys map[string]bool) string {
+	if plainTextKeys[key] {
+		return "text"
+	}
+	return "password"
 }
 
 func IntegrationDetail(page layouts.PageData, data IntegrationDetailData) templ.Component {
@@ -61,7 +69,7 @@ func IntegrationDetail(page layouts.PageData, data IntegrationDetailData) templ.
 			var templ_7745c5c3_Var3 string
 			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(data.Name)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 20, Col: 91}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 28, Col: 91}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 			if templ_7745c5c3_Err != nil {
@@ -82,7 +90,7 @@ func IntegrationDetail(page layouts.PageData, data IntegrationDetailData) templ.
 			var templ_7745c5c3_Var4 templ.SafeURL
 			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("/integrations/" + data.Name))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 23, Col: 74}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 31, Col: 74}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 			if templ_7745c5c3_Err != nil {
@@ -101,7 +109,7 @@ func IntegrationDetail(page layouts.PageData, data IntegrationDetailData) templ.
 				return templ_7745c5c3_Err
 			}
 			for key, val := range data.Credentials {
-				templ_7745c5c3_Err = components.FormGroup(key, "cred_"+key, "password", val, "Enter "+key).Render(ctx, templ_7745c5c3_Buffer)
+				templ_7745c5c3_Err = components.FormGroup(key, "cred_"+key, credInputType(key, data.PlainTextKeys), val, "Enter "+key).Render(ctx, templ_7745c5c3_Buffer)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}

--- a/web/web.go
+++ b/web/web.go
@@ -182,17 +182,27 @@ func (w *WebServer) handleIntegrationDetail(rw http.ResponseWriter, r *http.Requ
 	enabled := exists && ic.Enabled
 
 	var healthy bool
-	var creds mcp.Credentials
-	if exists {
-		creds = ic.Credentials
-		if enabled {
-			if err := integration.Configure(ic.Credentials); err == nil {
-				healthy = integration.Healthy(r.Context())
-			}
+	if exists && enabled {
+		if err := integration.Configure(ic.Credentials); err == nil {
+			healthy = integration.Healthy(r.Context())
 		}
 	}
-	if creds == nil {
-		creds = mcp.Credentials{}
+
+	creds := mcp.Credentials{}
+	for _, key := range w.services.Config.DefaultCredentialKeys(name) {
+		creds[key] = ""
+	}
+	if exists {
+		for k, v := range ic.Credentials {
+			creds[k] = v
+		}
+	}
+
+	plainTextKeys := map[string]bool{}
+	if ptc, ok := integration.(mcp.PlainTextCredentials); ok {
+		for _, k := range ptc.PlainTextKeys() {
+			plainTextKeys[k] = true
+		}
 	}
 
 	var tools []string
@@ -202,11 +212,12 @@ func (w *WebServer) handleIntegrationDetail(rw http.ResponseWriter, r *http.Requ
 
 	page := w.pageData(r, integration.Name(), "/integrations")
 	data := pages.IntegrationDetailData{
-		Name:        name,
-		Enabled:     enabled,
-		Healthy:     healthy,
-		Credentials: creds,
-		Tools:       tools,
+		Name:          name,
+		Enabled:       enabled,
+		Healthy:       healthy,
+		Credentials:   creds,
+		PlainTextKeys: plainTextKeys,
+		Tools:         tools,
 	}
 
 	pages.IntegrationDetail(page, data).Render(r.Context(), rw)

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -44,6 +44,7 @@ func (m *mockConfigService) EnabledIntegrations() []string {
 	}
 	return names
 }
+func (m *mockConfigService) DefaultCredentialKeys(_ string) []string { return nil }
 
 type mockIntegration struct {
 	name    string


### PR DESCRIPTION
## Summary

- Add native pganalyze integration adapter with GraphQL client, 3 tools (`pganalyze_get_servers`, `pganalyze_get_issues`, `pganalyze_get_query_stats`), field compaction specs, and config-level `organization_slug` default
- Add `PlainTextCredentials` optional interface so integrations can declare credential keys rendered as `type="text"` instead of `type="password"` in the web UI (pganalyze uses it for `base_url` and `organization_slug`)
- Improve config merging to always include default credential keys for new integrations, ensuring the web UI form renders all expected fields even when the config file predates the integration

## Test plan

- [x] All 19 test packages pass (`go test ./...`)
- [x] 31 new tests in `integrations/pganalyze/` covering constructor, configure, dispatch parity, GraphQL helper, arg helpers, result helpers, compact specs, PlainTextKeys, orgSlug fallback
- [x] Config tests updated for new integration count and credential keys
- [x] `go vet ./...` clean
- [x] `golangci-lint run` — 0 issues
- [x] `gosec` — 0 issues
- [ ] Manual verification: web UI renders `base_url` and `organization_slug` as text fields, `api_key` as password


🐾 Generated with Crush