### PR TITLE
feat(mcp): add context.Context to Configure interface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -275,7 +275,7 @@ Every integration adapter implements this interface defined in `mcp.go`:
 ```go
 type Integration interface {
     Name() string
-    Configure(creds Credentials) error
+    Configure(ctx context.Context, creds Credentials) error
     Tools() []ToolDefinition
     Execute(ctx context.Context, toolName string, args map[string]any) (*ToolResult, error)
     Healthy(ctx context.Context) bool
@@ -283,7 +283,7 @@ type Integration interface {
 ```
 
 - **`Name()`** — Lowercase identifier (e.g., `"github"`). Must match config key.
-- **`Configure()`** — Receives `Credentials` (`map[string]string`). Validate and store.
+- **`Configure(ctx)`** — Receives `context.Context` and `Credentials` (`map[string]string`). Validate and store. I/O adapters propagate ctx.
 - **`Tools()`** — Returns tool definitions for progressive discovery via the `search` MCP tool.
 - **`Execute()`** — Dispatches to the correct handler by tool name. Returns `*ToolResult`.
 - **`Healthy()`** — Lightweight API call to verify credentials.

--- a/integrations/aws/aws.go
+++ b/integrations/aws/aws.go
@@ -47,7 +47,7 @@ func New() mcp.Integration {
 
 func (a *integration) Name() string { return "aws" }
 
-func (a *integration) Configure(creds mcp.Credentials) error {
+func (a *integration) Configure(ctx context.Context, creds mcp.Credentials) error {
 	region := creds["region"]
 	if region == "" {
 		region = "us-east-1"
@@ -66,7 +66,7 @@ func (a *integration) Configure(creds mcp.Credentials) error {
 		))
 	}
 
-	cfg, err := awsconfig.LoadDefaultConfig(context.Background(), opts...)
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, opts...)
 	if err != nil {
 		return fmt.Errorf("aws: failed to load config: %w", err)
 	}

--- a/integrations/aws/aws_test.go
+++ b/integrations/aws/aws_test.go
@@ -19,7 +19,7 @@ func TestNew(t *testing.T) {
 
 func TestConfigure_WithStaticCredentials(t *testing.T) {
 	i := New()
-	err := i.Configure(mcp.Credentials{
+	err := i.Configure(context.Background(), mcp.Credentials{
 		"access_key_id":     "AKIAIOSFODNN7EXAMPLE",
 		"secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
 		"region":            "us-west-2",
@@ -29,7 +29,7 @@ func TestConfigure_WithStaticCredentials(t *testing.T) {
 
 func TestConfigure_DefaultRegion(t *testing.T) {
 	a := &integration{}
-	err := a.Configure(mcp.Credentials{
+	err := a.Configure(context.Background(), mcp.Credentials{
 		"access_key_id":     "AKIAIOSFODNN7EXAMPLE",
 		"secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
 	})
@@ -39,7 +39,7 @@ func TestConfigure_DefaultRegion(t *testing.T) {
 
 func TestConfigure_WithSessionToken(t *testing.T) {
 	i := New()
-	err := i.Configure(mcp.Credentials{
+	err := i.Configure(context.Background(), mcp.Credentials{
 		"access_key_id":     "AKIAIOSFODNN7EXAMPLE",
 		"secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
 		"session_token":     "FwoGZXIvYXdzEBYaDG...",
@@ -50,7 +50,7 @@ func TestConfigure_WithSessionToken(t *testing.T) {
 
 func TestConfigure_DefaultConfig(t *testing.T) {
 	i := New()
-	err := i.Configure(mcp.Credentials{"region": "ap-southeast-1"})
+	err := i.Configure(context.Background(), mcp.Credentials{"region": "ap-southeast-1"})
 	assert.NoError(t, err)
 }
 
@@ -83,7 +83,7 @@ func TestTools_NoDuplicateNames(t *testing.T) {
 
 func TestExecute_UnknownTool(t *testing.T) {
 	a := &integration{}
-	err := a.Configure(mcp.Credentials{
+	err := a.Configure(context.Background(), mcp.Credentials{
 		"access_key_id":     "AKIAIOSFODNN7EXAMPLE",
 		"secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
 		"region":            "us-east-1",

--- a/integrations/clickhouse/clickhouse.go
+++ b/integrations/clickhouse/clickhouse.go
@@ -25,7 +25,7 @@ func New() mcp.Integration {
 
 func (c *clickhouseInt) Name() string { return "clickhouse" }
 
-func (c *clickhouseInt) Configure(creds mcp.Credentials) error {
+func (c *clickhouseInt) Configure(_ context.Context, creds mcp.Credentials) error {
 	if c.conn != nil {
 		_ = c.conn.Close()
 	}

--- a/integrations/clickhouse/clickhouse_test.go
+++ b/integrations/clickhouse/clickhouse_test.go
@@ -18,7 +18,7 @@ func TestNew(t *testing.T) {
 
 func TestConfigure_Defaults(t *testing.T) {
 	c := &clickhouseInt{}
-	err := c.Configure(mcp.Credentials{"host": "localhost", "port": "9000"})
+	err := c.Configure(context.Background(), mcp.Credentials{"host": "localhost", "port": "9000"})
 	if err != nil {
 		t.Skipf("ClickHouse not available: %v", err)
 	}

--- a/integrations/datadog/datadog.go
+++ b/integrations/datadog/datadog.go
@@ -26,7 +26,7 @@ func New() mcp.Integration {
 
 func (d *dd) Name() string { return "datadog" }
 
-func (d *dd) Configure(creds mcp.Credentials) error {
+func (d *dd) Configure(_ context.Context, creds mcp.Credentials) error {
 	d.apiKey = creds["api_key"]
 	d.appKey = creds["app_key"]
 	if d.apiKey == "" || d.appKey == "" {

--- a/integrations/datadog/datadog_test.go
+++ b/integrations/datadog/datadog_test.go
@@ -1,6 +1,7 @@
 package datadog
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -18,32 +19,32 @@ func TestNew(t *testing.T) {
 
 func TestConfigure_Success(t *testing.T) {
 	i := New()
-	err := i.Configure(mcp.Credentials{"api_key": "key123", "app_key": "app456"})
+	err := i.Configure(context.Background(), mcp.Credentials{"api_key": "key123", "app_key": "app456"})
 	assert.NoError(t, err)
 }
 
 func TestConfigure_MissingAPIKey(t *testing.T) {
 	i := New()
-	err := i.Configure(mcp.Credentials{"api_key": "", "app_key": "app456"})
+	err := i.Configure(context.Background(), mcp.Credentials{"api_key": "", "app_key": "app456"})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "api_key and app_key are required")
 }
 
 func TestConfigure_MissingAppKey(t *testing.T) {
 	i := New()
-	err := i.Configure(mcp.Credentials{"api_key": "key123", "app_key": ""})
+	err := i.Configure(context.Background(), mcp.Credentials{"api_key": "key123", "app_key": ""})
 	assert.Error(t, err)
 }
 
 func TestConfigure_EmptyCredentials(t *testing.T) {
 	i := New()
-	err := i.Configure(mcp.Credentials{})
+	err := i.Configure(context.Background(), mcp.Credentials{})
 	assert.Error(t, err)
 }
 
 func TestConfigure_WithSite(t *testing.T) {
 	d := &dd{}
-	err := d.Configure(mcp.Credentials{"api_key": "key", "app_key": "app", "site": "datadoghq.eu"})
+	err := d.Configure(context.Background(), mcp.Credentials{"api_key": "key", "app_key": "app", "site": "datadoghq.eu"})
 	assert.NoError(t, err)
 	assert.Equal(t, "datadoghq.eu", d.site)
 }
@@ -77,7 +78,7 @@ func TestTools_NoDuplicateNames(t *testing.T) {
 
 func TestExecute_UnknownTool(t *testing.T) {
 	d := &dd{apiKey: "key", appKey: "app"}
-	d.Configure(mcp.Credentials{"api_key": "key", "app_key": "app"})
+	d.Configure(context.Background(), mcp.Credentials{"api_key": "key", "app_key": "app"})
 	result, err := d.Execute(t.Context(), "datadog_nonexistent", nil)
 	require.NoError(t, err)
 	assert.True(t, result.IsError)

--- a/integrations/github/github.go
+++ b/integrations/github/github.go
@@ -28,7 +28,7 @@ func New() mcp.Integration {
 
 func (g *integration) Name() string { return "github" }
 
-func (g *integration) Configure(creds mcp.Credentials) error {
+func (g *integration) Configure(_ context.Context, creds mcp.Credentials) error {
 	g.token = creds["token"]
 	if g.token == "" {
 		return fmt.Errorf("github: token is required")

--- a/integrations/github/github_test.go
+++ b/integrations/github/github_test.go
@@ -18,20 +18,20 @@ func TestNew(t *testing.T) {
 
 func TestConfigure_Success(t *testing.T) {
 	i := New()
-	err := i.Configure(mcp.Credentials{"token": "ghp_test123"})
+	err := i.Configure(context.Background(), mcp.Credentials{"token": "ghp_test123"})
 	assert.NoError(t, err)
 }
 
 func TestConfigure_MissingToken(t *testing.T) {
 	i := New()
-	err := i.Configure(mcp.Credentials{"token": ""})
+	err := i.Configure(context.Background(), mcp.Credentials{"token": ""})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "token is required")
 }
 
 func TestConfigure_EmptyCredentials(t *testing.T) {
 	i := New()
-	err := i.Configure(mcp.Credentials{})
+	err := i.Configure(context.Background(), mcp.Credentials{})
 	assert.Error(t, err)
 }
 

--- a/integrations/gmail/gmail.go
+++ b/integrations/gmail/gmail.go
@@ -48,7 +48,7 @@ func SetConfigService(i mcp.Integration, svc mcp.ConfigService) {
 
 func (g *gmail) Name() string { return "gmail" }
 
-func (g *gmail) Configure(creds mcp.Credentials) error {
+func (g *gmail) Configure(_ context.Context, creds mcp.Credentials) error {
 	g.accessToken = creds["access_token"]
 	g.refreshToken = creds["refresh_token"]
 	g.clientID = creds["client_id"]

--- a/integrations/gmail/gmail_test.go
+++ b/integrations/gmail/gmail_test.go
@@ -21,20 +21,20 @@ func TestNew(t *testing.T) {
 
 func TestConfigure_Success(t *testing.T) {
 	i := New()
-	err := i.Configure(mcp.Credentials{"access_token": "ya29.test-token"})
+	err := i.Configure(context.Background(), mcp.Credentials{"access_token": "ya29.test-token"})
 	assert.NoError(t, err)
 }
 
 func TestConfigure_MissingAccessToken(t *testing.T) {
 	i := New()
-	err := i.Configure(mcp.Credentials{"access_token": ""})
+	err := i.Configure(context.Background(), mcp.Credentials{"access_token": ""})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "access_token is required")
 }
 
 func TestConfigure_CustomBaseURL(t *testing.T) {
 	g := &gmail{client: &http.Client{}, baseURL: "https://gmail.googleapis.com"}
-	err := g.Configure(mcp.Credentials{
+	err := g.Configure(context.Background(), mcp.Credentials{
 		"access_token": "ya29.test",
 		"base_url":     "https://custom.example.com/",
 	})

--- a/integrations/homeassistant/homeassistant.go
+++ b/integrations/homeassistant/homeassistant.go
@@ -41,7 +41,7 @@ func (h *homeassistant) PlainTextKeys() []string {
 	return []string{"base_url"}
 }
 
-func (h *homeassistant) Configure(creds mcp.Credentials) error {
+func (h *homeassistant) Configure(_ context.Context, creds mcp.Credentials) error {
 	h.token = creds["token"]
 	if h.token == "" {
 		return fmt.Errorf("homeassistant: token is required")

--- a/integrations/homeassistant/homeassistant_test.go
+++ b/integrations/homeassistant/homeassistant_test.go
@@ -21,27 +21,27 @@ func TestNew(t *testing.T) {
 
 func TestConfigure_Success(t *testing.T) {
 	i := New()
-	err := i.Configure(mcp.Credentials{"token": "test-token", "base_url": "http://localhost:8123"})
+	err := i.Configure(context.Background(), mcp.Credentials{"token": "test-token", "base_url": "http://localhost:8123"})
 	assert.NoError(t, err)
 }
 
 func TestConfigure_MissingToken(t *testing.T) {
 	i := New()
-	err := i.Configure(mcp.Credentials{"base_url": "http://localhost:8123"})
+	err := i.Configure(context.Background(), mcp.Credentials{"base_url": "http://localhost:8123"})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "token is required")
 }
 
 func TestConfigure_MissingBaseURL(t *testing.T) {
 	i := New()
-	err := i.Configure(mcp.Credentials{"token": "test-token"})
+	err := i.Configure(context.Background(), mcp.Credentials{"token": "test-token"})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "base_url is required")
 }
 
 func TestConfigure_TrimsTrailingSlash(t *testing.T) {
 	ha := &homeassistant{client: &http.Client{}}
-	err := ha.Configure(mcp.Credentials{
+	err := ha.Configure(context.Background(), mcp.Credentials{
 		"token":    "test",
 		"base_url": "http://localhost:8123/",
 	})

--- a/integrations/linear/linear.go
+++ b/integrations/linear/linear.go
@@ -26,7 +26,7 @@ func New() mcp.Integration {
 
 func (l *linear) Name() string { return "linear" }
 
-func (l *linear) Configure(creds mcp.Credentials) error {
+func (l *linear) Configure(_ context.Context, creds mcp.Credentials) error {
 	l.apiKey = creds["api_key"]
 	if l.apiKey == "" {
 		return fmt.Errorf("linear: api_key is required")

--- a/integrations/linear/linear_test.go
+++ b/integrations/linear/linear_test.go
@@ -23,20 +23,20 @@ func TestNew(t *testing.T) {
 
 func TestConfigure_Success(t *testing.T) {
 	i := New()
-	err := i.Configure(mcp.Credentials{"api_key": "lin_api_test123"})
+	err := i.Configure(context.Background(), mcp.Credentials{"api_key": "lin_api_test123"})
 	assert.NoError(t, err)
 }
 
 func TestConfigure_MissingAPIKey(t *testing.T) {
 	i := New()
-	err := i.Configure(mcp.Credentials{"api_key": ""})
+	err := i.Configure(context.Background(), mcp.Credentials{"api_key": ""})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "api_key is required")
 }
 
 func TestConfigure_EmptyCredentials(t *testing.T) {
 	i := New()
-	err := i.Configure(mcp.Credentials{})
+	err := i.Configure(context.Background(), mcp.Credentials{})
 	assert.Error(t, err)
 }
 

--- a/integrations/metabase/metabase.go
+++ b/integrations/metabase/metabase.go
@@ -27,7 +27,7 @@ func New() mcp.Integration {
 
 func (m *metabase) Name() string { return "metabase" }
 
-func (m *metabase) Configure(creds mcp.Credentials) error {
+func (m *metabase) Configure(_ context.Context, creds mcp.Credentials) error {
 	m.apiKey = creds["api_key"]
 	m.baseURL = strings.TrimRight(creds["url"], "/")
 	if m.apiKey == "" {

--- a/integrations/metabase/metabase_test.go
+++ b/integrations/metabase/metabase_test.go
@@ -21,27 +21,27 @@ func TestNew(t *testing.T) {
 
 func TestConfigure_Success(t *testing.T) {
 	i := New()
-	err := i.Configure(mcp.Credentials{"api_key": "mb_key", "url": "https://metabase.example.com"})
+	err := i.Configure(context.Background(), mcp.Credentials{"api_key": "mb_key", "url": "https://metabase.example.com"})
 	assert.NoError(t, err)
 }
 
 func TestConfigure_MissingAPIKey(t *testing.T) {
 	i := New()
-	err := i.Configure(mcp.Credentials{"api_key": "", "url": "https://metabase.example.com"})
+	err := i.Configure(context.Background(), mcp.Credentials{"api_key": "", "url": "https://metabase.example.com"})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "api_key is required")
 }
 
 func TestConfigure_MissingURL(t *testing.T) {
 	i := New()
-	err := i.Configure(mcp.Credentials{"api_key": "key", "url": ""})
+	err := i.Configure(context.Background(), mcp.Credentials{"api_key": "key", "url": ""})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "url is required")
 }
 
 func TestConfigure_TrimsTrailingSlash(t *testing.T) {
 	m := &metabase{client: &http.Client{}}
-	err := m.Configure(mcp.Credentials{"api_key": "key", "url": "https://metabase.example.com/"})
+	err := m.Configure(context.Background(), mcp.Credentials{"api_key": "key", "url": "https://metabase.example.com/"})
 	assert.NoError(t, err)
 	assert.Equal(t, "https://metabase.example.com", m.baseURL)
 }

--- a/integrations/notion/notion.go
+++ b/integrations/notion/notion.go
@@ -47,7 +47,7 @@ func New() mcp.Integration {
 
 func (n *notion) Name() string { return "notion" }
 
-func (n *notion) Configure(creds mcp.Credentials) error {
+func (n *notion) Configure(ctx context.Context, creds mcp.Credentials) error {
 	n.tokenV2 = creds["token_v2"]
 	if n.tokenV2 == "" {
 		return fmt.Errorf("notion: token_v2 is required")
@@ -56,7 +56,7 @@ func (n *notion) Configure(creds mcp.Credentials) error {
 		n.baseURL = strings.TrimRight(v, "/")
 	}
 
-	spaceID, userID, err := n.resolveSpaceAndUser()
+	spaceID, userID, err := n.resolveSpaceAndUser(ctx)
 	if err != nil {
 		return fmt.Errorf("notion: failed to resolve workspace: %w", err)
 	}
@@ -66,8 +66,8 @@ func (n *notion) Configure(creds mcp.Credentials) error {
 }
 
 // resolveSpaceAndUser calls getSpaces to discover the first space ID and user ID.
-func (n *notion) resolveSpaceAndUser() (string, string, error) {
-	data, err := n.doRequest(context.Background(), "/api/v3/getSpaces", map[string]any{})
+func (n *notion) resolveSpaceAndUser(ctx context.Context) (string, string, error) {
+	data, err := n.doRequest(ctx, "/api/v3/getSpaces", map[string]any{})
 	if err != nil {
 		return "", "", err
 	}

--- a/integrations/notion/notion_test.go
+++ b/integrations/notion/notion_test.go
@@ -77,7 +77,7 @@ func TestConfigure_AcceptsTokenV2AndResolvesSpaceAndUser(t *testing.T) {
 	defer ts.Close()
 
 	n := &notion{client: ts.Client(), baseURL: ts.URL}
-	err := n.Configure(mcp.Credentials{"token_v2": "v2-token-123"})
+	err := n.Configure(context.Background(), mcp.Credentials{"token_v2": "v2-token-123"})
 	require.NoError(t, err)
 	assert.Equal(t, "v2-token-123", n.tokenV2)
 	assert.Equal(t, "space-xyz", n.spaceID)
@@ -86,7 +86,7 @@ func TestConfigure_AcceptsTokenV2AndResolvesSpaceAndUser(t *testing.T) {
 
 func TestConfigure_RejectsEmptyTokenV2(t *testing.T) {
 	i := New()
-	err := i.Configure(mcp.Credentials{"token_v2": ""})
+	err := i.Configure(context.Background(), mcp.Credentials{"token_v2": ""})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "token_v2 is required")
 }
@@ -98,7 +98,7 @@ func TestConfigure_TrimsTrailingSlashFromCustomBaseURL(t *testing.T) {
 	defer ts.Close()
 
 	n := &notion{client: ts.Client(), baseURL: ts.URL + "/"}
-	err := n.Configure(mcp.Credentials{"token_v2": "tok", "base_url": ts.URL + "/"})
+	err := n.Configure(context.Background(), mcp.Credentials{"token_v2": "tok", "base_url": ts.URL + "/"})
 	require.NoError(t, err)
 	assert.Equal(t, ts.URL, n.baseURL)
 }
@@ -116,7 +116,7 @@ func TestConfigure_ReturnsErrorWhenGetSpacesFails(t *testing.T) {
 	defer ts.Close()
 
 	n := &notion{client: ts.Client(), baseURL: ts.URL}
-	err := n.Configure(mcp.Credentials{"token_v2": "bad-token"})
+	err := n.Configure(context.Background(), mcp.Credentials{"token_v2": "bad-token"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "resolve workspace")
 }
@@ -1882,7 +1882,7 @@ func TestResolveSpaceAndUser_DeterministicSelection(t *testing.T) {
 	// Run multiple times to verify determinism (Go map iteration is random)
 	for i := 0; i < 10; i++ {
 		n := &notion{client: ts.Client(), baseURL: ts.URL, tokenV2: "tok"}
-		spaceID, userID, err := n.resolveSpaceAndUser()
+		spaceID, userID, err := n.resolveSpaceAndUser(context.Background())
 		require.NoError(t, err)
 		assert.Equal(t, "space-ccc", spaceID, "iteration %d: should consistently pick first sorted user's first sorted space", i)
 		assert.Equal(t, "user-aaa", userID, "iteration %d: should consistently pick first sorted user", i)

--- a/integrations/pganalyze/pganalyze.go
+++ b/integrations/pganalyze/pganalyze.go
@@ -34,7 +34,7 @@ func New() mcp.Integration {
 
 func (p *pganalyze) Name() string { return "pganalyze" }
 
-func (p *pganalyze) Configure(creds mcp.Credentials) error {
+func (p *pganalyze) Configure(_ context.Context, creds mcp.Credentials) error {
 	p.apiKey = creds["api_key"]
 	if p.apiKey == "" {
 		return fmt.Errorf("pganalyze: api_key is required")

--- a/integrations/pganalyze/pganalyze_test.go
+++ b/integrations/pganalyze/pganalyze_test.go
@@ -21,40 +21,40 @@ func TestNew(t *testing.T) {
 
 func TestConfigure_Success(t *testing.T) {
 	i := New()
-	err := i.Configure(mcp.Credentials{"api_key": "test-token-123"})
+	err := i.Configure(context.Background(), mcp.Credentials{"api_key": "test-token-123"})
 	assert.NoError(t, err)
 }
 
 func TestConfigure_MissingAPIKey(t *testing.T) {
 	i := New()
-	err := i.Configure(mcp.Credentials{"api_key": ""})
+	err := i.Configure(context.Background(), mcp.Credentials{"api_key": ""})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "api_key is required")
 }
 
 func TestConfigure_EmptyCredentials(t *testing.T) {
 	i := New()
-	err := i.Configure(mcp.Credentials{})
+	err := i.Configure(context.Background(), mcp.Credentials{})
 	assert.Error(t, err)
 }
 
 func TestConfigure_CustomBaseURL(t *testing.T) {
 	p := &pganalyze{client: &http.Client{}}
-	err := p.Configure(mcp.Credentials{"api_key": "key", "base_url": "https://pganalyze.example.com/"})
+	err := p.Configure(context.Background(), mcp.Credentials{"api_key": "key", "base_url": "https://pganalyze.example.com/"})
 	assert.NoError(t, err)
 	assert.Equal(t, "https://pganalyze.example.com/graphql", p.graphqlURL)
 }
 
 func TestConfigure_DefaultBaseURL(t *testing.T) {
 	p := &pganalyze{client: &http.Client{}}
-	err := p.Configure(mcp.Credentials{"api_key": "key"})
+	err := p.Configure(context.Background(), mcp.Credentials{"api_key": "key"})
 	assert.NoError(t, err)
 	assert.Equal(t, defaultGraphQLURL, p.graphqlURL)
 }
 
 func TestConfigure_BaseURLWithGraphQLSuffix(t *testing.T) {
 	p := &pganalyze{client: &http.Client{}}
-	err := p.Configure(mcp.Credentials{"api_key": "key", "base_url": "https://app.pganalyze.com/graphql"})
+	err := p.Configure(context.Background(), mcp.Credentials{"api_key": "key", "base_url": "https://app.pganalyze.com/graphql"})
 	assert.NoError(t, err)
 	assert.Equal(t, "https://app.pganalyze.com/graphql", p.graphqlURL)
 }
@@ -216,7 +216,7 @@ func TestPlainTextKeys(t *testing.T) {
 
 func TestConfigure_OrganizationSlug(t *testing.T) {
 	p := &pganalyze{client: &http.Client{}}
-	err := p.Configure(mcp.Credentials{"api_key": "key", "organization_slug": "my-org"})
+	err := p.Configure(context.Background(), mcp.Credentials{"api_key": "key", "organization_slug": "my-org"})
 	assert.NoError(t, err)
 	assert.Equal(t, "my-org", p.organizationSlug)
 }

--- a/integrations/postgres/postgres.go
+++ b/integrations/postgres/postgres.go
@@ -27,7 +27,7 @@ func New() mcp.Integration {
 
 func (p *postgres) Name() string { return "postgres" }
 
-func (p *postgres) Configure(creds mcp.Credentials) error {
+func (p *postgres) Configure(ctx context.Context, creds mcp.Credentials) error {
 	p.readOnly = creds["read_only"] != "false"
 
 	connStr := creds["connection_string"]
@@ -72,7 +72,7 @@ func (p *postgres) Configure(creds mcp.Credentials) error {
 	db.SetMaxIdleConns(2)
 	db.SetConnMaxLifetime(30 * time.Minute)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	if err := db.PingContext(ctx); err != nil {
 		_ = db.Close()

--- a/integrations/postgres/postgres_test.go
+++ b/integrations/postgres/postgres_test.go
@@ -21,7 +21,7 @@ func TestNew(t *testing.T) {
 
 func TestConfigure_ConnectionString(t *testing.T) {
 	p := &postgres{}
-	err := p.Configure(mcp.Credentials{"connection_string": "host=localhost port=5432 user=test dbname=testdb sslmode=disable"})
+	err := p.Configure(context.Background(), mcp.Credentials{"connection_string": "host=localhost port=5432 user=test dbname=testdb sslmode=disable"})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to ping")
 	assert.True(t, p.readOnly)
@@ -29,7 +29,7 @@ func TestConfigure_ConnectionString(t *testing.T) {
 
 func TestConfigure_IndividualCredentials(t *testing.T) {
 	p := &postgres{}
-	err := p.Configure(mcp.Credentials{
+	err := p.Configure(context.Background(), mcp.Credentials{
 		"host":     "myhost",
 		"port":     "5433",
 		"user":     "myuser",
@@ -48,7 +48,7 @@ func TestConfigure_IndividualCredentials(t *testing.T) {
 
 func TestConfigure_Defaults(t *testing.T) {
 	p := &postgres{}
-	err := p.Configure(mcp.Credentials{"user": "test"})
+	err := p.Configure(context.Background(), mcp.Credentials{"user": "test"})
 	assert.Error(t, err)
 	assert.Contains(t, p.connStr, "localhost")
 	assert.Contains(t, p.connStr, "5432")
@@ -57,20 +57,20 @@ func TestConfigure_Defaults(t *testing.T) {
 
 func TestConfigure_MissingUser(t *testing.T) {
 	p := &postgres{}
-	err := p.Configure(mcp.Credentials{"host": "localhost"})
+	err := p.Configure(context.Background(), mcp.Credentials{"host": "localhost"})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "user is required")
 }
 
 func TestConfigure_ReadOnlyDefault(t *testing.T) {
 	p := &postgres{}
-	_ = p.Configure(mcp.Credentials{"connection_string": "host=localhost"})
+	_ = p.Configure(context.Background(), mcp.Credentials{"connection_string": "host=localhost"})
 	assert.True(t, p.readOnly)
 }
 
 func TestConfigure_ReadOnlyExplicitFalse(t *testing.T) {
 	p := &postgres{}
-	_ = p.Configure(mcp.Credentials{"connection_string": "host=localhost", "read_only": "false"})
+	_ = p.Configure(context.Background(), mcp.Credentials{"connection_string": "host=localhost", "read_only": "false"})
 	assert.False(t, p.readOnly)
 }
 

--- a/integrations/posthog/posthog.go
+++ b/integrations/posthog/posthog.go
@@ -33,7 +33,7 @@ func New() mcp.Integration {
 
 func (p *posthog) Name() string { return "posthog" }
 
-func (p *posthog) Configure(creds mcp.Credentials) error {
+func (p *posthog) Configure(_ context.Context, creds mcp.Credentials) error {
 	p.apiKey = creds["api_key"]
 	p.projectID = creds["project_id"]
 	if p.apiKey == "" {

--- a/integrations/posthog/posthog_test.go
+++ b/integrations/posthog/posthog_test.go
@@ -21,27 +21,27 @@ func TestNew(t *testing.T) {
 
 func TestConfigure_Success(t *testing.T) {
 	i := New()
-	err := i.Configure(mcp.Credentials{"api_key": "phx_test123", "project_id": "12345"})
+	err := i.Configure(context.Background(), mcp.Credentials{"api_key": "phx_test123", "project_id": "12345"})
 	assert.NoError(t, err)
 }
 
 func TestConfigure_MissingAPIKey(t *testing.T) {
 	i := New()
-	err := i.Configure(mcp.Credentials{"api_key": "", "project_id": "12345"})
+	err := i.Configure(context.Background(), mcp.Credentials{"api_key": "", "project_id": "12345"})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "api_key is required")
 }
 
 func TestConfigure_MissingProjectID(t *testing.T) {
 	i := New()
-	err := i.Configure(mcp.Credentials{"api_key": "phx_test123", "project_id": ""})
+	err := i.Configure(context.Background(), mcp.Credentials{"api_key": "phx_test123", "project_id": ""})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "project_id is required")
 }
 
 func TestConfigure_CustomBaseURL(t *testing.T) {
 	p := &posthog{client: &http.Client{}, baseURL: "https://us.posthog.com"}
-	err := p.Configure(mcp.Credentials{
+	err := p.Configure(context.Background(), mcp.Credentials{
 		"api_key":    "phx_test",
 		"project_id": "1",
 		"base_url":   "https://eu.posthog.com/",

--- a/integrations/rwx/rwx.go
+++ b/integrations/rwx/rwx.go
@@ -42,7 +42,7 @@ func New() mcp.Integration {
 
 func (r *rwx) Name() string { return "rwx" }
 
-func (r *rwx) Configure(creds mcp.Credentials) error {
+func (r *rwx) Configure(_ context.Context, creds mcp.Credentials) error {
 	r.accessToken = creds["access_token"]
 	if r.accessToken == "" {
 		return fmt.Errorf("rwx: access_token is required")

--- a/integrations/rwx/rwx_test.go
+++ b/integrations/rwx/rwx_test.go
@@ -21,13 +21,13 @@ func TestNew(t *testing.T) {
 
 func TestConfigure_Success(t *testing.T) {
 	i := New()
-	err := i.Configure(mcp.Credentials{"access_token": "rwx_test_token"})
+	err := i.Configure(context.Background(), mcp.Credentials{"access_token": "rwx_test_token"})
 	assert.NoError(t, err)
 }
 
 func TestConfigure_MissingAccessToken(t *testing.T) {
 	i := New()
-	err := i.Configure(mcp.Credentials{"access_token": ""})
+	err := i.Configure(context.Background(), mcp.Credentials{"access_token": ""})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "access_token is required")
 }

--- a/integrations/sentry/sentry.go
+++ b/integrations/sentry/sentry.go
@@ -30,7 +30,7 @@ func New() mcp.Integration {
 
 func (s *sentry) Name() string { return "sentry" }
 
-func (s *sentry) Configure(creds mcp.Credentials) error {
+func (s *sentry) Configure(_ context.Context, creds mcp.Credentials) error {
 	s.authToken = creds["auth_token"]
 	s.organization = creds["organization"]
 	if s.authToken == "" {

--- a/integrations/sentry/sentry_test.go
+++ b/integrations/sentry/sentry_test.go
@@ -21,27 +21,27 @@ func TestNew(t *testing.T) {
 
 func TestConfigure_Success(t *testing.T) {
 	i := New()
-	err := i.Configure(mcp.Credentials{"auth_token": "sntrys_test", "organization": "my-org"})
+	err := i.Configure(context.Background(), mcp.Credentials{"auth_token": "sntrys_test", "organization": "my-org"})
 	assert.NoError(t, err)
 }
 
 func TestConfigure_MissingAuthToken(t *testing.T) {
 	i := New()
-	err := i.Configure(mcp.Credentials{"auth_token": "", "organization": "my-org"})
+	err := i.Configure(context.Background(), mcp.Credentials{"auth_token": "", "organization": "my-org"})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "auth_token is required")
 }
 
 func TestConfigure_MissingOrganization(t *testing.T) {
 	i := New()
-	err := i.Configure(mcp.Credentials{"auth_token": "token", "organization": ""})
+	err := i.Configure(context.Background(), mcp.Credentials{"auth_token": "token", "organization": ""})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "organization is required")
 }
 
 func TestConfigure_CustomBaseURL(t *testing.T) {
 	s := &sentry{client: &http.Client{}, baseURL: "https://sentry.io/api/0"}
-	err := s.Configure(mcp.Credentials{
+	err := s.Configure(context.Background(), mcp.Credentials{
 		"auth_token":   "token",
 		"organization": "org",
 		"base_url":     "https://custom.sentry.io/api/0/",

--- a/integrations/slack/slack.go
+++ b/integrations/slack/slack.go
@@ -28,7 +28,7 @@ func New() mcp.Integration {
 
 func (s *slackIntegration) Name() string { return "slack" }
 
-func (s *slackIntegration) Configure(creds mcp.Credentials) error {
+func (s *slackIntegration) Configure(_ context.Context, creds mcp.Credentials) error {
 	s.store = newTokenStore()
 
 	// Seed the store from config credentials if present.

--- a/mcp.go
+++ b/mcp.go
@@ -79,7 +79,7 @@ type Integration interface {
 	Name() string
 
 	// Configure initializes the integration with credentials.
-	Configure(creds Credentials) error
+	Configure(ctx context.Context, creds Credentials) error
 
 	// Tools returns the tool definitions this integration provides.
 	// Used by the search tool for progressive discovery.

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -16,7 +16,7 @@ type mockIntegration struct {
 }
 
 func (m *mockIntegration) Name() string                      { return m.name }
-func (m *mockIntegration) Configure(_ mcp.Credentials) error { return nil }
+func (m *mockIntegration) Configure(_ context.Context, _ mcp.Credentials) error { return nil }
 func (m *mockIntegration) Tools() []mcp.ToolDefinition       { return m.tools }
 func (m *mockIntegration) Execute(_ context.Context, _ string, _ map[string]any) (*mcp.ToolResult, error) {
 	return &mcp.ToolResult{Data: "ok"}, nil

--- a/server/server.go
+++ b/server/server.go
@@ -170,7 +170,7 @@ func (s *Server) configureIntegrations() {
 			continue
 		}
 
-		if err := integration.Configure(ic.Credentials); err != nil {
+		if err := integration.Configure(context.Background(), ic.Credentials); err != nil {
 			log.Printf("WARN: failed to configure %q: %v", name, err)
 			continue
 		}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -55,7 +55,7 @@ type mockIntegration struct {
 }
 
 func (m *mockIntegration) Name() string { return m.name }
-func (m *mockIntegration) Configure(_ mcp.Credentials) error {
+func (m *mockIntegration) Configure(_ context.Context, _ mcp.Credentials) error {
 	return m.configErr
 }
 func (m *mockIntegration) Tools() []mcp.ToolDefinition { return m.tools }

--- a/web/health_cache.go
+++ b/web/health_cache.go
@@ -55,7 +55,7 @@ func (hc *healthCache) refreshAll(ctx context.Context) {
 
 			var healthy bool
 			if exists {
-				if err := a.Configure(ic.Credentials); err == nil {
+				if err := a.Configure(ctx, ic.Credentials); err == nil {
 					healthy = a.Healthy(ctx)
 					if healthy && !enabled {
 						enabled = true

--- a/web/web.go
+++ b/web/web.go
@@ -198,7 +198,7 @@ func (w *WebServer) handleIntegrationDetail(rw http.ResponseWriter, r *http.Requ
 
 	var healthy bool
 	if exists && enabled {
-		if err := integration.Configure(ic.Credentials); err == nil {
+		if err := integration.Configure(r.Context(), ic.Credentials); err == nil {
 			healthy = integration.Healthy(r.Context())
 		}
 	}
@@ -298,7 +298,7 @@ func (w *WebServer) handleSlackSetup(rw http.ResponseWriter, r *http.Request) {
 	if info.HasToken {
 		integration, ok := w.services.Registry.Get("slack")
 		if ok && exists {
-			if err := integration.Configure(ic.Credentials); err == nil {
+			if err := integration.Configure(r.Context(), ic.Credentials); err == nil {
 				healthy = integration.Healthy(r.Context())
 			}
 		}
@@ -389,7 +389,7 @@ func (w *WebServer) handleGitHubSetup(rw http.ResponseWriter, r *http.Request) {
 	if hasToken {
 		integration, ok := w.services.Registry.Get("github")
 		if ok {
-			if err := integration.Configure(ic.Credentials); err == nil {
+			if err := integration.Configure(r.Context(), ic.Credentials); err == nil {
 				healthy = integration.Healthy(r.Context())
 			}
 		}
@@ -499,7 +499,7 @@ func (w *WebServer) handleLinearSetup(rw http.ResponseWriter, r *http.Request) {
 	if hasToken {
 		integration, ok := w.services.Registry.Get("linear")
 		if ok {
-			if err := integration.Configure(ic.Credentials); err == nil {
+			if err := integration.Configure(r.Context(), ic.Credentials); err == nil {
 				healthy = integration.Healthy(r.Context())
 			}
 		}
@@ -627,7 +627,7 @@ func (w *WebServer) handleSentrySetup(rw http.ResponseWriter, r *http.Request) {
 	if hasToken {
 		integration, ok := w.services.Registry.Get("sentry")
 		if ok {
-			if err := integration.Configure(ic.Credentials); err == nil {
+			if err := integration.Configure(r.Context(), ic.Credentials); err == nil {
 				healthy = integration.Healthy(r.Context())
 			}
 		}
@@ -794,7 +794,7 @@ func (w *WebServer) handleNotionSetup(rw http.ResponseWriter, r *http.Request) {
 	if hasToken {
 		integration, ok := w.services.Registry.Get("notion")
 		if ok {
-			if err := integration.Configure(ic.Credentials); err == nil {
+			if err := integration.Configure(r.Context(), ic.Credentials); err == nil {
 				healthy = integration.Healthy(r.Context())
 			}
 		}
@@ -915,7 +915,7 @@ func (w *WebServer) handleGmailSetup(rw http.ResponseWriter, r *http.Request) {
 	if hasToken {
 		integration, ok := w.services.Registry.Get("gmail")
 		if ok {
-			if err := integration.Configure(ic.Credentials); err == nil {
+			if err := integration.Configure(r.Context(), ic.Credentials); err == nil {
 				healthy = integration.Healthy(r.Context())
 			}
 		}

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -53,7 +53,7 @@ type mockIntegration struct {
 }
 
 func (mi *mockIntegration) Name() string                      { return mi.name }
-func (mi *mockIntegration) Configure(_ mcp.Credentials) error { return nil }
+func (mi *mockIntegration) Configure(_ context.Context, _ mcp.Credentials) error { return nil }
 func (mi *mockIntegration) Tools() []mcp.ToolDefinition       { return mi.tools }
 func (mi *mockIntegration) Execute(_ context.Context, _ string, _ map[string]any) (*mcp.ToolResult, error) {
 	return &mcp.ToolResult{Data: "ok"}, nil


### PR DESCRIPTION
Just threading the context into the `Configure` interface.