### PR TITLE
Add missing CRUD and management tools to Readarr integration

### DIFF
--- a/integrations/readarr/authors.go
+++ b/integrations/readarr/authors.go
@@ -2,6 +2,7 @@ package readarr
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	mcp "github.com/daltoniam/switchboard"
@@ -25,6 +26,142 @@ func getAuthor(ctx context.Context, r *readarr, args map[string]any) (*mcp.ToolR
 		return mcp.ErrResult(fmt.Errorf("id is required"))
 	}
 	data, err := r.get(ctx, "/api/v1/author/%d", id)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func addAuthor(ctx context.Context, r *readarr, args map[string]any) (*mcp.ToolResult, error) {
+	a := mcp.NewArgs(args)
+	foreignAuthorID := a.Str("foreign_author_id")
+	rootFolderPath := a.Str("root_folder_path")
+	qualityProfileID := a.OptInt("quality_profile_id", 1)
+	metadataProfileID := a.OptInt("metadata_profile_id", 1)
+	monitored := a.Bool("monitored")
+	monitor := a.Str("monitor")
+	searchForMissing := a.Bool("search_for_missing_books")
+	if err := a.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if foreignAuthorID == "" {
+		return mcp.ErrResult(fmt.Errorf("foreign_author_id is required"))
+	}
+	if rootFolderPath == "" {
+		return mcp.ErrResult(fmt.Errorf("root_folder_path is required"))
+	}
+
+	if _, ok := args["monitored"]; !ok {
+		monitored = true
+	}
+	if monitor == "" {
+		monitor = "all"
+	}
+
+	body := map[string]any{
+		"foreignAuthorId":   foreignAuthorID,
+		"qualityProfileId":  qualityProfileID,
+		"metadataProfileId": metadataProfileID,
+		"rootFolderPath":    rootFolderPath,
+		"monitored":         monitored,
+		"monitorNewItems":   "all",
+		"addOptions": map[string]any{
+			"monitor":               monitor,
+			"searchForMissingBooks": searchForMissing,
+		},
+	}
+	data, err := r.post(ctx, "/api/v1/author", body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func updateAuthor(ctx context.Context, r *readarr, args map[string]any) (*mcp.ToolResult, error) {
+	a := mcp.NewArgs(args)
+	id := a.Int("id")
+	if err := a.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if id == 0 {
+		return mcp.ErrResult(fmt.Errorf("id is required"))
+	}
+
+	existing, err := r.get(ctx, "/api/v1/author/%d", id)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	var author map[string]any
+	if err := json.Unmarshal(existing, &author); err != nil {
+		return mcp.ErrResult(fmt.Errorf("failed to parse author: %w", err))
+	}
+
+	if v, ok := args["monitored"]; ok {
+		b, err := mcp.ArgBool(args, "monitored")
+		if err != nil {
+			return mcp.ErrResult(err)
+		}
+		_ = v
+		author["monitored"] = b
+	}
+	if v, ok := args["quality_profile_id"]; ok {
+		_ = v
+		qp, err := mcp.ArgInt(args, "quality_profile_id")
+		if err != nil {
+			return mcp.ErrResult(err)
+		}
+		author["qualityProfileId"] = qp
+	}
+	if v, ok := args["metadata_profile_id"]; ok {
+		_ = v
+		mp, err := mcp.ArgInt(args, "metadata_profile_id")
+		if err != nil {
+			return mcp.ErrResult(err)
+		}
+		author["metadataProfileId"] = mp
+	}
+	if v, ok := args["path"]; ok {
+		_ = v
+		p, err := mcp.ArgStr(args, "path")
+		if err != nil {
+			return mcp.ErrResult(err)
+		}
+		author["path"] = p
+	}
+
+	moveFiles := a.Bool("move_files")
+	params := map[string]string{}
+	if moveFiles {
+		params["moveFiles"] = "true"
+	}
+
+	data, err := r.put(ctx, fmt.Sprintf("/api/v1/author/%d%s", id, queryEncode(params)), author)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func deleteAuthor(ctx context.Context, r *readarr, args map[string]any) (*mcp.ToolResult, error) {
+	a := mcp.NewArgs(args)
+	id := a.Int("id")
+	deleteFiles := a.Bool("delete_files")
+	addExclusion := a.Bool("add_import_list_exclusion")
+	if err := a.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if id == 0 {
+		return mcp.ErrResult(fmt.Errorf("id is required"))
+	}
+	params := map[string]string{}
+	if deleteFiles {
+		params["deleteFiles"] = "true"
+	}
+	if addExclusion {
+		params["addImportListExclusion"] = "true"
+	}
+	data, err := r.delWithQuery(ctx, fmt.Sprintf("/api/v1/author/%d%s", id, queryEncode(params)))
 	if err != nil {
 		return mcp.ErrResult(err)
 	}

--- a/integrations/readarr/books.go
+++ b/integrations/readarr/books.go
@@ -97,3 +97,79 @@ func monitorBooks(ctx context.Context, r *readarr, args map[string]any) (*mcp.To
 	}
 	return mcp.RawResult(data)
 }
+
+func addBook(ctx context.Context, r *readarr, args map[string]any) (*mcp.ToolResult, error) {
+	a := mcp.NewArgs(args)
+	foreignBookID := a.Str("foreign_book_id")
+	foreignAuthorID := a.Str("foreign_author_id")
+	rootFolderPath := a.Str("root_folder_path")
+	qualityProfileID := a.OptInt("quality_profile_id", 1)
+	metadataProfileID := a.OptInt("metadata_profile_id", 1)
+	monitored := a.Bool("monitored")
+	searchForBook := a.Bool("search_for_book")
+	if err := a.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if foreignBookID == "" {
+		return mcp.ErrResult(fmt.Errorf("foreign_book_id is required"))
+	}
+	if foreignAuthorID == "" {
+		return mcp.ErrResult(fmt.Errorf("foreign_author_id is required"))
+	}
+	if rootFolderPath == "" {
+		return mcp.ErrResult(fmt.Errorf("root_folder_path is required"))
+	}
+
+	// Default monitored to true if not explicitly set
+	if _, ok := args["monitored"]; !ok {
+		monitored = true
+	}
+
+	body := map[string]any{
+		"foreignBookId": foreignBookID,
+		"monitored":     monitored,
+		"editions": []map[string]any{{
+			"foreignEditionId": "0",
+			"monitored":        true,
+		}},
+		"author": map[string]any{
+			"foreignAuthorId":   foreignAuthorID,
+			"qualityProfileId":  qualityProfileID,
+			"metadataProfileId": metadataProfileID,
+			"rootFolderPath":    rootFolderPath,
+		},
+		"addOptions": map[string]any{
+			"searchForNewBook": searchForBook,
+		},
+	}
+	data, err := r.post(ctx, "/api/v1/book", body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func deleteBook(ctx context.Context, r *readarr, args map[string]any) (*mcp.ToolResult, error) {
+	a := mcp.NewArgs(args)
+	id := a.Int("id")
+	deleteFiles := a.Bool("delete_files")
+	addExclusion := a.Bool("add_import_list_exclusion")
+	if err := a.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if id == 0 {
+		return mcp.ErrResult(fmt.Errorf("id is required"))
+	}
+	params := map[string]string{}
+	if deleteFiles {
+		params["deleteFiles"] = "true"
+	}
+	if addExclusion {
+		params["addImportListExclusion"] = "true"
+	}
+	data, err := r.delWithQuery(ctx, fmt.Sprintf("/api/v1/book/%d%s", id, queryEncode(params)))
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}

--- a/integrations/readarr/compact_specs.go
+++ b/integrations/readarr/compact_specs.go
@@ -90,6 +90,28 @@ var rawFieldCompactionSpecs = map[string][]string{
 	"readarr_list_tags": {
 		"id", "label",
 	},
+	"readarr_list_book_files": {
+		"id", "path", "size", "quality.quality.name",
+		"bookId", "authorId",
+	},
+	"readarr_list_blocklist": {
+		"records[].id", "records[].authorId", "records[].bookIds",
+		"records[].sourceTitle", "records[].date",
+		"page", "pageSize", "totalRecords",
+	},
+	"readarr_get_rename": {
+		"bookId", "bookFileId", "existingPath", "newPath",
+	},
+	"readarr_get_retag": {
+		"bookId", "bookFileId", "path",
+		"changes[].field", "changes[].oldValue", "changes[].newValue",
+	},
+	"readarr_get_manual_import": {
+		"id", "path", "name", "size",
+		"author.id", "author.authorName",
+		"book.id", "book.title",
+		"quality.quality.name", "rejections",
+	},
 }
 
 var fieldCompactionSpecs = mustBuildFieldCompactionSpecs(rawFieldCompactionSpecs)

--- a/integrations/readarr/readarr.go
+++ b/integrations/readarr/readarr.go
@@ -164,10 +164,15 @@ var dispatch = map[string]handlerFunc{
 	"readarr_get_book":      getBook,
 	"readarr_search_books":  searchBooks,
 	"readarr_monitor_books": monitorBooks,
+	"readarr_add_book":      addBook,
+	"readarr_delete_book":   deleteBook,
 
 	// Authors
-	"readarr_list_authors": listAuthors,
-	"readarr_get_author":   getAuthor,
+	"readarr_list_authors":  listAuthors,
+	"readarr_get_author":    getAuthor,
+	"readarr_add_author":    addAuthor,
+	"readarr_update_author": updateAuthor,
+	"readarr_delete_author": deleteAuthor,
 
 	// Calendar
 	"readarr_get_calendar": getCalendar,
@@ -186,6 +191,7 @@ var dispatch = map[string]handlerFunc{
 	"readarr_get_history":        getHistory,
 	"readarr_get_history_author": getHistoryAuthor,
 	"readarr_get_history_since":  getHistorySince,
+	"readarr_mark_failed":        markFailed,
 
 	// Commands
 	"readarr_list_commands": listCommands,
@@ -205,5 +211,22 @@ var dispatch = map[string]handlerFunc{
 	"readarr_list_metadata_profiles": listMetadataProfiles,
 
 	// Tags
-	"readarr_list_tags": listTags,
+	"readarr_list_tags":  listTags,
+	"readarr_create_tag": createTag,
+	"readarr_delete_tag": deleteTag,
+
+	// Book Files
+	"readarr_list_book_files":  listBookFiles,
+	"readarr_delete_book_file": deleteBookFile,
+
+	// Blocklist
+	"readarr_list_blocklist":        listBlocklist,
+	"readarr_delete_blocklist_item": deleteBlocklistItem,
+
+	// Rename / Retag
+	"readarr_get_rename": getRename,
+	"readarr_get_retag":  getRetag,
+
+	// Manual Import
+	"readarr_get_manual_import": getManualImport,
 }

--- a/integrations/readarr/readarr_test.go
+++ b/integrations/readarr/readarr_test.go
@@ -720,3 +720,335 @@ func TestErrResult(t *testing.T) {
 	assert.True(t, result.IsError)
 	assert.Equal(t, "test error", result.Data)
 }
+
+// --- New tool handler tests ---
+
+func TestAddBook(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/book", r.URL.Path)
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		assert.Equal(t, "12345", body["foreignBookId"])
+		assert.Equal(t, true, body["monitored"])
+		_, _ = w.Write([]byte(`{"id":1,"title":"New Book"}`))
+	}))
+	defer ts.Close()
+
+	ra := &readarr{apiKey: "key", client: ts.Client(), baseURL: ts.URL}
+	result, err := ra.Execute(context.Background(), "readarr_add_book", map[string]any{
+		"foreign_book_id":   "12345",
+		"foreign_author_id": "67890",
+		"root_folder_path":  "/books",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "New Book")
+}
+
+func TestAddBook_MissingFields(t *testing.T) {
+	ra := &readarr{apiKey: "key", baseURL: "http://localhost", client: &http.Client{}}
+	result, err := ra.Execute(context.Background(), "readarr_add_book", map[string]any{})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "foreign_book_id is required")
+}
+
+func TestDeleteBook(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method)
+		assert.Contains(t, r.URL.Path, "/api/v1/book/1")
+		w.WriteHeader(204)
+	}))
+	defer ts.Close()
+
+	ra := &readarr{apiKey: "key", client: ts.Client(), baseURL: ts.URL}
+	result, err := ra.Execute(context.Background(), "readarr_delete_book", map[string]any{"id": float64(1)})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+}
+
+func TestDeleteBook_WithOptions(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.RawQuery, "deleteFiles=true")
+		w.WriteHeader(204)
+	}))
+	defer ts.Close()
+
+	ra := &readarr{apiKey: "key", client: ts.Client(), baseURL: ts.URL}
+	result, err := ra.Execute(context.Background(), "readarr_delete_book", map[string]any{
+		"id": float64(1), "delete_files": true,
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+}
+
+func TestAddAuthor(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/author", r.URL.Path)
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		assert.Equal(t, "12345", body["foreignAuthorId"])
+		assert.Equal(t, true, body["monitored"])
+		_, _ = w.Write([]byte(`{"id":1,"authorName":"New Author"}`))
+	}))
+	defer ts.Close()
+
+	ra := &readarr{apiKey: "key", client: ts.Client(), baseURL: ts.URL}
+	result, err := ra.Execute(context.Background(), "readarr_add_author", map[string]any{
+		"foreign_author_id": "12345",
+		"root_folder_path":  "/books",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "New Author")
+}
+
+func TestAddAuthor_MissingFields(t *testing.T) {
+	ra := &readarr{apiKey: "key", baseURL: "http://localhost", client: &http.Client{}}
+	result, err := ra.Execute(context.Background(), "readarr_add_author", map[string]any{})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "foreign_author_id is required")
+}
+
+func TestUpdateAuthor(t *testing.T) {
+	callCount := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if r.Method == "GET" {
+			_, _ = w.Write([]byte(`{"id":1,"authorName":"Author","monitored":true,"qualityProfileId":1}`))
+			return
+		}
+		assert.Equal(t, "PUT", r.Method)
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		assert.Equal(t, false, body["monitored"])
+		_, _ = w.Write([]byte(`{"id":1,"authorName":"Author","monitored":false}`))
+	}))
+	defer ts.Close()
+
+	ra := &readarr{apiKey: "key", client: ts.Client(), baseURL: ts.URL}
+	result, err := ra.Execute(context.Background(), "readarr_update_author", map[string]any{
+		"id": float64(1), "monitored": false,
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "false")
+}
+
+func TestUpdateAuthor_MissingID(t *testing.T) {
+	ra := &readarr{apiKey: "key", baseURL: "http://localhost", client: &http.Client{}}
+	result, err := ra.Execute(context.Background(), "readarr_update_author", map[string]any{})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "id is required")
+}
+
+func TestDeleteAuthor(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method)
+		assert.Contains(t, r.URL.Path, "/api/v1/author/1")
+		w.WriteHeader(204)
+	}))
+	defer ts.Close()
+
+	ra := &readarr{apiKey: "key", client: ts.Client(), baseURL: ts.URL}
+	result, err := ra.Execute(context.Background(), "readarr_delete_author", map[string]any{"id": float64(1)})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+}
+
+func TestDeleteAuthor_MissingID(t *testing.T) {
+	ra := &readarr{apiKey: "key", baseURL: "http://localhost", client: &http.Client{}}
+	result, err := ra.Execute(context.Background(), "readarr_delete_author", map[string]any{})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "id is required")
+}
+
+func TestCreateTag(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/tag", r.URL.Path)
+		var body map[string]string
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		assert.Equal(t, "scifi", body["label"])
+		_, _ = w.Write([]byte(`{"id":1,"label":"scifi"}`))
+	}))
+	defer ts.Close()
+
+	ra := &readarr{apiKey: "key", client: ts.Client(), baseURL: ts.URL}
+	result, err := ra.Execute(context.Background(), "readarr_create_tag", map[string]any{"label": "scifi"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "scifi")
+}
+
+func TestCreateTag_MissingLabel(t *testing.T) {
+	ra := &readarr{apiKey: "key", baseURL: "http://localhost", client: &http.Client{}}
+	result, err := ra.Execute(context.Background(), "readarr_create_tag", map[string]any{})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "label is required")
+}
+
+func TestDeleteTag(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method)
+		assert.Equal(t, "/api/v1/tag/1", r.URL.Path)
+		w.WriteHeader(204)
+	}))
+	defer ts.Close()
+
+	ra := &readarr{apiKey: "key", client: ts.Client(), baseURL: ts.URL}
+	result, err := ra.Execute(context.Background(), "readarr_delete_tag", map[string]any{"id": float64(1)})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+}
+
+func TestListBookFiles(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Contains(t, r.URL.Path, "/api/v1/bookfile")
+		assert.Contains(t, r.URL.RawQuery, "authorId=1")
+		_, _ = w.Write([]byte(`[{"id":1,"path":"/books/author/book.m4b","size":1024}]`))
+	}))
+	defer ts.Close()
+
+	ra := &readarr{apiKey: "key", client: ts.Client(), baseURL: ts.URL}
+	result, err := ra.Execute(context.Background(), "readarr_list_book_files", map[string]any{"author_id": "1"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "book.m4b")
+}
+
+func TestDeleteBookFile(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method)
+		assert.Equal(t, "/api/v1/bookfile/1", r.URL.Path)
+		w.WriteHeader(204)
+	}))
+	defer ts.Close()
+
+	ra := &readarr{apiKey: "key", client: ts.Client(), baseURL: ts.URL}
+	result, err := ra.Execute(context.Background(), "readarr_delete_book_file", map[string]any{"id": float64(1)})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+}
+
+func TestListBlocklist(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Contains(t, r.URL.Path, "/api/v1/blocklist")
+		_, _ = w.Write([]byte(`{"page":1,"pageSize":20,"totalRecords":1,"records":[{"id":1,"sourceTitle":"Bad Release"}]}`))
+	}))
+	defer ts.Close()
+
+	ra := &readarr{apiKey: "key", client: ts.Client(), baseURL: ts.URL}
+	result, err := ra.Execute(context.Background(), "readarr_list_blocklist", map[string]any{})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "Bad Release")
+}
+
+func TestDeleteBlocklistItem(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method)
+		assert.Equal(t, "/api/v1/blocklist/1", r.URL.Path)
+		w.WriteHeader(204)
+	}))
+	defer ts.Close()
+
+	ra := &readarr{apiKey: "key", client: ts.Client(), baseURL: ts.URL}
+	result, err := ra.Execute(context.Background(), "readarr_delete_blocklist_item", map[string]any{"id": float64(1)})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+}
+
+func TestGetRename(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Contains(t, r.URL.Path, "/api/v1/rename")
+		assert.Contains(t, r.URL.RawQuery, "authorId=1")
+		_, _ = w.Write([]byte(`[{"bookFileId":1,"existingPath":"/old.m4b","newPath":"/new.m4b"}]`))
+	}))
+	defer ts.Close()
+
+	ra := &readarr{apiKey: "key", client: ts.Client(), baseURL: ts.URL}
+	result, err := ra.Execute(context.Background(), "readarr_get_rename", map[string]any{"author_id": float64(1)})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "new.m4b")
+}
+
+func TestGetRename_MissingAuthorID(t *testing.T) {
+	ra := &readarr{apiKey: "key", baseURL: "http://localhost", client: &http.Client{}}
+	result, err := ra.Execute(context.Background(), "readarr_get_rename", map[string]any{})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "author_id is required")
+}
+
+func TestGetRetag(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Contains(t, r.URL.Path, "/api/v1/retag")
+		assert.Contains(t, r.URL.RawQuery, "authorId=1")
+		_, _ = w.Write([]byte(`[{"bookFileId":1,"path":"/book.m4b","changes":[]}]`))
+	}))
+	defer ts.Close()
+
+	ra := &readarr{apiKey: "key", client: ts.Client(), baseURL: ts.URL}
+	result, err := ra.Execute(context.Background(), "readarr_get_retag", map[string]any{"author_id": float64(1)})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "book.m4b")
+}
+
+func TestGetManualImport(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Contains(t, r.URL.Path, "/api/v1/manualimport")
+		assert.Contains(t, r.URL.RawQuery, "folder=")
+		_, _ = w.Write([]byte(`[{"id":1,"path":"/incoming/book.m4b","name":"book.m4b"}]`))
+	}))
+	defer ts.Close()
+
+	ra := &readarr{apiKey: "key", client: ts.Client(), baseURL: ts.URL}
+	result, err := ra.Execute(context.Background(), "readarr_get_manual_import", map[string]any{"folder": "/incoming"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "book.m4b")
+}
+
+func TestGetManualImport_MissingFolder(t *testing.T) {
+	ra := &readarr{apiKey: "key", baseURL: "http://localhost", client: &http.Client{}}
+	result, err := ra.Execute(context.Background(), "readarr_get_manual_import", map[string]any{})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "folder is required")
+}
+
+func TestMarkFailed(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/history/failed/1", r.URL.Path)
+		w.WriteHeader(204)
+	}))
+	defer ts.Close()
+
+	ra := &readarr{apiKey: "key", client: ts.Client(), baseURL: ts.URL}
+	result, err := ra.Execute(context.Background(), "readarr_mark_failed", map[string]any{"id": float64(1)})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+}
+
+func TestMarkFailed_MissingID(t *testing.T) {
+	ra := &readarr{apiKey: "key", baseURL: "http://localhost", client: &http.Client{}}
+	result, err := ra.Execute(context.Background(), "readarr_mark_failed", map[string]any{})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "id is required")
+}

