### PR TITLE
Add project-interop spec support

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/daltoniam/switchboard/integrations/rwx"
 	"github.com/daltoniam/switchboard/integrations/sentry"
 	slackInt "github.com/daltoniam/switchboard/integrations/slack"
+	"github.com/daltoniam/switchboard/project"
 	"github.com/daltoniam/switchboard/registry"
 	"github.com/daltoniam/switchboard/server"
 	"github.com/daltoniam/switchboard/web"
@@ -209,9 +210,20 @@ func runServer(stdioMode bool, port int) {
 		defer func() { _ = daemon.RemovePID() }()
 	}
 
+	projectStore := project.NewStore(project.DefaultConfigDir())
+	if err := projectStore.Load(); err != nil {
+		log.Printf("WARN: failed to load project definitions: %v", err)
+	}
+	if names := projectStore.Names(); len(names) > 0 {
+		log.Printf("Loaded %d project(s): %v", len(names), names)
+	}
+
+	projectRouter := server.NewProjectRouter(services, projectStore, "")
+
 	mux := http.NewServeMux()
 
 	mux.Handle("/mcp", srv.Handler())
+	mux.Handle("/mcp/{project}", projectRouter.Handler())
 
 	ws := web.New(services, port)
 	mux.Handle("/", ws.Handler())
@@ -220,6 +232,7 @@ func runServer(stdioMode bool, port int) {
 	fmt.Fprintf(os.Stderr, "Switchboard on http://localhost:%d\n", port)
 	fmt.Fprintf(os.Stderr, "  Web UI:  http://localhost:%d/\n", port)
 	fmt.Fprintf(os.Stderr, "  MCP:     http://localhost:%d/mcp\n", port)
+	fmt.Fprintf(os.Stderr, "  Project: http://localhost:%d/mcp/{project}\n", port)
 
 	httpServer := &http.Server{Addr: addr, Handler: mux, ReadHeaderTimeout: 10 * time.Second}
 	go func() {

--- a/project/context.go
+++ b/project/context.go
@@ -1,0 +1,204 @@
+package project
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ContextEntry describes a single file in the assembled context bundle.
+type ContextEntry struct {
+	Path     string `json:"path"`
+	Source   string `json:"source"`
+	MIMEType string `json:"mimeType"`
+	Size     int    `json:"sizeBytes"`
+}
+
+// AssembleManifest builds the context manifest for a project definition.
+// Layer 1: repoIncludes (committed files from the repository)
+// Layer 2: files (non-committed files from the context store)
+// Deduplication: higher layer wins.
+func AssembleManifest(def *Definition, configDir string) []ContextEntry {
+	if def.Context == nil {
+		return nil
+	}
+	return assembleManifestFromConfig(def.Context, def.ResolvedRepo(), configDir, def.Name)
+}
+
+// AssembleManifestWithRole applies role context overrides before assembling.
+func AssembleManifestWithRole(def *Definition, configDir string, role string) []ContextEntry {
+	ctx := effectiveContext(def, role)
+	if ctx == nil {
+		return nil
+	}
+	return assembleManifestFromConfig(ctx, def.ResolvedRepo(), configDir, def.Name)
+}
+
+func effectiveContext(def *Definition, role string) *ContextConfig {
+	if def.Context == nil && role == "" {
+		return nil
+	}
+	base := def.Context
+	if base == nil {
+		base = &ContextConfig{}
+	}
+	if role == "" || def.Agents == nil || def.Agents.Roles == nil {
+		return base
+	}
+	roleDef, ok := def.Agents.Roles[role]
+	if !ok || roleDef.ContextOverrides == nil {
+		return base
+	}
+
+	result := &ContextConfig{}
+	ov := roleDef.ContextOverrides
+
+	if len(ov.Files) > 0 {
+		result.Files = ov.Files
+	} else {
+		result.Files = base.Files
+	}
+	if len(ov.RepoIncludes) > 0 {
+		result.RepoIncludes = ov.RepoIncludes
+	} else {
+		result.RepoIncludes = base.RepoIncludes
+	}
+	if ov.MaxBytes > 0 {
+		result.MaxBytes = ov.MaxBytes
+	} else {
+		result.MaxBytes = base.MaxBytes
+	}
+	return result
+}
+
+func assembleManifestFromConfig(ctx *ContextConfig, repoRoot, configDir, projectName string) []ContextEntry {
+	var entries []ContextEntry
+
+	for _, inc := range ctx.RepoIncludes {
+		if repoRoot == "" {
+			continue
+		}
+		full := filepath.Join(repoRoot, inc)
+		matches, _ := filepath.Glob(full)
+		if len(matches) == 0 {
+			matches = []string{full}
+		}
+		for _, m := range matches {
+			info, err := os.Stat(m)
+			if err != nil {
+				continue
+			}
+			rel, _ := filepath.Rel(repoRoot, m)
+			entries = append(entries, ContextEntry{
+				Path:     rel,
+				Source:   "repo",
+				MIMEType: GuessMIME(rel),
+				Size:     int(info.Size()),
+			})
+		}
+	}
+
+	contextDir := filepath.Join(configDir, "context", projectName)
+	for _, f := range ctx.Files {
+		full := filepath.Join(contextDir, f)
+		info, err := os.Stat(full)
+		if err != nil {
+			continue
+		}
+		entries = append(entries, ContextEntry{
+			Path:     f,
+			Source:   "store",
+			MIMEType: GuessMIME(f),
+			Size:     int(info.Size()),
+		})
+	}
+
+	return deduplicate(entries)
+}
+
+// ReadContextFile reads a context file by path, searching the context store first,
+// then the repo. Returns content and an error if not found.
+func ReadContextFile(def *Definition, configDir, path string) (string, error) {
+	contextDir := filepath.Join(configDir, "context", def.Name)
+
+	candidates := []string{
+		filepath.Join(contextDir, path),
+	}
+	if repoRoot := def.ResolvedRepo(); repoRoot != "" {
+		candidates = append(candidates, filepath.Join(repoRoot, path))
+	}
+
+	for _, candidate := range candidates {
+		data, err := os.ReadFile(candidate)
+		if err == nil {
+			return string(data), nil
+		}
+	}
+	return "", fmt.Errorf("context file not found: %s", path)
+}
+
+// AssembleBundle assembles the full context bundle as a concatenated string.
+// Respects maxBytes if set.
+func AssembleBundle(def *Definition, configDir string, role string) (string, []ContextEntry) {
+	entries := AssembleManifestWithRole(def, configDir, role)
+	if len(entries) == 0 {
+		return "", nil
+	}
+
+	ctx := effectiveContext(def, role)
+	maxBytes := 0
+	if ctx != nil {
+		maxBytes = ctx.MaxBytes
+	}
+
+	var sb strings.Builder
+	var included []ContextEntry
+	for _, entry := range entries {
+		content, err := ReadContextFile(def, configDir, entry.Path)
+		if err != nil {
+			continue
+		}
+		section := fmt.Sprintf("--- %s (%s) ---\n%s\n\n", entry.Path, entry.Source, content)
+		if maxBytes > 0 && sb.Len()+len(section) > maxBytes {
+			fmt.Fprintf(&sb, "--- TRUNCATED: context exceeded %d bytes ---\n", maxBytes)
+			break
+		}
+		sb.WriteString(section)
+		included = append(included, entry)
+	}
+	return sb.String(), included
+}
+
+func deduplicate(entries []ContextEntry) []ContextEntry {
+	seen := make(map[string]int)
+	for i, e := range entries {
+		seen[e.Path] = i
+	}
+	var result []ContextEntry
+	added := make(map[string]bool)
+	for _, e := range entries {
+		idx := seen[e.Path]
+		if !added[e.Path] {
+			result = append(result, entries[idx])
+			added[e.Path] = true
+		}
+	}
+	return result
+}
+
+// GuessMIME returns a MIME type based on file extension.
+func GuessMIME(path string) string {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".md":
+		return "text/markdown"
+	case ".txt":
+		return "text/plain"
+	case ".json":
+		return "application/json"
+	case ".yaml", ".yml":
+		return "text/yaml"
+	default:
+		return "text/plain"
+	}
+}

--- a/project/context_test.go
+++ b/project/context_test.go
@@ -1,0 +1,222 @@
+package project
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupContextTestDirs(t *testing.T) (configDir, repoDir string) {
+	t.Helper()
+	base := t.TempDir()
+	configDir = filepath.Join(base, "config")
+	repoDir = filepath.Join(base, "repo")
+
+	require.NoError(t, os.MkdirAll(filepath.Join(configDir, "context", "test-project"), 0700))
+	require.NoError(t, os.MkdirAll(filepath.Join(repoDir, "docs"), 0700))
+
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "context", "test-project", "sprint.md"), []byte("Sprint goals"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "AGENTS.md"), []byte("Agent instructions"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "docs", "arch.md"), []byte("Architecture"), 0600))
+
+	return configDir, repoDir
+}
+
+func TestAssembleManifest(t *testing.T) {
+	configDir, repoDir := setupContextTestDirs(t)
+
+	def := &Definition{
+		Version: "1",
+		Name:    "test-project",
+		Repo:    repoDir,
+		Context: &ContextConfig{
+			Files:        []string{"sprint.md"},
+			RepoIncludes: []string{"AGENTS.md", "docs/arch.md"},
+		},
+	}
+
+	entries := AssembleManifest(def, configDir)
+	assert.Len(t, entries, 3)
+
+	assert.Equal(t, "AGENTS.md", entries[0].Path)
+	assert.Equal(t, "repo", entries[0].Source)
+	assert.Equal(t, "text/markdown", entries[0].MIMEType)
+
+	assert.Equal(t, "docs/arch.md", entries[1].Path)
+	assert.Equal(t, "repo", entries[1].Source)
+
+	assert.Equal(t, "sprint.md", entries[2].Path)
+	assert.Equal(t, "store", entries[2].Source)
+}
+
+func TestAssembleManifest_NilContext(t *testing.T) {
+	def := &Definition{Version: "1", Name: "p"}
+	entries := AssembleManifest(def, "/tmp/nonexistent")
+	assert.Nil(t, entries)
+}
+
+func TestAssembleManifest_MissingFiles(t *testing.T) {
+	def := &Definition{
+		Version: "1",
+		Name:    "p",
+		Context: &ContextConfig{
+			Files:        []string{"nonexistent.md"},
+			RepoIncludes: []string{"nonexistent.md"},
+		},
+	}
+	entries := AssembleManifest(def, "/tmp/nonexistent")
+	assert.Empty(t, entries)
+}
+
+func TestAssembleManifest_Dedup(t *testing.T) {
+	configDir, repoDir := setupContextTestDirs(t)
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(configDir, "context", "test-project", "AGENTS.md"),
+		[]byte("Store version"), 0600,
+	))
+
+	def := &Definition{
+		Version: "1",
+		Name:    "test-project",
+		Repo:    repoDir,
+		Context: &ContextConfig{
+			Files:        []string{"AGENTS.md"},
+			RepoIncludes: []string{"AGENTS.md"},
+		},
+	}
+
+	entries := AssembleManifest(def, configDir)
+	assert.Len(t, entries, 1)
+	assert.Equal(t, "store", entries[0].Source)
+}
+
+func TestReadContextFile(t *testing.T) {
+	configDir, repoDir := setupContextTestDirs(t)
+
+	def := &Definition{
+		Version: "1",
+		Name:    "test-project",
+		Repo:    repoDir,
+	}
+
+	t.Run("reads from store", func(t *testing.T) {
+		content, err := ReadContextFile(def, configDir, "sprint.md")
+		require.NoError(t, err)
+		assert.Equal(t, "Sprint goals", content)
+	})
+
+	t.Run("reads from repo", func(t *testing.T) {
+		content, err := ReadContextFile(def, configDir, "AGENTS.md")
+		require.NoError(t, err)
+		assert.Equal(t, "Agent instructions", content)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := ReadContextFile(def, configDir, "nonexistent.md")
+		assert.ErrorContains(t, err, "context file not found")
+	})
+}
+
+func TestAssembleManifestWithRole(t *testing.T) {
+	configDir, repoDir := setupContextTestDirs(t)
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(configDir, "context", "test-project", "review.md"),
+		[]byte("Review checklist"), 0600,
+	))
+
+	def := &Definition{
+		Version: "1",
+		Name:    "test-project",
+		Repo:    repoDir,
+		Context: &ContextConfig{
+			Files:        []string{"sprint.md"},
+			RepoIncludes: []string{"AGENTS.md"},
+		},
+		Agents: &AgentsConfig{
+			Roles: map[string]*RoleDefinition{
+				"reviewer": {
+					ContextOverrides: &ContextConfig{
+						Files: []string{"review.md"},
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("no role uses project context", func(t *testing.T) {
+		entries := AssembleManifestWithRole(def, configDir, "")
+		assert.Len(t, entries, 2)
+	})
+
+	t.Run("role replaces files", func(t *testing.T) {
+		entries := AssembleManifestWithRole(def, configDir, "reviewer")
+		assert.Len(t, entries, 2)
+		paths := make([]string, len(entries))
+		for i, e := range entries {
+			paths[i] = e.Path
+		}
+		assert.Contains(t, paths, "AGENTS.md")
+		assert.Contains(t, paths, "review.md")
+	})
+}
+
+func TestAssembleBundle(t *testing.T) {
+	configDir, repoDir := setupContextTestDirs(t)
+
+	def := &Definition{
+		Version: "1",
+		Name:    "test-project",
+		Repo:    repoDir,
+		Context: &ContextConfig{
+			Files:        []string{"sprint.md"},
+			RepoIncludes: []string{"AGENTS.md"},
+		},
+	}
+
+	bundle, entries := AssembleBundle(def, configDir, "")
+	assert.Len(t, entries, 2)
+	assert.Contains(t, bundle, "Agent instructions")
+	assert.Contains(t, bundle, "Sprint goals")
+}
+
+func TestAssembleBundle_MaxBytes(t *testing.T) {
+	configDir, repoDir := setupContextTestDirs(t)
+
+	def := &Definition{
+		Version: "1",
+		Name:    "test-project",
+		Repo:    repoDir,
+		Context: &ContextConfig{
+			Files:        []string{"sprint.md"},
+			RepoIncludes: []string{"AGENTS.md"},
+			MaxBytes:     50,
+		},
+	}
+
+	bundle, _ := AssembleBundle(def, configDir, "")
+	assert.Contains(t, bundle, "TRUNCATED")
+}
+
+func TestGuessMIME(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"readme.md", "text/markdown"},
+		{"notes.txt", "text/plain"},
+		{"config.json", "application/json"},
+		{"config.yaml", "text/yaml"},
+		{"config.yml", "text/yaml"},
+		{"unknown.xyz", "text/plain"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			assert.Equal(t, tt.want, GuessMIME(tt.path))
+		})
+	}
+}

--- a/project/project.go
+++ b/project/project.go
@@ -1,0 +1,495 @@
+package project
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+var nameRE = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
+
+// Definition represents a project-interop project definition (.project.json).
+type Definition struct {
+	Schema     string                `json:"$schema,omitempty"`
+	Version    string                `json:"version"`
+	Name       string                `json:"name"`
+	Repo       string                `json:"repo,omitempty"`
+	Branch     string                `json:"branch,omitempty"`
+	Launch     *LaunchConfig         `json:"launch,omitempty"`
+	Tools      map[string]*ScopeRule `json:"tools,omitempty"`
+	Context    *ContextConfig        `json:"context,omitempty"`
+	Agents     *AgentsConfig         `json:"agents,omitempty"`
+	Extensions map[string]any        `json:"extensions,omitempty"`
+}
+
+// LaunchConfig controls how agents are bootstrapped.
+type LaunchConfig struct {
+	Prompt     string            `json:"prompt,omitempty"`
+	PromptFile string            `json:"promptFile,omitempty"`
+	Env        map[string]string `json:"env,omitempty"`
+}
+
+// ScopeRule defines allow/deny/defaults for a single MCP server.
+type ScopeRule struct {
+	Allow    []string                  `json:"allow,omitempty"`
+	Deny     []string                  `json:"deny,omitempty"`
+	Defaults map[string]map[string]any `json:"defaults,omitempty"`
+}
+
+// ContextConfig specifies context files and assembly limits.
+type ContextConfig struct {
+	Files        []string `json:"files,omitempty"`
+	RepoIncludes []string `json:"repoIncludes,omitempty"`
+	MaxBytes     int      `json:"maxBytes,omitempty"`
+}
+
+// AgentsConfig holds multi-agent coordination settings.
+type AgentsConfig struct {
+	MaxConcurrent int                        `json:"maxConcurrent,omitempty"`
+	Roles         map[string]*RoleDefinition `json:"roles,omitempty"`
+}
+
+// RoleDefinition scopes tool access and context for an agent role.
+type RoleDefinition struct {
+	Description      string                `json:"description,omitempty"`
+	ToolOverrides    map[string]*ScopeRule `json:"toolOverrides,omitempty"`
+	ContextOverrides *ContextConfig        `json:"contextOverrides,omitempty"`
+}
+
+// Validate checks that the definition has required fields and valid values.
+func (d *Definition) Validate() error {
+	if d.Version != "1" {
+		return fmt.Errorf("unsupported version %q (must be \"1\")", d.Version)
+	}
+	if d.Name == "" {
+		return fmt.Errorf("name is required")
+	}
+	if len(d.Name) > 128 {
+		return fmt.Errorf("name exceeds 128 characters")
+	}
+	if !nameRE.MatchString(d.Name) {
+		return fmt.Errorf("name %q does not match pattern ^[a-zA-Z0-9][a-zA-Z0-9._-]*$", d.Name)
+	}
+	return nil
+}
+
+// ExpandHome expands a leading ~/ to $HOME.
+func ExpandHome(path string) string {
+	if strings.HasPrefix(path, "~/") {
+		home, _ := os.UserHomeDir()
+		return filepath.Join(home, path[2:])
+	}
+	return path
+}
+
+// ResolvedRepo returns the absolute path to the project repository.
+func (d *Definition) ResolvedRepo() string {
+	if d.Repo == "" {
+		return ""
+	}
+	return ExpandHome(d.Repo)
+}
+
+// Merge merges a higher-precedence definition onto a base, returning a new Definition.
+// The base is the user-level definition; overlay is the repo-local override.
+func Merge(base, overlay *Definition) (*Definition, error) {
+	if base.Name != "" && overlay.Name != "" && base.Name != overlay.Name {
+		return nil, fmt.Errorf("cannot merge projects with different names: %q vs %q", base.Name, overlay.Name)
+	}
+
+	result := &Definition{}
+
+	data, _ := json.Marshal(base)
+	_ = json.Unmarshal(data, result)
+
+	if overlay.Schema != "" {
+		result.Schema = overlay.Schema
+	}
+	if overlay.Repo != "" {
+		result.Repo = overlay.Repo
+	}
+	if overlay.Branch != "" {
+		result.Branch = overlay.Branch
+	}
+
+	result.Launch = mergeLaunch(base.Launch, overlay.Launch)
+	result.Tools = mergeTools(base.Tools, overlay.Tools)
+	result.Context = mergeContext(base.Context, overlay.Context)
+	result.Agents = mergeAgents(base.Agents, overlay.Agents)
+	result.Extensions = mergeExtensions(base.Extensions, overlay.Extensions)
+
+	return result, nil
+}
+
+func mergeLaunch(base, overlay *LaunchConfig) *LaunchConfig {
+	if overlay == nil {
+		return base
+	}
+	if base == nil {
+		return overlay
+	}
+	result := &LaunchConfig{}
+	if overlay.Prompt != "" {
+		result.Prompt = overlay.Prompt
+	} else {
+		result.Prompt = base.Prompt
+	}
+	if overlay.PromptFile != "" {
+		result.PromptFile = overlay.PromptFile
+	} else {
+		result.PromptFile = base.PromptFile
+	}
+	result.Env = make(map[string]string)
+	for k, v := range base.Env {
+		result.Env[k] = v
+	}
+	for k, v := range overlay.Env {
+		result.Env[k] = v
+	}
+	return result
+}
+
+func mergeTools(base, overlay map[string]*ScopeRule) map[string]*ScopeRule {
+	if overlay == nil {
+		return base
+	}
+	if base == nil {
+		return overlay
+	}
+	result := make(map[string]*ScopeRule)
+	for k, v := range base {
+		result[k] = copyScopeRule(v)
+	}
+	for k, v := range overlay {
+		existing, ok := result[k]
+		if !ok {
+			result[k] = copyScopeRule(v)
+			continue
+		}
+		existing.Allow = append(existing.Allow, v.Allow...)
+		existing.Deny = append(existing.Deny, v.Deny...)
+		if v.Defaults != nil {
+			if existing.Defaults == nil {
+				existing.Defaults = make(map[string]map[string]any)
+			}
+			for pattern, args := range v.Defaults {
+				existing.Defaults[pattern] = args
+			}
+		}
+	}
+	return result
+}
+
+func copyScopeRule(r *ScopeRule) *ScopeRule {
+	c := &ScopeRule{}
+	c.Allow = append(c.Allow, r.Allow...)
+	c.Deny = append(c.Deny, r.Deny...)
+	if r.Defaults != nil {
+		c.Defaults = make(map[string]map[string]any)
+		for k, v := range r.Defaults {
+			c.Defaults[k] = v
+		}
+	}
+	return c
+}
+
+func mergeContext(base, overlay *ContextConfig) *ContextConfig {
+	if overlay == nil {
+		return base
+	}
+	if base == nil {
+		return overlay
+	}
+	result := &ContextConfig{}
+	result.Files = append(result.Files, base.Files...)
+	result.Files = append(result.Files, overlay.Files...)
+	result.RepoIncludes = append(result.RepoIncludes, base.RepoIncludes...)
+	result.RepoIncludes = append(result.RepoIncludes, overlay.RepoIncludes...)
+	if overlay.MaxBytes > 0 {
+		result.MaxBytes = overlay.MaxBytes
+	} else {
+		result.MaxBytes = base.MaxBytes
+	}
+	return result
+}
+
+func mergeAgents(base, overlay *AgentsConfig) *AgentsConfig {
+	if overlay == nil {
+		return base
+	}
+	if base == nil {
+		return overlay
+	}
+	result := &AgentsConfig{
+		MaxConcurrent: base.MaxConcurrent,
+	}
+	if overlay.MaxConcurrent > 0 {
+		result.MaxConcurrent = overlay.MaxConcurrent
+	}
+	result.Roles = make(map[string]*RoleDefinition)
+	for k, v := range base.Roles {
+		result.Roles[k] = v
+	}
+	for k, v := range overlay.Roles {
+		result.Roles[k] = v
+	}
+	return result
+}
+
+func mergeExtensions(base, overlay map[string]any) map[string]any {
+	if overlay == nil {
+		return base
+	}
+	if base == nil {
+		return overlay
+	}
+	result := make(map[string]any)
+	for k, v := range base {
+		result[k] = v
+	}
+	for k, v := range overlay {
+		result[k] = v
+	}
+	return result
+}
+
+// Store manages project definitions in the user-level store.
+type Store struct {
+	configDir string
+	mu        sync.RWMutex
+	projects  map[string]*Definition
+}
+
+// NewStore creates a store rooted at the project-interop config directory.
+func NewStore(configDir string) *Store {
+	return &Store{
+		configDir: configDir,
+		projects:  make(map[string]*Definition),
+	}
+}
+
+// DefaultConfigDir returns the default project-interop config directory.
+func DefaultConfigDir() string {
+	if dir := os.Getenv("XDG_CONFIG_HOME"); dir != "" {
+		return filepath.Join(dir, "project-interop")
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".config", "project-interop")
+}
+
+// Load discovers and loads all project definitions from the user-level store.
+// For each project with a repo path, it also attempts to merge a repo-local .project.json.
+func (s *Store) Load() error {
+	dir := filepath.Join(s.configDir, "projects")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("reading projects dir: %w", err)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, e := range entries {
+		if !strings.HasSuffix(e.Name(), ".project.json") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			continue
+		}
+		var def Definition
+		if err := json.Unmarshal(data, &def); err != nil {
+			continue
+		}
+		if err := def.Validate(); err != nil {
+			continue
+		}
+
+		merged, err := s.mergeRepoLocal(&def)
+		if err == nil && merged != nil {
+			s.projects[merged.Name] = merged
+		} else {
+			s.projects[def.Name] = &def
+		}
+	}
+	return nil
+}
+
+func (s *Store) mergeRepoLocal(base *Definition) (*Definition, error) {
+	repoRoot := base.ResolvedRepo()
+	if repoRoot == "" {
+		return nil, nil
+	}
+	repoLocalPath := filepath.Join(repoRoot, ".project.json")
+	data, err := os.ReadFile(repoLocalPath)
+	if err != nil {
+		return nil, nil
+	}
+	var overlay Definition
+	if err := json.Unmarshal(data, &overlay); err != nil {
+		return nil, err
+	}
+	return Merge(base, &overlay)
+}
+
+// Get returns a project definition by name.
+func (s *Store) Get(name string) (*Definition, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	d, ok := s.projects[name]
+	return d, ok
+}
+
+// All returns all loaded project definitions.
+func (s *Store) All() map[string]*Definition {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	result := make(map[string]*Definition, len(s.projects))
+	for k, v := range s.projects {
+		result[k] = v
+	}
+	return result
+}
+
+// Names returns all project names.
+func (s *Store) Names() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	names := make([]string, 0, len(s.projects))
+	for k := range s.projects {
+		names = append(names, k)
+	}
+	return names
+}
+
+// Create writes a new project definition to the user-level store.
+func (s *Store) Create(def *Definition) error {
+	if err := def.Validate(); err != nil {
+		return fmt.Errorf("invalid project definition: %w", err)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.projects[def.Name]; exists {
+		return fmt.Errorf("project %q already exists", def.Name)
+	}
+
+	if err := s.writeToDisk(def); err != nil {
+		return err
+	}
+	s.projects[def.Name] = def
+	return nil
+}
+
+// Update applies a JSON merge patch to the user-level store file.
+func (s *Store) Update(name string, patch json.RawMessage) (*Definition, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	existing, ok := s.projects[name]
+	if !ok {
+		return nil, fmt.Errorf("project %q not found", name)
+	}
+
+	base, err := json.Marshal(existing)
+	if err != nil {
+		return nil, err
+	}
+
+	var baseMap map[string]any
+	_ = json.Unmarshal(base, &baseMap)
+
+	var patchMap map[string]any
+	if err := json.Unmarshal(patch, &patchMap); err != nil {
+		return nil, fmt.Errorf("invalid patch: %w", err)
+	}
+
+	merged := jsonMergePatch(baseMap, patchMap)
+	result, err := json.Marshal(merged)
+	if err != nil {
+		return nil, err
+	}
+
+	var def Definition
+	if err := json.Unmarshal(result, &def); err != nil {
+		return nil, err
+	}
+	if err := def.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid project definition after patch: %w", err)
+	}
+
+	if err := s.writeToDisk(&def); err != nil {
+		return nil, err
+	}
+	s.projects[name] = &def
+	return &def, nil
+}
+
+// Delete removes a project definition from the user-level store.
+func (s *Store) Delete(name string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.projects[name]; !ok {
+		return fmt.Errorf("project %q not found", name)
+	}
+
+	path := filepath.Join(s.configDir, "projects", name+".project.json")
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	delete(s.projects, name)
+	return nil
+}
+
+func (s *Store) writeToDisk(def *Definition) error {
+	dir := filepath.Join(s.configDir, "projects")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(def, "", "  ")
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(dir, def.Name+".project.json")
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// jsonMergePatch implements RFC 7396 JSON Merge Patch.
+func jsonMergePatch(base, patch map[string]any) map[string]any {
+	result := make(map[string]any)
+	for k, v := range base {
+		result[k] = v
+	}
+	for k, v := range patch {
+		if v == nil {
+			delete(result, k)
+			continue
+		}
+		if patchObj, ok := v.(map[string]any); ok {
+			if baseObj, ok := result[k].(map[string]any); ok {
+				result[k] = jsonMergePatch(baseObj, patchObj)
+				continue
+			}
+		}
+		result[k] = v
+	}
+	return result
+}
+
+// ConfigDir returns the store's config directory root.
+func (s *Store) ConfigDir() string {
+	return s.configDir
+}

--- a/project/project_test.go
+++ b/project/project_test.go
@@ -1,0 +1,325 @@
+package project
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefinition_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		def     Definition
+		wantErr string
+	}{
+		{
+			name:    "valid minimal",
+			def:     Definition{Version: "1", Name: "my-project"},
+			wantErr: "",
+		},
+		{
+			name:    "missing version",
+			def:     Definition{Version: "", Name: "my-project"},
+			wantErr: "unsupported version",
+		},
+		{
+			name:    "wrong version",
+			def:     Definition{Version: "2", Name: "my-project"},
+			wantErr: "unsupported version",
+		},
+		{
+			name:    "missing name",
+			def:     Definition{Version: "1", Name: ""},
+			wantErr: "name is required",
+		},
+		{
+			name:    "name too long",
+			def:     Definition{Version: "1", Name: string(make([]byte, 129))},
+			wantErr: "exceeds 128 characters",
+		},
+		{
+			name:    "name starts with dash",
+			def:     Definition{Version: "1", Name: "-bad"},
+			wantErr: "does not match pattern",
+		},
+		{
+			name:    "name with spaces",
+			def:     Definition{Version: "1", Name: "bad name"},
+			wantErr: "does not match pattern",
+		},
+		{
+			name:    "name with dots and dashes",
+			def:     Definition{Version: "1", Name: "my-project.v2"},
+			wantErr: "",
+		},
+		{
+			name:    "name with underscore",
+			def:     Definition{Version: "1", Name: "my_project"},
+			wantErr: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.def.Validate()
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestExpandHome(t *testing.T) {
+	home, _ := os.UserHomeDir()
+	assert.Equal(t, filepath.Join(home, "work"), ExpandHome("~/work"))
+	assert.Equal(t, "/absolute/path", ExpandHome("/absolute/path"))
+	assert.Equal(t, "relative/path", ExpandHome("relative/path"))
+}
+
+func TestMerge_Scalars(t *testing.T) {
+	base := &Definition{
+		Version: "1",
+		Name:    "myproject",
+		Repo:    "~/work/base",
+		Branch:  "main",
+	}
+	overlay := &Definition{
+		Version: "1",
+		Name:    "myproject",
+		Branch:  "develop",
+	}
+
+	result, err := Merge(base, overlay)
+	require.NoError(t, err)
+	assert.Equal(t, "myproject", result.Name)
+	assert.Equal(t, "~/work/base", result.Repo)
+	assert.Equal(t, "develop", result.Branch)
+}
+
+func TestMerge_ConflictingNames(t *testing.T) {
+	base := &Definition{Version: "1", Name: "a"}
+	overlay := &Definition{Version: "1", Name: "b"}
+	_, err := Merge(base, overlay)
+	assert.ErrorContains(t, err, "different names")
+}
+
+func TestMerge_Launch(t *testing.T) {
+	base := &Definition{
+		Version: "1",
+		Name:    "p",
+		Launch: &LaunchConfig{
+			Prompt: "base prompt",
+			Env:    map[string]string{"A": "1", "B": "2"},
+		},
+	}
+	overlay := &Definition{
+		Version: "1",
+		Name:    "p",
+		Launch: &LaunchConfig{
+			Prompt: "overlay prompt",
+			Env:    map[string]string{"B": "3", "C": "4"},
+		},
+	}
+
+	result, err := Merge(base, overlay)
+	require.NoError(t, err)
+	assert.Equal(t, "overlay prompt", result.Launch.Prompt)
+	assert.Equal(t, "1", result.Launch.Env["A"])
+	assert.Equal(t, "3", result.Launch.Env["B"])
+	assert.Equal(t, "4", result.Launch.Env["C"])
+}
+
+func TestMerge_Tools(t *testing.T) {
+	base := &Definition{
+		Version: "1",
+		Name:    "p",
+		Tools: map[string]*ScopeRule{
+			"proxy": {
+				Allow: []string{"github_*"},
+				Deny:  []string{"github_delete_*"},
+				Defaults: map[string]map[string]any{
+					"github_*": {"owner": "base-org"},
+				},
+			},
+		},
+	}
+	overlay := &Definition{
+		Version: "1",
+		Name:    "p",
+		Tools: map[string]*ScopeRule{
+			"proxy": {
+				Allow: []string{"linear_*"},
+				Deny:  []string{"linear_delete_*"},
+				Defaults: map[string]map[string]any{
+					"github_*": {"owner": "overlay-org"},
+				},
+			},
+		},
+	}
+
+	result, err := Merge(base, overlay)
+	require.NoError(t, err)
+
+	rule := result.Tools["proxy"]
+	assert.Equal(t, []string{"github_*", "linear_*"}, rule.Allow)
+	assert.Equal(t, []string{"github_delete_*", "linear_delete_*"}, rule.Deny)
+	assert.Equal(t, "overlay-org", rule.Defaults["github_*"]["owner"])
+}
+
+func TestMerge_Context(t *testing.T) {
+	base := &Definition{
+		Version: "1",
+		Name:    "p",
+		Context: &ContextConfig{
+			Files:        []string{"a.md"},
+			RepoIncludes: []string{"AGENTS.md"},
+			MaxBytes:     1000,
+		},
+	}
+	overlay := &Definition{
+		Version: "1",
+		Name:    "p",
+		Context: &ContextConfig{
+			Files:        []string{"b.md"},
+			RepoIncludes: []string{"docs/arch.md"},
+			MaxBytes:     2000,
+		},
+	}
+
+	result, err := Merge(base, overlay)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a.md", "b.md"}, result.Context.Files)
+	assert.Equal(t, []string{"AGENTS.md", "docs/arch.md"}, result.Context.RepoIncludes)
+	assert.Equal(t, 2000, result.Context.MaxBytes)
+}
+
+func TestStore_CRUD(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	def := &Definition{
+		Version: "1",
+		Name:    "test-project",
+		Repo:    "~/work/test",
+	}
+
+	require.NoError(t, store.Create(def))
+
+	got, ok := store.Get("test-project")
+	require.True(t, ok)
+	assert.Equal(t, "test-project", got.Name)
+
+	names := store.Names()
+	assert.Contains(t, names, "test-project")
+
+	all := store.All()
+	assert.Len(t, all, 1)
+
+	_, err := store.Update("test-project", json.RawMessage(`{"branch": "develop"}`))
+	require.NoError(t, err)
+
+	got, _ = store.Get("test-project")
+	assert.Equal(t, "develop", got.Branch)
+
+	require.NoError(t, store.Delete("test-project"))
+	_, ok = store.Get("test-project")
+	assert.False(t, ok)
+}
+
+func TestStore_CreateDuplicate(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	def := &Definition{Version: "1", Name: "dup"}
+	require.NoError(t, store.Create(def))
+
+	err := store.Create(def)
+	assert.ErrorContains(t, err, "already exists")
+}
+
+func TestStore_Load(t *testing.T) {
+	dir := t.TempDir()
+	projDir := filepath.Join(dir, "projects")
+	require.NoError(t, os.MkdirAll(projDir, 0700))
+
+	def := &Definition{Version: "1", Name: "loaded-project", Repo: "~/work/test"}
+	data, _ := json.Marshal(def)
+	require.NoError(t, os.WriteFile(filepath.Join(projDir, "loaded-project.project.json"), data, 0600))
+
+	store := NewStore(dir)
+	require.NoError(t, store.Load())
+
+	got, ok := store.Get("loaded-project")
+	require.True(t, ok)
+	assert.Equal(t, "loaded-project", got.Name)
+}
+
+func TestStore_LoadEmpty(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+	require.NoError(t, store.Load())
+	assert.Empty(t, store.Names())
+}
+
+func TestStore_LoadWithRepoLocal(t *testing.T) {
+	dir := t.TempDir()
+	repoDir := filepath.Join(dir, "repo")
+	require.NoError(t, os.MkdirAll(repoDir, 0700))
+
+	projDir := filepath.Join(dir, "projects")
+	require.NoError(t, os.MkdirAll(projDir, 0700))
+
+	baseDef := &Definition{
+		Version: "1",
+		Name:    "merged",
+		Repo:    repoDir,
+		Context: &ContextConfig{Files: []string{"a.md"}},
+	}
+	data, _ := json.Marshal(baseDef)
+	require.NoError(t, os.WriteFile(filepath.Join(projDir, "merged.project.json"), data, 0600))
+
+	overlayDef := &Definition{
+		Version: "1",
+		Name:    "merged",
+		Context: &ContextConfig{Files: []string{"b.md"}},
+	}
+	data, _ = json.Marshal(overlayDef)
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, ".project.json"), data, 0600))
+
+	store := NewStore(dir)
+	require.NoError(t, store.Load())
+
+	got, ok := store.Get("merged")
+	require.True(t, ok)
+	assert.Equal(t, []string{"a.md", "b.md"}, got.Context.Files)
+}
+
+func TestStore_DeleteNotFound(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+	err := store.Delete("nonexistent")
+	assert.ErrorContains(t, err, "not found")
+}
+
+func TestStore_UpdateNotFound(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+	_, err := store.Update("nonexistent", json.RawMessage(`{}`))
+	assert.ErrorContains(t, err, "not found")
+}
+
+func TestJsonMergePatch(t *testing.T) {
+	base := map[string]any{"a": "1", "b": "2", "c": map[string]any{"d": "3"}}
+	patch := map[string]any{"b": nil, "c": map[string]any{"e": "4"}}
+	result := jsonMergePatch(base, patch)
+	assert.Equal(t, "1", result["a"])
+	assert.Nil(t, result["b"])
+	inner := result["c"].(map[string]any)
+	assert.Equal(t, "3", inner["d"])
+	assert.Equal(t, "4", inner["e"])
+}