--- a/integrations/readarr/system.go
+++ b/integrations/readarr/system.go
@@ -3,6 +3,7 @@ package readarr
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	mcp "github.com/daltoniam/switchboard"
 )
@@ -90,6 +91,198 @@ func listMetadataProfiles(ctx context.Context, r *readarr, _ map[string]any) (*m
 
 func listTags(ctx context.Context, r *readarr, _ map[string]any) (*mcp.ToolResult, error) {
 	data, err := r.get(ctx, "/api/v1/tag")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func createTag(ctx context.Context, r *readarr, args map[string]any) (*mcp.ToolResult, error) {
+	a := mcp.NewArgs(args)
+	label := a.Str("label")
+	if err := a.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if label == "" {
+		return mcp.ErrResult(fmt.Errorf("label is required"))
+	}
+	data, err := r.post(ctx, "/api/v1/tag", map[string]string{"label": label})
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func deleteTag(ctx context.Context, r *readarr, args map[string]any) (*mcp.ToolResult, error) {
+	a := mcp.NewArgs(args)
+	id := a.Int("id")
+	if err := a.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if id == 0 {
+		return mcp.ErrResult(fmt.Errorf("id is required"))
+	}
+	data, err := r.delWithQuery(ctx, fmt.Sprintf("/api/v1/tag/%d", id))
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func listBookFiles(ctx context.Context, r *readarr, args map[string]any) (*mcp.ToolResult, error) {
+	a := mcp.NewArgs(args)
+	authorID := a.Str("author_id")
+	bookID := a.Str("book_id")
+	if err := a.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	params := map[string]string{}
+	if authorID != "" {
+		params["authorId"] = authorID
+	}
+	if bookID != "" {
+		params["bookId"] = bookID
+	}
+	data, err := r.get(ctx, "/api/v1/bookfile%s", queryEncode(params))
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func deleteBookFile(ctx context.Context, r *readarr, args map[string]any) (*mcp.ToolResult, error) {
+	a := mcp.NewArgs(args)
+	id := a.Int("id")
+	if err := a.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if id == 0 {
+		return mcp.ErrResult(fmt.Errorf("id is required"))
+	}
+	data, err := r.delWithQuery(ctx, fmt.Sprintf("/api/v1/bookfile/%d", id))
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func listBlocklist(ctx context.Context, r *readarr, args map[string]any) (*mcp.ToolResult, error) {
+	a := mcp.NewArgs(args)
+	page := a.OptInt("page", 1)
+	pageSize := a.OptInt("page_size", 20)
+	sortKey := a.Str("sort_key")
+	sortDir := a.Str("sort_direction")
+	if err := a.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	params := map[string]string{
+		"page":     strconv.Itoa(page),
+		"pageSize": strconv.Itoa(pageSize),
+	}
+	if sortKey != "" {
+		params["sortKey"] = sortKey
+	}
+	if sortDir != "" {
+		params["sortDirection"] = sortDir
+	}
+	data, err := r.get(ctx, "/api/v1/blocklist%s", queryEncode(params))
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func deleteBlocklistItem(ctx context.Context, r *readarr, args map[string]any) (*mcp.ToolResult, error) {
+	a := mcp.NewArgs(args)
+	id := a.Int("id")
+	if err := a.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if id == 0 {
+		return mcp.ErrResult(fmt.Errorf("id is required"))
+	}
+	data, err := r.delWithQuery(ctx, fmt.Sprintf("/api/v1/blocklist/%d", id))
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func getRename(ctx context.Context, r *readarr, args map[string]any) (*mcp.ToolResult, error) {
+	a := mcp.NewArgs(args)
+	authorID := a.Int("author_id")
+	bookID := a.Int("book_id")
+	if err := a.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if authorID == 0 {
+		return mcp.ErrResult(fmt.Errorf("author_id is required"))
+	}
+	params := map[string]string{"authorId": strconv.Itoa(authorID)}
+	if bookID != 0 {
+		params["bookId"] = strconv.Itoa(bookID)
+	}
+	data, err := r.get(ctx, "/api/v1/rename%s", queryEncode(params))
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func getRetag(ctx context.Context, r *readarr, args map[string]any) (*mcp.ToolResult, error) {
+	a := mcp.NewArgs(args)
+	authorID := a.Int("author_id")
+	bookID := a.Int("book_id")
+	if err := a.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if authorID == 0 {
+		return mcp.ErrResult(fmt.Errorf("author_id is required"))
+	}
+	params := map[string]string{"authorId": strconv.Itoa(authorID)}
+	if bookID != 0 {
+		params["bookId"] = strconv.Itoa(bookID)
+	}
+	data, err := r.get(ctx, "/api/v1/retag%s", queryEncode(params))
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func getManualImport(ctx context.Context, r *readarr, args map[string]any) (*mcp.ToolResult, error) {
+	a := mcp.NewArgs(args)
+	folder := a.Str("folder")
+	filterExisting := a.Str("filter_existing_files")
+	if err := a.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if folder == "" {
+		return mcp.ErrResult(fmt.Errorf("folder is required"))
+	}
+	params := map[string]string{"folder": folder}
+	if filterExisting == "" {
+		params["filterExistingFiles"] = "true"
+	} else {
+		params["filterExistingFiles"] = filterExisting
+	}
+	data, err := r.get(ctx, "/api/v1/manualimport%s", queryEncode(params))
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func markFailed(ctx context.Context, r *readarr, args map[string]any) (*mcp.ToolResult, error) {
+	a := mcp.NewArgs(args)
+	id := a.Int("id")
+	if err := a.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if id == 0 {
+		return mcp.ErrResult(fmt.Errorf("id is required"))
+	}
+	data, err := r.post(ctx, fmt.Sprintf("/api/v1/history/failed/%d", id), nil)
 	if err != nil {
 		return mcp.ErrResult(err)
 	}

--- a/integrations/readarr/tools.go
+++ b/integrations/readarr/tools.go
@@ -24,6 +24,17 @@ var tools = []mcp.ToolDefinition{
 		Required:   []string{"book_ids"},
 	},
 
+	{
+		Name: "readarr_add_book", Description: "Add a book to the Readarr library from search results. Use search_books first to get the foreign_book_id. The book's author must already exist in Readarr or will be created.",
+		Parameters: map[string]string{"foreign_book_id": "Foreign book ID from search results", "foreign_author_id": "Foreign author ID from search results", "quality_profile_id": "Quality profile ID (use list_quality_profiles, default 1)", "metadata_profile_id": "Metadata profile ID (use list_metadata_profiles, default 1)", "root_folder_path": "Root folder path (use list_root_folders)", "monitored": "Whether to monitor the book (true/false, default true)", "search_for_book": "Trigger automatic search after adding (true/false, default false)"},
+		Required:   []string{"foreign_book_id", "foreign_author_id", "root_folder_path"},
+	},
+	{
+		Name: "readarr_delete_book", Description: "Delete a book from the Readarr library. Can optionally delete files and add to import exclusion list.",
+		Parameters: map[string]string{"id": "Book ID (integer)", "delete_files": "Delete book files from disk (true/false, default false)", "add_import_list_exclusion": "Add to import exclusion list (true/false, default false)"},
+		Required:   []string{"id"},
+	},
+
 	// ── Authors ─────────────────────────────────────────────────────
 	{
 		Name: "readarr_list_authors", Description: "List all authors in the Readarr library. Shows monitored authors, book counts, and quality profiles.",
@@ -32,6 +43,21 @@ var tools = []mcp.ToolDefinition{
 	{
 		Name: "readarr_get_author", Description: "Get details of a specific author by ID, including books, statistics, and metadata. Use after list_authors.",
 		Parameters: map[string]string{"id": "Author ID (integer)"},
+		Required:   []string{"id"},
+	},
+	{
+		Name: "readarr_add_author", Description: "Add an author to the Readarr library from search results. Use search_books first to get the foreign_author_id. All of the author's books will be added based on the metadata profile.",
+		Parameters: map[string]string{"foreign_author_id": "Foreign author ID from search results", "quality_profile_id": "Quality profile ID (use list_quality_profiles, default 1)", "metadata_profile_id": "Metadata profile ID (use list_metadata_profiles, default 1)", "root_folder_path": "Root folder path (use list_root_folders)", "monitored": "Whether to monitor the author (true/false, default true)", "monitor": "Which books to monitor: all, future, missing, existing, first, latest, none (default all)", "search_for_missing_books": "Trigger automatic search for missing books after adding (true/false, default false)"},
+		Required:   []string{"foreign_author_id", "root_folder_path"},
+	},
+	{
+		Name: "readarr_update_author", Description: "Update an author's settings in Readarr (monitoring, quality profile, path). Get the author first, modify fields, and pass the full JSON body.",
+		Parameters: map[string]string{"id": "Author ID (integer)", "monitored": "Whether to monitor the author (true/false)", "quality_profile_id": "Quality profile ID", "metadata_profile_id": "Metadata profile ID", "path": "Author folder path", "move_files": "Move files to new path when path changes (true/false, default false)"},
+		Required:   []string{"id"},
+	},
+	{
+		Name: "readarr_delete_author", Description: "Delete an author and optionally their files from the Readarr library.",
+		Parameters: map[string]string{"id": "Author ID (integer)", "delete_files": "Delete author folder and files from disk (true/false, default false)", "add_import_list_exclusion": "Add to import exclusion list (true/false, default false)"},
 		Required:   []string{"id"},
 	},
 
@@ -132,5 +158,63 @@ var tools = []mcp.ToolDefinition{
 	{
 		Name: "readarr_list_tags", Description: "List all tags used to organize and filter books and authors in Readarr.",
 		Parameters: map[string]string{},
+	},
+	{
+		Name: "readarr_create_tag", Description: "Create a new tag for organizing books and authors in Readarr.",
+		Parameters: map[string]string{"label": "Tag label name"},
+		Required:   []string{"label"},
+	},
+	{
+		Name: "readarr_delete_tag", Description: "Delete a tag from Readarr by ID.",
+		Parameters: map[string]string{"id": "Tag ID (integer)"},
+		Required:   []string{"id"},
+	},
+
+	// ── Book Files ──────────────────────────────────────────────────
+	{
+		Name: "readarr_list_book_files", Description: "List book files on disk for a specific author or book. Shows file paths, quality, and size. Use to audit library files.",
+		Parameters: map[string]string{"author_id": "Filter by author ID (integer)", "book_id": "Filter by book ID (integer)"},
+	},
+	{
+		Name: "readarr_delete_book_file", Description: "Delete a specific book file from disk. Use after list_book_files to get the file ID.",
+		Parameters: map[string]string{"id": "Book file ID (integer)"},
+		Required:   []string{"id"},
+	},
+
+	// ── Blocklist ───────────────────────────────────────────────────
+	{
+		Name: "readarr_list_blocklist", Description: "List blocklisted releases that Readarr will skip when searching for downloads. Paginated.",
+		Parameters: map[string]string{"page": "Page number (default 1)", "page_size": "Items per page (default 20)", "sort_key": "Sort field", "sort_direction": "Sort direction (asc/desc)"},
+	},
+	{
+		Name: "readarr_delete_blocklist_item", Description: "Remove an item from the blocklist, allowing Readarr to grab that release again.",
+		Parameters: map[string]string{"id": "Blocklist item ID (integer)"},
+		Required:   []string{"id"},
+	},
+
+	// ── Rename / Retag ──────────────────────────────────────────────
+	{
+		Name: "readarr_get_rename", Description: "Preview file rename operations for an author. Shows what files would be renamed based on naming rules.",
+		Parameters: map[string]string{"author_id": "Author ID (integer)", "book_id": "Book ID to filter renames (integer, optional)"},
+		Required:   []string{"author_id"},
+	},
+	{
+		Name: "readarr_get_retag", Description: "Preview file retagging operations for an author. Shows what metadata tags would be updated in audio/ebook files.",
+		Parameters: map[string]string{"author_id": "Author ID (integer)", "book_id": "Book ID to filter retags (integer, optional)"},
+		Required:   []string{"author_id"},
+	},
+
+	// ── Manual Import ───────────────────────────────────────────────
+	{
+		Name: "readarr_get_manual_import", Description: "List files in a folder that can be manually imported into Readarr. Shows unmatched files with suggested book/author matches.",
+		Parameters: map[string]string{"folder": "Folder path to scan for importable files", "filter_existing_files": "Hide files already in library (true/false, default true)"},
+		Required:   []string{"folder"},
+	},
+
+	// ── History ─────────────────────────────────────────────────────
+	{
+		Name: "readarr_mark_failed", Description: "Mark a download history item as failed. Triggers Readarr to search for an alternative release.",
+		Parameters: map[string]string{"id": "History item ID (integer)"},
+		Required:   []string{"id"},
 	},
 }


### PR DESCRIPTION

## Summary

- Add 15 new tools to Readarr integration (24 → 39 total): add/delete books, add/update/delete authors, create/delete tags, list/delete book files, list/delete blocklist items, rename/retag preview, manual import, mark history failed
- Compaction specs for all new read tools (book files, blocklist, rename, retag, manual import)
- Full test coverage for all new handlers including error cases

## Test plan

- [x] `make ci` passes (build, vet, test-race, lint, security)
- [x] Dispatch parity tests pass
- [x] Field compaction orphan spec test passes
- [x] All new handler tests pass with httptest servers


🐨 Generated with Crush