--- a/project/scope.go
+++ b/project/scope.go
@@ -1,0 +1,154 @@
+package project
+
+import (
+	"path"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+// IsToolPermitted implements the RFC-0002 §5 resolution algorithm.
+// It returns true if the given tool name is permitted under the scope rule.
+func IsToolPermitted(toolName string, rule *ScopeRule) bool {
+	if rule == nil {
+		return true
+	}
+
+	candidate := true
+	if len(rule.Allow) > 0 {
+		candidate = false
+		for _, pattern := range rule.Allow {
+			if globMatch(pattern, toolName) {
+				candidate = true
+				break
+			}
+		}
+	}
+
+	if !candidate {
+		return false
+	}
+
+	for _, pattern := range rule.Deny {
+		if globMatch(pattern, toolName) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// FilterTools returns only the tools permitted by the scope rule.
+func FilterTools(tools []mcp.ToolDefinition, rule *ScopeRule) []mcp.ToolDefinition {
+	if rule == nil {
+		return tools
+	}
+	var result []mcp.ToolDefinition
+	for _, t := range tools {
+		if IsToolPermitted(t.Name, rule) {
+			result = append(result, t)
+		}
+	}
+	return result
+}
+
+// ResolveDefaults computes the merged default arguments for a tool name
+// by matching against all patterns in the defaults map. Patterns are applied
+// in iteration order; later patterns override earlier ones. Agent-provided
+// arguments override everything.
+func ResolveDefaults(toolName string, rule *ScopeRule, agentArgs map[string]any) map[string]any {
+	if rule == nil || len(rule.Defaults) == 0 {
+		return agentArgs
+	}
+
+	merged := make(map[string]any)
+
+	for pattern, defaults := range rule.Defaults {
+		if globMatch(pattern, toolName) {
+			for k, v := range defaults {
+				merged[k] = v
+			}
+		}
+	}
+
+	for k, v := range agentArgs {
+		merged[k] = v
+	}
+
+	return merged
+}
+
+// ResolveRoleScope computes the effective scope rule for a server
+// after applying role overrides per RFC-0004 §3.1:
+//   - allow: role REPLACES project-level allow
+//   - deny: role APPENDS to project-level deny
+//   - defaults: role MERGES with project-level (role wins per key)
+func ResolveRoleScope(projectRule *ScopeRule, roleRule *ScopeRule) *ScopeRule {
+	if roleRule == nil {
+		return projectRule
+	}
+	if projectRule == nil {
+		return roleRule
+	}
+
+	result := &ScopeRule{}
+
+	if len(roleRule.Allow) > 0 {
+		result.Allow = append(result.Allow, roleRule.Allow...)
+	} else {
+		result.Allow = append(result.Allow, projectRule.Allow...)
+	}
+
+	result.Deny = append(result.Deny, projectRule.Deny...)
+	result.Deny = append(result.Deny, roleRule.Deny...)
+
+	result.Defaults = make(map[string]map[string]any)
+	for pattern, args := range projectRule.Defaults {
+		copied := make(map[string]any)
+		for k, v := range args {
+			copied[k] = v
+		}
+		result.Defaults[pattern] = copied
+	}
+	for pattern, args := range roleRule.Defaults {
+		if existing, ok := result.Defaults[pattern]; ok {
+			for k, v := range args {
+				existing[k] = v
+			}
+		} else {
+			result.Defaults[pattern] = args
+		}
+	}
+
+	return result
+}
+
+// GetEffectiveRule returns the effective scope rule for a given server
+// and optional role within a project definition.
+func GetEffectiveRule(def *Definition, serverID string, role string) *ScopeRule {
+	if def.Tools == nil {
+		return nil
+	}
+	projectRule, ok := def.Tools[serverID]
+	if !ok {
+		return nil
+	}
+	if role == "" || def.Agents == nil || def.Agents.Roles == nil {
+		return projectRule
+	}
+	roleDef, ok := def.Agents.Roles[role]
+	if !ok || roleDef.ToolOverrides == nil {
+		return projectRule
+	}
+	roleRule, ok := roleDef.ToolOverrides[serverID]
+	if !ok {
+		return projectRule
+	}
+	return ResolveRoleScope(projectRule, roleRule)
+}
+
+// globMatch matches a tool name against a glob pattern.
+// Uses path.Match which supports *, ?, and [] character classes.
+func globMatch(pattern, name string) bool {
+	matched, _ := path.Match(pattern, name)
+	return matched
+}

--- a/project/scope_test.go
+++ b/project/scope_test.go
@@ -1,0 +1,251 @@
+package project
+
+import (
+	"testing"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsToolPermitted(t *testing.T) {
+	tests := []struct {
+		name     string
+		tool     string
+		rule     *ScopeRule
+		expected bool
+	}{
+		{
+			name:     "nil rule permits all",
+			tool:     "anything",
+			rule:     nil,
+			expected: true,
+		},
+		{
+			name:     "empty rule permits all",
+			tool:     "anything",
+			rule:     &ScopeRule{},
+			expected: true,
+		},
+		{
+			name:     "allow matches",
+			tool:     "github_list_issues",
+			rule:     &ScopeRule{Allow: []string{"github_*"}},
+			expected: true,
+		},
+		{
+			name:     "allow does not match",
+			tool:     "datadog_search_logs",
+			rule:     &ScopeRule{Allow: []string{"github_*"}},
+			expected: false,
+		},
+		{
+			name:     "deny overrides allow",
+			tool:     "github_delete_repo",
+			rule:     &ScopeRule{Allow: []string{"github_*"}, Deny: []string{"github_delete_*"}},
+			expected: false,
+		},
+		{
+			name:     "deny without allow",
+			tool:     "github_delete_repo",
+			rule:     &ScopeRule{Deny: []string{"github_delete_*"}},
+			expected: false,
+		},
+		{
+			name:     "deny without allow permits non-matching",
+			tool:     "github_list_issues",
+			rule:     &ScopeRule{Deny: []string{"github_delete_*"}},
+			expected: true,
+		},
+		{
+			name:     "multiple allow patterns",
+			tool:     "linear_list_issues",
+			rule:     &ScopeRule{Allow: []string{"github_*", "linear_*"}},
+			expected: true,
+		},
+		{
+			name:     "wildcard deny",
+			tool:     "postgres_drop_table",
+			rule:     &ScopeRule{Allow: []string{"postgres_*"}, Deny: []string{"*_drop_*"}},
+			expected: false,
+		},
+		{
+			name:     "exact match allow",
+			tool:     "datadog_search_logs",
+			rule:     &ScopeRule{Allow: []string{"datadog_search_logs"}},
+			expected: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, IsToolPermitted(tt.tool, tt.rule))
+		})
+	}
+}
+
+func TestFilterTools(t *testing.T) {
+	tools := []mcp.ToolDefinition{
+		{Name: "github_list_issues"},
+		{Name: "github_delete_repo"},
+		{Name: "linear_list_issues"},
+		{Name: "datadog_search_logs"},
+	}
+
+	rule := &ScopeRule{
+		Allow: []string{"github_*", "linear_*"},
+		Deny:  []string{"github_delete_*"},
+	}
+
+	result := FilterTools(tools, rule)
+	assert.Len(t, result, 2)
+	assert.Equal(t, "github_list_issues", result[0].Name)
+	assert.Equal(t, "linear_list_issues", result[1].Name)
+}
+
+func TestFilterTools_NilRule(t *testing.T) {
+	tools := []mcp.ToolDefinition{
+		{Name: "github_list_issues"},
+	}
+	result := FilterTools(tools, nil)
+	assert.Len(t, result, 1)
+}
+
+func TestResolveDefaults(t *testing.T) {
+	rule := &ScopeRule{
+		Defaults: map[string]map[string]any{
+			"github_*":      {"owner": "myorg"},
+			"github_list_*": {"owner": "myorg", "per_page": "50"},
+		},
+	}
+
+	t.Run("merged defaults", func(t *testing.T) {
+		args := map[string]any{"state": "open"}
+		result := ResolveDefaults("github_list_issues", rule, args)
+		assert.Equal(t, "myorg", result["owner"])
+		assert.Equal(t, "50", result["per_page"])
+		assert.Equal(t, "open", result["state"])
+	})
+
+	t.Run("agent overrides defaults", func(t *testing.T) {
+		args := map[string]any{"owner": "other", "state": "open"}
+		result := ResolveDefaults("github_list_issues", rule, args)
+		assert.Equal(t, "other", result["owner"])
+		assert.Equal(t, "50", result["per_page"])
+		assert.Equal(t, "open", result["state"])
+	})
+
+	t.Run("no matching defaults", func(t *testing.T) {
+		args := map[string]any{"query": "test"}
+		result := ResolveDefaults("datadog_search_logs", rule, args)
+		assert.Equal(t, "test", result["query"])
+		assert.Len(t, result, 1)
+	})
+
+	t.Run("nil rule", func(t *testing.T) {
+		args := map[string]any{"a": "1"}
+		result := ResolveDefaults("any_tool", nil, args)
+		assert.Equal(t, args, result)
+	})
+}
+
+func TestResolveRoleScope(t *testing.T) {
+	t.Run("role replaces allow", func(t *testing.T) {
+		project := &ScopeRule{
+			Allow: []string{"github_*", "linear_*"},
+			Deny:  []string{"github_delete_*"},
+		}
+		role := &ScopeRule{
+			Allow: []string{"github_*"},
+		}
+
+		result := ResolveRoleScope(project, role)
+		assert.Equal(t, []string{"github_*"}, result.Allow)
+		assert.Equal(t, []string{"github_delete_*"}, result.Deny)
+	})
+
+	t.Run("role appends deny", func(t *testing.T) {
+		project := &ScopeRule{
+			Deny: []string{"github_delete_*"},
+		}
+		role := &ScopeRule{
+			Deny: []string{"github_merge_*"},
+		}
+
+		result := ResolveRoleScope(project, role)
+		assert.Equal(t, []string{"github_delete_*", "github_merge_*"}, result.Deny)
+	})
+
+	t.Run("role merges defaults", func(t *testing.T) {
+		project := &ScopeRule{
+			Defaults: map[string]map[string]any{
+				"github_*": {"owner": "base-org", "repo": "base-repo"},
+			},
+		}
+		role := &ScopeRule{
+			Defaults: map[string]map[string]any{
+				"github_*": {"owner": "role-org"},
+			},
+		}
+
+		result := ResolveRoleScope(project, role)
+		assert.Equal(t, "role-org", result.Defaults["github_*"]["owner"])
+		assert.Equal(t, "base-repo", result.Defaults["github_*"]["repo"])
+	})
+
+	t.Run("nil project rule", func(t *testing.T) {
+		role := &ScopeRule{Allow: []string{"github_*"}}
+		result := ResolveRoleScope(nil, role)
+		assert.Equal(t, role, result)
+	})
+
+	t.Run("nil role rule", func(t *testing.T) {
+		project := &ScopeRule{Allow: []string{"github_*"}}
+		result := ResolveRoleScope(project, nil)
+		assert.Equal(t, project, result)
+	})
+}
+
+func TestGetEffectiveRule(t *testing.T) {
+	def := &Definition{
+		Version: "1",
+		Name:    "test",
+		Tools: map[string]*ScopeRule{
+			"switchboard": {
+				Allow: []string{"github_*", "linear_*"},
+				Deny:  []string{"github_delete_*"},
+			},
+		},
+		Agents: &AgentsConfig{
+			Roles: map[string]*RoleDefinition{
+				"reviewer": {
+					ToolOverrides: map[string]*ScopeRule{
+						"switchboard": {
+							Allow: []string{"github_get_*", "github_list_*"},
+							Deny:  []string{"github_create_*"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("no role", func(t *testing.T) {
+		rule := GetEffectiveRule(def, "switchboard", "")
+		assert.Equal(t, []string{"github_*", "linear_*"}, rule.Allow)
+	})
+
+	t.Run("with role", func(t *testing.T) {
+		rule := GetEffectiveRule(def, "switchboard", "reviewer")
+		assert.Equal(t, []string{"github_get_*", "github_list_*"}, rule.Allow)
+		assert.Equal(t, []string{"github_delete_*", "github_create_*"}, rule.Deny)
+	})
+
+	t.Run("unknown server", func(t *testing.T) {
+		rule := GetEffectiveRule(def, "unknown", "")
+		assert.Nil(t, rule)
+	})
+
+	t.Run("unknown role", func(t *testing.T) {
+		rule := GetEffectiveRule(def, "switchboard", "unknown")
+		assert.Equal(t, []string{"github_*", "linear_*"}, rule.Allow)
+	})
+}

--- a/server/project_server.go
+++ b/server/project_server.go
@@ -1,0 +1,718 @@
+package server
+
+import (
+	"cmp"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"slices"
+	"strings"
+	"sync"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/daltoniam/switchboard/project"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const defaultServerID = "switchboard"
+
+// ProjectRouter serves project-scoped MCP endpoints at /mcp/{project}.
+type ProjectRouter struct {
+	services *mcp.Services
+	store    *project.Store
+	serverID string
+
+	mu      sync.RWMutex
+	servers map[string]*projectMCPServer
+}
+
+type projectMCPServer struct {
+	mcpSrv *mcpsdk.Server
+	def    *project.Definition
+}
+
+// NewProjectRouter creates a router that dispatches /mcp/{project} requests
+// to per-project MCP servers with tool scoping and context delivery.
+func NewProjectRouter(services *mcp.Services, store *project.Store, serverID string) *ProjectRouter {
+	if serverID == "" {
+		serverID = defaultServerID
+	}
+	return &ProjectRouter{
+		services: services,
+		store:    store,
+		serverID: serverID,
+		servers:  make(map[string]*projectMCPServer),
+	}
+}
+
+// Handler returns an http.Handler for /mcp/{project} routes.
+func (pr *ProjectRouter) Handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		projectName := r.PathValue("project")
+		if projectName == "" {
+			http.Error(w, "missing project name", http.StatusBadRequest)
+			return
+		}
+
+		srv, err := pr.getOrCreate(projectName)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+
+		handler := mcpsdk.NewStreamableHTTPHandler(
+			func(_ *http.Request) *mcpsdk.Server {
+				return srv.mcpSrv
+			},
+			&mcpsdk.StreamableHTTPOptions{
+				Stateless: true,
+				Logger:    slog.Default(),
+			},
+		)
+		handler.ServeHTTP(w, r)
+	})
+}
+
+func (pr *ProjectRouter) getOrCreate(projectName string) (*projectMCPServer, error) {
+	pr.mu.RLock()
+	srv, ok := pr.servers[projectName]
+	pr.mu.RUnlock()
+	if ok {
+		return srv, nil
+	}
+
+	def, exists := pr.store.Get(projectName)
+	if !exists {
+		return nil, fmt.Errorf("project %q not found", projectName)
+	}
+
+	srv = pr.buildServer(def)
+
+	pr.mu.Lock()
+	pr.servers[projectName] = srv
+	pr.mu.Unlock()
+
+	return srv, nil
+}
+
+func (pr *ProjectRouter) buildServer(def *project.Definition) *projectMCPServer {
+	mcpSrv := mcpsdk.NewServer(
+		&mcpsdk.Implementation{
+			Name:    "switchboard",
+			Version: "0.2.0",
+		},
+		&mcpsdk.ServerOptions{
+			Instructions: fmt.Sprintf(
+				"Project-scoped MCP server for %q. Use the search tool to discover available operations and project_context to retrieve project context.",
+				def.Name,
+			),
+			Logger: slog.Default(),
+		},
+	)
+
+	ps := &projectMCPServer{mcpSrv: mcpSrv, def: def}
+
+	scopeRule := project.GetEffectiveRule(def, pr.serverID, "")
+
+	searchTool := &mcpsdk.Tool{
+		Name: "search",
+		Description: `Search available tools scoped to this project.
+Use this to discover what operations are available before calling execute.
+
+You can filter by integration name, tool name, or keyword. Returns tool definitions
+with their parameters and descriptions. Results are paginated (default limit: 20).
+
+Examples:
+- Search by integration: {"query": "github"}
+- Search by action: {"query": "list issues"}
+- Search specific tool: {"query": "datadog_search_logs"}
+- Page through results: {"query": "github", "offset": 20, "limit": 20}
+- Count all tools: {"limit": 0}`,
+		InputSchema: objectSchema(map[string]any{
+			"query": map[string]any{
+				"type":        "string",
+				"description": "Search query to filter tools.",
+			},
+			"limit": map[string]any{
+				"type":        "integer",
+				"description": "Maximum number of tools to return. Defaults to 20. Set to 0 to return only the total count.",
+			},
+			"offset": map[string]any{
+				"type":        "integer",
+				"description": "Number of results to skip for pagination. Defaults to 0.",
+			},
+		}, nil),
+	}
+
+	executeTool := &mcpsdk.Tool{
+		Name: "execute",
+		Description: `Execute a tool scoped to this project. Default arguments from the project definition are injected automatically.
+
+Mode 1 — Single tool (provide tool_name + arguments):
+  {"tool_name": "github_list_issues", "arguments": {"state": "open"}}
+
+Mode 2 — Script (provide script):
+  Write JavaScript that calls api.call(toolName, args) to invoke tools.
+
+Use search first to discover available tools and their parameter schemas.`,
+		InputSchema: objectSchema(map[string]any{
+			"tool_name": map[string]any{
+				"type":        "string",
+				"description": "The exact name of the tool to execute (mutually exclusive with script)",
+			},
+			"arguments": map[string]any{
+				"type":        "object",
+				"description": "Arguments to pass to the tool (mutually exclusive with script)",
+			},
+			"script": map[string]any{
+				"type":        "string",
+				"description": "JavaScript code to execute server-side. Use api.call(toolName, args) to invoke tools. Return the final result. (mutually exclusive with tool_name)",
+			},
+		}, nil),
+	}
+
+	mcpSrv.AddTool(searchTool, pr.makeSearchHandler(scopeRule))
+	mcpSrv.AddTool(executeTool, pr.makeExecuteHandler(def, scopeRule))
+
+	pr.addContextTool(mcpSrv, def)
+	pr.addProjectManagementTools(mcpSrv, def)
+
+	return ps
+}
+
+func (pr *ProjectRouter) makeSearchHandler(scopeRule *project.ScopeRule) mcpsdk.ToolHandler {
+	return func(ctx context.Context, req *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+		var args struct {
+			Query  string `json:"query"`
+			Limit  *int   `json:"limit"`
+			Offset int    `json:"offset"`
+		}
+		if req.Params.Arguments != nil {
+			if err := json.Unmarshal(req.Params.Arguments, &args); err != nil {
+				return errorResult("invalid arguments: " + err.Error()), nil
+			}
+		}
+
+		limit := defaultSearchLimit
+		if args.Limit != nil {
+			limit = max(*args.Limit, 0)
+		}
+		if args.Offset < 0 {
+			args.Offset = 0
+		}
+		query := strings.ToLower(args.Query)
+
+		type toolInfo struct {
+			Integration string            `json:"integration"`
+			Name        string            `json:"name"`
+			Description string            `json:"description"`
+			Parameters  map[string]string `json:"parameters"`
+			Required    []string          `json:"required,omitempty"`
+		}
+
+		enabled := pr.services.Config.EnabledIntegrations()
+		var all []toolInfo
+
+		for _, name := range enabled {
+			integration, ok := pr.services.Registry.Get(name)
+			if !ok {
+				continue
+			}
+
+			permitted := project.FilterTools(integration.Tools(), scopeRule)
+			for _, tool := range permitted {
+				if query == "" || matches(tool, name, query) {
+					all = append(all, toolInfo{
+						Integration: name,
+						Name:        tool.Name,
+						Description: tool.Description,
+						Parameters:  tool.Parameters,
+						Required:    tool.Required,
+					})
+				}
+			}
+		}
+
+		slices.SortFunc(all, func(a, b toolInfo) int {
+			if c := cmp.Compare(a.Integration, b.Integration); c != 0 {
+				return c
+			}
+			return cmp.Compare(a.Name, b.Name)
+		})
+
+		total := len(all)
+		offset := args.Offset
+		if offset > total {
+			offset = total
+		}
+		end := offset + limit
+		if end > total {
+			end = total
+		}
+		page := all[offset:end]
+
+		type response struct {
+			Summary      string     `json:"summary"`
+			Total        int        `json:"total"`
+			Offset       int        `json:"offset"`
+			Limit        int        `json:"limit"`
+			HasMore      bool       `json:"has_more"`
+			Integrations []string   `json:"integrations"`
+			Tools        []toolInfo `json:"tools"`
+		}
+
+		summary := fmt.Sprintf("Found %d tools", total)
+		if query != "" {
+			summary += fmt.Sprintf(" matching %q", args.Query)
+		}
+
+		data, _ := json.Marshal(response{
+			Summary:      summary,
+			Total:        total,
+			Offset:       offset,
+			Limit:        limit,
+			HasMore:      limit > 0 && offset+limit < total,
+			Integrations: enabled,
+			Tools:        page,
+		})
+
+		return &mcpsdk.CallToolResult{
+			Content: []mcpsdk.Content{&mcpsdk.TextContent{Text: string(data)}},
+		}, nil
+	}
+}
+
+func (pr *ProjectRouter) makeExecuteHandler(def *project.Definition, scopeRule *project.ScopeRule) mcpsdk.ToolHandler {
+	return func(ctx context.Context, req *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+		var args struct {
+			ToolName  string         `json:"tool_name"`
+			Arguments map[string]any `json:"arguments"`
+			Script    string         `json:"script"`
+		}
+		if err := json.Unmarshal(req.Params.Arguments, &args); err != nil {
+			return errorResult("invalid arguments: " + err.Error()), nil
+		}
+
+		if args.Script != "" {
+			return errorResult("scripts are not supported on project-scoped endpoints"), nil
+		}
+
+		if args.ToolName == "" {
+			return errorResult("tool_name is required"), nil
+		}
+
+		if !project.IsToolPermitted(args.ToolName, scopeRule) {
+			return errorResult(fmt.Sprintf("tool %q is denied by project scoping rules", args.ToolName)), nil
+		}
+
+		if args.Arguments == nil {
+			args.Arguments = map[string]any{}
+		}
+		args.Arguments = project.ResolveDefaults(args.ToolName, scopeRule, args.Arguments)
+
+		integration, found := pr.findIntegration(args.ToolName)
+		if !found {
+			return errorResult(fmt.Sprintf("tool %q not found. Use the search tool to discover available tools.", args.ToolName)), nil
+		}
+
+		result, err := integration.Execute(ctx, args.ToolName, args.Arguments)
+		if err != nil {
+			return errorResult(err.Error()), nil
+		}
+
+		if !result.IsError {
+			result.Data = compactResult(integration, args.ToolName, result.Data)
+
+			if len(result.Data) > maxResponseBytes {
+				return errorResult(fmt.Sprintf(
+					"Response exceeded %dKB (actual: %dKB). Use more specific filters, lower limit/per_page, or fetch individual items.",
+					maxResponseBytes/1024, len(result.Data)/1024,
+				)), nil
+			}
+		}
+
+		return &mcpsdk.CallToolResult{
+			Content: []mcpsdk.Content{&mcpsdk.TextContent{Text: result.Data}},
+			IsError: result.IsError,
+		}, nil
+	}
+}
+
+func (pr *ProjectRouter) findIntegration(toolName string) (mcp.Integration, bool) {
+	for _, name := range pr.services.Config.EnabledIntegrations() {
+		integration, ok := pr.services.Registry.Get(name)
+		if !ok {
+			continue
+		}
+		for _, tool := range integration.Tools() {
+			if tool.Name == toolName {
+				return integration, true
+			}
+		}
+	}
+	return nil, false
+}
+
+func (pr *ProjectRouter) addContextTool(mcpSrv *mcpsdk.Server, def *project.Definition) {
+	contextTool := &mcpsdk.Tool{
+		Name:        "project_context",
+		Description: "Search and retrieve project context files. Call with no arguments to list available context entries, with a query to search, or with a path to fetch a specific file's content.",
+		InputSchema: objectSchema(map[string]any{
+			"query": map[string]any{
+				"type":        "string",
+				"description": "Search query to filter context entries by path. If omitted, returns a manifest of all available context.",
+			},
+			"path": map[string]any{
+				"type":        "string",
+				"description": "Exact path of a context file to retrieve its full content.",
+			},
+			"role": map[string]any{
+				"type":        "string",
+				"description": "Role name to apply context overrides.",
+			},
+		}, nil),
+	}
+
+	mcpSrv.AddTool(contextTool, pr.makeContextHandler(def))
+}
+
+func (pr *ProjectRouter) makeContextHandler(def *project.Definition) mcpsdk.ToolHandler {
+	return func(ctx context.Context, req *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+		var args struct {
+			Query string `json:"query"`
+			Path  string `json:"path"`
+			Role  string `json:"role"`
+		}
+		if req.Params.Arguments != nil {
+			if err := json.Unmarshal(req.Params.Arguments, &args); err != nil {
+				return errorResult("invalid arguments: " + err.Error()), nil
+			}
+		}
+
+		configDir := pr.store.ConfigDir()
+
+		if args.Path != "" {
+			content, err := project.ReadContextFile(def, configDir, args.Path)
+			if err != nil {
+				return &mcpsdk.CallToolResult{
+					Content: []mcpsdk.Content{&mcpsdk.TextContent{Text: err.Error()}},
+				}, nil
+			}
+			return &mcpsdk.CallToolResult{
+				Content: []mcpsdk.Content{&mcpsdk.TextContent{Text: content}},
+			}, nil
+		}
+
+		entries := project.AssembleManifestWithRole(def, configDir, args.Role)
+
+		if args.Query != "" {
+			q := strings.ToLower(args.Query)
+			var filtered []project.ContextEntry
+			for _, e := range entries {
+				if strings.Contains(strings.ToLower(e.Path), q) {
+					filtered = append(filtered, e)
+				}
+			}
+			entries = filtered
+		}
+
+		data, err := json.MarshalIndent(entries, "", "  ")
+		if err != nil {
+			return errorResult("failed to marshal context manifest: " + err.Error()), nil
+		}
+		return &mcpsdk.CallToolResult{
+			Content: []mcpsdk.Content{&mcpsdk.TextContent{Text: string(data)}},
+		}, nil
+	}
+}
+
+func (pr *ProjectRouter) addProjectManagementTools(mcpSrv *mcpsdk.Server, boundDef *project.Definition) {
+	listTool := &mcpsdk.Tool{
+		Name:        "project_list",
+		Description: "List all project names and summaries.",
+		InputSchema: objectSchema(nil, nil),
+	}
+
+	getTool := &mcpsdk.Tool{
+		Name:        "project_get",
+		Description: "Return the fully merged project definition. Name defaults to the current project.",
+		InputSchema: objectSchema(map[string]any{
+			"name": map[string]any{
+				"type":        "string",
+				"description": "Project name. Optional when served at a project-scoped URL.",
+			},
+		}, nil),
+	}
+
+	createTool := &mcpsdk.Tool{
+		Name:        "project_create",
+		Description: "Create a new project definition in the user-level store.",
+		InputSchema: objectSchema(map[string]any{
+			"name": map[string]any{
+				"type":        "string",
+				"description": "Project name.",
+			},
+			"repo": map[string]any{
+				"type":        "string",
+				"description": "Path to source repository.",
+			},
+			"branch": map[string]any{
+				"type":        "string",
+				"description": "Default branch.",
+			},
+		}, []string{"name"}),
+	}
+
+	updateTool := &mcpsdk.Tool{
+		Name:        "project_update",
+		Description: "Apply a JSON merge patch to the project definition. Name defaults to the current project.",
+		InputSchema: objectSchema(map[string]any{
+			"name": map[string]any{
+				"type":        "string",
+				"description": "Project name. Optional when served at a project-scoped URL.",
+			},
+			"patch": map[string]any{
+				"type":        "object",
+				"description": "JSON merge patch (RFC 7396) to apply.",
+			},
+		}, []string{"patch"}),
+	}
+
+	deleteTool := &mcpsdk.Tool{
+		Name:        "project_delete",
+		Description: "Delete the project definition from the user-level store. Name defaults to the current project.",
+		InputSchema: objectSchema(map[string]any{
+			"name": map[string]any{
+				"type":        "string",
+				"description": "Project name. Optional when served at a project-scoped URL.",
+			},
+		}, nil),
+	}
+
+	toolsTool := &mcpsdk.Tool{
+		Name:        "project_tools",
+		Description: "Return the resolved tool manifest after allow/deny/role filtering.",
+		InputSchema: objectSchema(map[string]any{
+			"name": map[string]any{
+				"type":        "string",
+				"description": "Project name. Optional when served at a project-scoped URL.",
+			},
+			"role": map[string]any{
+				"type":        "string",
+				"description": "Role name to apply tool overrides.",
+			},
+		}, nil),
+	}
+
+	defaultsTool := &mcpsdk.Tool{
+		Name:        "project_defaults",
+		Description: "Return the resolved default arguments for a specific tool.",
+		InputSchema: objectSchema(map[string]any{
+			"name": map[string]any{
+				"type":        "string",
+				"description": "Project name. Optional when served at a project-scoped URL.",
+			},
+			"tool_name": map[string]any{
+				"type":        "string",
+				"description": "Tool name to resolve defaults for.",
+			},
+		}, []string{"tool_name"}),
+	}
+
+	mcpSrv.AddTool(listTool, pr.handleProjectList)
+	mcpSrv.AddTool(getTool, pr.makeProjectGetHandler(boundDef))
+	mcpSrv.AddTool(createTool, pr.handleProjectCreate)
+	mcpSrv.AddTool(updateTool, pr.makeProjectUpdateHandler(boundDef))
+	mcpSrv.AddTool(deleteTool, pr.makeProjectDeleteHandler(boundDef))
+	mcpSrv.AddTool(toolsTool, pr.makeProjectToolsHandler(boundDef))
+	mcpSrv.AddTool(defaultsTool, pr.makeProjectDefaultsHandler(boundDef))
+}
+
+func (pr *ProjectRouter) handleProjectList(_ context.Context, _ *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+	type summary struct {
+		Name   string `json:"name"`
+		Repo   string `json:"repo,omitempty"`
+		Branch string `json:"branch,omitempty"`
+	}
+	all := pr.store.All()
+	var summaries []summary
+	for _, def := range all {
+		summaries = append(summaries, summary{
+			Name:   def.Name,
+			Repo:   def.Repo,
+			Branch: def.Branch,
+		})
+	}
+	slices.SortFunc(summaries, func(a, b summary) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
+	data, _ := json.MarshalIndent(summaries, "", "  ")
+	return &mcpsdk.CallToolResult{
+		Content: []mcpsdk.Content{&mcpsdk.TextContent{Text: string(data)}},
+	}, nil
+}
+
+func (pr *ProjectRouter) makeProjectGetHandler(boundDef *project.Definition) mcpsdk.ToolHandler {
+	return func(_ context.Context, req *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+		name := pr.resolveProjectName(req, boundDef)
+		def, ok := pr.store.Get(name)
+		if !ok {
+			return errorResult(fmt.Sprintf("project %q not found", name)), nil
+		}
+		data, _ := json.MarshalIndent(def, "", "  ")
+		return &mcpsdk.CallToolResult{
+			Content: []mcpsdk.Content{&mcpsdk.TextContent{Text: string(data)}},
+		}, nil
+	}
+}
+
+func (pr *ProjectRouter) handleProjectCreate(_ context.Context, req *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+	var args struct {
+		Name   string `json:"name"`
+		Repo   string `json:"repo"`
+		Branch string `json:"branch"`
+	}
+	if err := json.Unmarshal(req.Params.Arguments, &args); err != nil {
+		return errorResult("invalid arguments: " + err.Error()), nil
+	}
+	if args.Name == "" {
+		return errorResult("name is required"), nil
+	}
+	def := &project.Definition{
+		Version: "1",
+		Name:    args.Name,
+		Repo:    args.Repo,
+		Branch:  args.Branch,
+	}
+	if err := pr.store.Create(def); err != nil {
+		return errorResult(err.Error()), nil
+	}
+	data, _ := json.MarshalIndent(def, "", "  ")
+	return &mcpsdk.CallToolResult{
+		Content: []mcpsdk.Content{&mcpsdk.TextContent{Text: string(data)}},
+	}, nil
+}
+
+func (pr *ProjectRouter) makeProjectUpdateHandler(boundDef *project.Definition) mcpsdk.ToolHandler {
+	return func(_ context.Context, req *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+		var args struct {
+			Name  string          `json:"name"`
+			Patch json.RawMessage `json:"patch"`
+		}
+		if err := json.Unmarshal(req.Params.Arguments, &args); err != nil {
+			return errorResult("invalid arguments: " + err.Error()), nil
+		}
+		name := args.Name
+		if name == "" && boundDef != nil {
+			name = boundDef.Name
+		}
+		if name == "" {
+			return errorResult("name is required"), nil
+		}
+		updated, err := pr.store.Update(name, args.Patch)
+		if err != nil {
+			return errorResult(err.Error()), nil
+		}
+		data, _ := json.MarshalIndent(updated, "", "  ")
+		return &mcpsdk.CallToolResult{
+			Content: []mcpsdk.Content{&mcpsdk.TextContent{Text: string(data)}},
+		}, nil
+	}
+}
+
+func (pr *ProjectRouter) makeProjectDeleteHandler(boundDef *project.Definition) mcpsdk.ToolHandler {
+	return func(_ context.Context, req *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+		name := pr.resolveProjectName(req, boundDef)
+		if err := pr.store.Delete(name); err != nil {
+			return errorResult(err.Error()), nil
+		}
+		return &mcpsdk.CallToolResult{
+			Content: []mcpsdk.Content{&mcpsdk.TextContent{Text: fmt.Sprintf("project %q deleted", name)}},
+		}, nil
+	}
+}
+
+func (pr *ProjectRouter) makeProjectToolsHandler(boundDef *project.Definition) mcpsdk.ToolHandler {
+	return func(_ context.Context, req *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+		var args struct {
+			Name string `json:"name"`
+			Role string `json:"role"`
+		}
+		if req.Params.Arguments != nil {
+			_ = json.Unmarshal(req.Params.Arguments, &args)
+		}
+		name := args.Name
+		if name == "" && boundDef != nil {
+			name = boundDef.Name
+		}
+		def, ok := pr.store.Get(name)
+		if !ok {
+			return errorResult(fmt.Sprintf("project %q not found", name)), nil
+		}
+
+		rule := project.GetEffectiveRule(def, pr.serverID, args.Role)
+
+		var toolNames []string
+		for _, intName := range pr.services.Config.EnabledIntegrations() {
+			integration, ok := pr.services.Registry.Get(intName)
+			if !ok {
+				continue
+			}
+			for _, tool := range project.FilterTools(integration.Tools(), rule) {
+				toolNames = append(toolNames, tool.Name)
+			}
+		}
+
+		slices.Sort(toolNames)
+		data, _ := json.MarshalIndent(toolNames, "", "  ")
+		return &mcpsdk.CallToolResult{
+			Content: []mcpsdk.Content{&mcpsdk.TextContent{Text: string(data)}},
+		}, nil
+	}
+}
+
+func (pr *ProjectRouter) makeProjectDefaultsHandler(boundDef *project.Definition) mcpsdk.ToolHandler {
+	return func(_ context.Context, req *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+		var args struct {
+			Name     string `json:"name"`
+			ToolName string `json:"tool_name"`
+		}
+		if err := json.Unmarshal(req.Params.Arguments, &args); err != nil {
+			return errorResult("invalid arguments: " + err.Error()), nil
+		}
+		name := args.Name
+		if name == "" && boundDef != nil {
+			name = boundDef.Name
+		}
+		def, ok := pr.store.Get(name)
+		if !ok {
+			return errorResult(fmt.Sprintf("project %q not found", name)), nil
+		}
+
+		rule := project.GetEffectiveRule(def, pr.serverID, "")
+		defaults := project.ResolveDefaults(args.ToolName, rule, nil)
+
+		data, _ := json.MarshalIndent(defaults, "", "  ")
+		return &mcpsdk.CallToolResult{
+			Content: []mcpsdk.Content{&mcpsdk.TextContent{Text: string(data)}},
+		}, nil
+	}
+}
+
+func (pr *ProjectRouter) resolveProjectName(req *mcpsdk.CallToolRequest, boundDef *project.Definition) string {
+	var args struct {
+		Name string `json:"name"`
+	}
+	if req.Params.Arguments != nil {
+		_ = json.Unmarshal(req.Params.Arguments, &args)
+	}
+	if args.Name != "" {
+		return args.Name
+	}
+	if boundDef != nil {
+		return boundDef.Name
+	}
+	return ""
+}

--- a/server/project_server_test.go
+++ b/server/project_server_test.go
@@ -1,0 +1,454 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/daltoniam/switchboard/project"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupProjectRouter(t *testing.T, def *project.Definition, integrations ...*mockIntegration) (*ProjectRouter, *project.Store) {
+	t.Helper()
+	dir := t.TempDir()
+	store := project.NewStore(dir)
+	require.NoError(t, store.Create(def))
+
+	reg := newMockRegistry()
+	cfgIntegrations := make(map[string]*mcp.IntegrationConfig)
+
+	for _, i := range integrations {
+		reg.Register(i)
+		cfgIntegrations[i.name] = &mcp.IntegrationConfig{
+			Enabled:     true,
+			Credentials: mcp.Credentials{"token": "test"},
+		}
+	}
+
+	services := &mcp.Services{
+		Config:   newMockConfigService(cfgIntegrations),
+		Registry: reg,
+	}
+
+	router := NewProjectRouter(services, store, "switchboard")
+	return router, store
+}
+
+func projectToolRequest(name string, args map[string]any) *mcpsdk.CallToolRequest {
+	data, _ := json.Marshal(args)
+	return &mcpsdk.CallToolRequest{
+		Params: &mcpsdk.CallToolParamsRaw{
+			Name:      name,
+			Arguments: json.RawMessage(data),
+		},
+	}
+}
+
+func TestProjectRouter_GetOrCreate(t *testing.T) {
+	def := &project.Definition{Version: "1", Name: "test-project"}
+	mi := &mockIntegration{
+		name:    "github",
+		healthy: true,
+		tools: []mcp.ToolDefinition{
+			{Name: "github_list_issues", Description: "List issues"},
+		},
+	}
+	router, _ := setupProjectRouter(t, def, mi)
+
+	srv, err := router.getOrCreate("test-project")
+	require.NoError(t, err)
+	require.NotNil(t, srv)
+
+	srv2, err := router.getOrCreate("test-project")
+	require.NoError(t, err)
+	assert.Same(t, srv, srv2)
+}
+
+func TestProjectRouter_GetOrCreate_NotFound(t *testing.T) {
+	def := &project.Definition{Version: "1", Name: "test-project"}
+	router, _ := setupProjectRouter(t, def)
+
+	_, err := router.getOrCreate("nonexistent")
+	assert.ErrorContains(t, err, "not found")
+}
+
+func TestProjectRouter_SearchFiltersTools(t *testing.T) {
+	def := &project.Definition{
+		Version: "1",
+		Name:    "scoped",
+		Tools: map[string]*project.ScopeRule{
+			"switchboard": {
+				Allow: []string{"github_*"},
+				Deny:  []string{"github_delete_*"},
+			},
+		},
+	}
+	mi := &mockIntegration{
+		name:    "github",
+		healthy: true,
+		tools: []mcp.ToolDefinition{
+			{Name: "github_list_issues", Description: "List issues"},
+			{Name: "github_delete_repo", Description: "Delete repo"},
+			{Name: "github_get_issue", Description: "Get issue"},
+		},
+	}
+	router, _ := setupProjectRouter(t, def, mi)
+
+	srv, err := router.getOrCreate("scoped")
+	require.NoError(t, err)
+
+	handler := router.makeSearchHandler(project.GetEffectiveRule(def, "switchboard", ""))
+
+	result, err := handler(context.Background(), projectToolRequest("search", map[string]any{}))
+	require.NoError(t, err)
+
+	resp := parseSearchResponse(t, result)
+	assert.Equal(t, 2, resp.Total)
+
+	var names []string
+	for _, tool := range resp.Tools {
+		names = append(names, tool.Name)
+	}
+	assert.Contains(t, names, "github_list_issues")
+	assert.Contains(t, names, "github_get_issue")
+	assert.NotContains(t, names, "github_delete_repo")
+
+	_ = srv
+}
+
+func TestProjectRouter_ExecuteInjectsDefaults(t *testing.T) {
+	def := &project.Definition{
+		Version: "1",
+		Name:    "defaults-test",
+		Tools: map[string]*project.ScopeRule{
+			"switchboard": {
+				Defaults: map[string]map[string]any{
+					"github_*": {"owner": "myorg", "repo": "myrepo"},
+				},
+			},
+		},
+	}
+
+	var capturedArgs map[string]any
+	mi := &mockIntegration{
+		name:    "github",
+		healthy: true,
+		tools: []mcp.ToolDefinition{
+			{Name: "github_list_issues", Description: "List issues"},
+		},
+		execFn: func(_ context.Context, _ string, args map[string]any) (*mcp.ToolResult, error) {
+			capturedArgs = args
+			return &mcp.ToolResult{Data: `[]`}, nil
+		},
+	}
+	router, _ := setupProjectRouter(t, def, mi)
+
+	scopeRule := project.GetEffectiveRule(def, "switchboard", "")
+	handler := router.makeExecuteHandler(def, scopeRule)
+
+	_, err := handler(context.Background(), projectToolRequest("execute", map[string]any{
+		"tool_name": "github_list_issues",
+		"arguments": map[string]any{"state": "open"},
+	}))
+	require.NoError(t, err)
+
+	assert.Equal(t, "myorg", capturedArgs["owner"])
+	assert.Equal(t, "myrepo", capturedArgs["repo"])
+	assert.Equal(t, "open", capturedArgs["state"])
+}
+
+func TestProjectRouter_ExecuteAgentOverridesDefaults(t *testing.T) {
+	def := &project.Definition{
+		Version: "1",
+		Name:    "override-test",
+		Tools: map[string]*project.ScopeRule{
+			"switchboard": {
+				Defaults: map[string]map[string]any{
+					"github_*": {"owner": "default-org"},
+				},
+			},
+		},
+	}
+
+	var capturedArgs map[string]any
+	mi := &mockIntegration{
+		name:    "github",
+		healthy: true,
+		tools: []mcp.ToolDefinition{
+			{Name: "github_list_issues", Description: "List issues"},
+		},
+		execFn: func(_ context.Context, _ string, args map[string]any) (*mcp.ToolResult, error) {
+			capturedArgs = args
+			return &mcp.ToolResult{Data: `[]`}, nil
+		},
+	}
+	router, _ := setupProjectRouter(t, def, mi)
+
+	scopeRule := project.GetEffectiveRule(def, "switchboard", "")
+	handler := router.makeExecuteHandler(def, scopeRule)
+
+	_, err := handler(context.Background(), projectToolRequest("execute", map[string]any{
+		"tool_name": "github_list_issues",
+		"arguments": map[string]any{"owner": "override-org"},
+	}))
+	require.NoError(t, err)
+
+	assert.Equal(t, "override-org", capturedArgs["owner"])
+}
+
+func TestProjectRouter_ExecuteDenied(t *testing.T) {
+	def := &project.Definition{
+		Version: "1",
+		Name:    "deny-test",
+		Tools: map[string]*project.ScopeRule{
+			"switchboard": {
+				Deny: []string{"github_delete_*"},
+			},
+		},
+	}
+	mi := &mockIntegration{
+		name:    "github",
+		healthy: true,
+		tools: []mcp.ToolDefinition{
+			{Name: "github_delete_repo", Description: "Delete repo"},
+		},
+	}
+	router, _ := setupProjectRouter(t, def, mi)
+
+	scopeRule := project.GetEffectiveRule(def, "switchboard", "")
+	handler := router.makeExecuteHandler(def, scopeRule)
+
+	result, err := handler(context.Background(), projectToolRequest("execute", map[string]any{
+		"tool_name": "github_delete_repo",
+	}))
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+
+	tc := result.Content[0].(*mcpsdk.TextContent)
+	assert.Contains(t, tc.Text, "denied")
+}
+
+func TestProjectRouter_ContextManifest(t *testing.T) {
+	dir := t.TempDir()
+	repoDir := filepath.Join(dir, "repo")
+	require.NoError(t, os.MkdirAll(repoDir, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "AGENTS.md"), []byte("instructions"), 0600))
+
+	configDir := filepath.Join(dir, "config")
+	contextDir := filepath.Join(configDir, "context", "ctx-test")
+	require.NoError(t, os.MkdirAll(contextDir, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(contextDir, "sprint.md"), []byte("goals"), 0600))
+
+	def := &project.Definition{
+		Version: "1",
+		Name:    "ctx-test",
+		Repo:    repoDir,
+		Context: &project.ContextConfig{
+			Files:        []string{"sprint.md"},
+			RepoIncludes: []string{"AGENTS.md"},
+		},
+	}
+
+	store := project.NewStore(configDir)
+	require.NoError(t, store.Create(def))
+
+	services := &mcp.Services{
+		Config:   newMockConfigService(nil),
+		Registry: newMockRegistry(),
+	}
+	router := NewProjectRouter(services, store, "switchboard")
+
+	handler := router.makeContextHandler(def)
+
+	t.Run("manifest with no args", func(t *testing.T) {
+		result, err := handler(context.Background(), projectToolRequest("project_context", map[string]any{}))
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+
+		tc := result.Content[0].(*mcpsdk.TextContent)
+		var entries []project.ContextEntry
+		require.NoError(t, json.Unmarshal([]byte(tc.Text), &entries))
+		assert.Len(t, entries, 2)
+	})
+
+	t.Run("fetch specific file", func(t *testing.T) {
+		result, err := handler(context.Background(), projectToolRequest("project_context", map[string]any{
+			"path": "AGENTS.md",
+		}))
+		require.NoError(t, err)
+
+		tc := result.Content[0].(*mcpsdk.TextContent)
+		assert.Equal(t, "instructions", tc.Text)
+	})
+
+	t.Run("query filter", func(t *testing.T) {
+		result, err := handler(context.Background(), projectToolRequest("project_context", map[string]any{
+			"query": "sprint",
+		}))
+		require.NoError(t, err)
+
+		tc := result.Content[0].(*mcpsdk.TextContent)
+		var entries []project.ContextEntry
+		require.NoError(t, json.Unmarshal([]byte(tc.Text), &entries))
+		assert.Len(t, entries, 1)
+		assert.Equal(t, "sprint.md", entries[0].Path)
+	})
+}
+
+func TestProjectRouter_ProjectList(t *testing.T) {
+	def := &project.Definition{Version: "1", Name: "p1", Repo: "~/work/p1"}
+	router, store := setupProjectRouter(t, def)
+
+	def2 := &project.Definition{Version: "1", Name: "p2"}
+	require.NoError(t, store.Create(def2))
+
+	result, err := router.handleProjectList(context.Background(), projectToolRequest("project_list", nil))
+	require.NoError(t, err)
+
+	tc := result.Content[0].(*mcpsdk.TextContent)
+	var list []struct {
+		Name string `json:"name"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(tc.Text), &list))
+	assert.Len(t, list, 2)
+}
+
+func TestProjectRouter_ProjectGet(t *testing.T) {
+	def := &project.Definition{Version: "1", Name: "myproj", Repo: "~/work/myproj"}
+	router, _ := setupProjectRouter(t, def)
+
+	handler := router.makeProjectGetHandler(def)
+	result, err := handler(context.Background(), projectToolRequest("project_get", map[string]any{}))
+	require.NoError(t, err)
+
+	tc := result.Content[0].(*mcpsdk.TextContent)
+	var got project.Definition
+	require.NoError(t, json.Unmarshal([]byte(tc.Text), &got))
+	assert.Equal(t, "myproj", got.Name)
+}
+
+func TestProjectRouter_ProjectCreate(t *testing.T) {
+	def := &project.Definition{Version: "1", Name: "existing"}
+	router, _ := setupProjectRouter(t, def)
+
+	result, err := router.handleProjectCreate(context.Background(), projectToolRequest("project_create", map[string]any{
+		"name": "new-project",
+		"repo": "~/work/new",
+	}))
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	got, ok := router.store.Get("new-project")
+	require.True(t, ok)
+	assert.Equal(t, "~/work/new", got.Repo)
+}
+
+func TestProjectRouter_ProjectCreateDuplicate(t *testing.T) {
+	def := &project.Definition{Version: "1", Name: "existing"}
+	router, _ := setupProjectRouter(t, def)
+
+	result, err := router.handleProjectCreate(context.Background(), projectToolRequest("project_create", map[string]any{
+		"name": "existing",
+	}))
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+}
+
+func TestProjectRouter_ProjectUpdate(t *testing.T) {
+	def := &project.Definition{Version: "1", Name: "updatable"}
+	router, _ := setupProjectRouter(t, def)
+
+	handler := router.makeProjectUpdateHandler(def)
+	result, err := handler(context.Background(), projectToolRequest("project_update", map[string]any{
+		"patch": map[string]any{"branch": "develop"},
+	}))
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	got, _ := router.store.Get("updatable")
+	assert.Equal(t, "develop", got.Branch)
+}
+
+func TestProjectRouter_ProjectDelete(t *testing.T) {
+	def := &project.Definition{Version: "1", Name: "deletable"}
+	router, _ := setupProjectRouter(t, def)
+
+	handler := router.makeProjectDeleteHandler(def)
+	result, err := handler(context.Background(), projectToolRequest("project_delete", map[string]any{}))
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	_, ok := router.store.Get("deletable")
+	assert.False(t, ok)
+}
+
+func TestProjectRouter_ProjectTools(t *testing.T) {
+	def := &project.Definition{
+		Version: "1",
+		Name:    "tools-test",
+		Tools: map[string]*project.ScopeRule{
+			"switchboard": {
+				Allow: []string{"github_list_*"},
+			},
+		},
+	}
+	mi := &mockIntegration{
+		name:    "github",
+		healthy: true,
+		tools: []mcp.ToolDefinition{
+			{Name: "github_list_issues", Description: "List issues"},
+			{Name: "github_get_issue", Description: "Get issue"},
+			{Name: "github_delete_repo", Description: "Delete repo"},
+		},
+	}
+	router, _ := setupProjectRouter(t, def, mi)
+
+	handler := router.makeProjectToolsHandler(def)
+	result, err := handler(context.Background(), projectToolRequest("project_tools", map[string]any{}))
+	require.NoError(t, err)
+
+	tc := result.Content[0].(*mcpsdk.TextContent)
+	var tools []string
+	require.NoError(t, json.Unmarshal([]byte(tc.Text), &tools))
+	assert.Equal(t, []string{"github_list_issues"}, tools)
+}
+
+func TestProjectRouter_ProjectDefaults(t *testing.T) {
+	def := &project.Definition{
+		Version: "1",
+		Name:    "defaults-test",
+		Tools: map[string]*project.ScopeRule{
+			"switchboard": {
+				Defaults: map[string]map[string]any{
+					"github_*": {"owner": "myorg"},
+				},
+			},
+		},
+	}
+	router, _ := setupProjectRouter(t, def)
+
+	handler := router.makeProjectDefaultsHandler(def)
+	result, err := handler(context.Background(), projectToolRequest("project_defaults", map[string]any{
+		"tool_name": "github_list_issues",
+	}))
+	require.NoError(t, err)
+
+	tc := result.Content[0].(*mcpsdk.TextContent)
+	var defaults map[string]any
+	require.NoError(t, json.Unmarshal([]byte(tc.Text), &defaults))
+	assert.Equal(t, "myorg", defaults["owner"])
+}
+
+func TestProjectRouter_Handler(t *testing.T) {
+	def := &project.Definition{Version: "1", Name: "handler-test"}
+	router, _ := setupProjectRouter(t, def)
+	handler := router.Handler()
+	assert.NotNil(t, handler)
+}
+


### PR DESCRIPTION

## Summary

- Implement the [project-interop specification](https://github.com/daltoniam/switchboard/blob/main/docs/specs/project-interop) (RFC-0001 through RFC-0005) so Switchboard can serve as a project-aware tool proxy
- New `/mcp/{project}` endpoint serves per-project MCP servers with tool scoping (allow/deny glob patterns), default argument injection, deny enforcement, and context delivery via `project_context` tool
- New `project/` package handles definition loading, merging (user-level + repo-local), validation, tool scoping resolution, role overrides, and context assembly

## What's included

| Component | Files | Description |
|-----------|-------|-------------|
| Project definitions | `project/project.go` | Types, discovery, merging (RFC-0001 §5), validation, Store CRUD |
| Tool scoping | `project/scope.go` | Allow/deny resolution (RFC-0002 §5), default injection, role overrides (RFC-0004 §3) |
| Context assembly | `project/context.go` | Repo includes + store files, dedup, maxBytes truncation (RFC-0003) |
| Project server | `server/project_server.go` | Scoped search/execute, `project_context` tool, project management tools |
| Wiring | `cmd/server/main.go` | Load project store at startup, register `/mcp/{project}` route |

## Test plan

- [x] `project/project_test.go` — 14 tests (validation, merge, CRUD, repo-local merge)
- [x] `project/scope_test.go` — 16 tests (allow/deny, defaults, role resolution)
- [x] `project/context_test.go` — 8 tests (manifest, dedup, role overrides, bundle truncation)
- [x] `server/project_server_test.go` — 16 tests (search filtering, default injection, deny enforcement, context, all management tools)
- [x] All existing tests still pass
- [x] `go vet` and `golangci-lint` clean


🐨 Generated with Crush