### PR TITLE
Add ACP integration for multi-agent communication

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -33,7 +33,7 @@ func TestLoad_CreatesDefaultWhenMissing(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Len(t, m.cfg.Integrations, 31)
-	for _, name := range []string{"github", "datadog", "linear", "sentry", "slack", "metabase", "aws", "posthog", "postgres", "clickhouse", "elasticsearch", "pganalyze", "rwx", "gmail", "notion", "ynab", "gcp", "suno", "amazon", "jira", "confluence", "readarr", "salesforce", "cloudflare", "digitalocean", "fly", "snowflake", "web", "botidentity", "x"} {
+	for _, name := range []string{"github", "datadog", "linear", "sentry", "slack", "metabase", "aws", "posthog", "postgres", "clickhouse", "elasticsearch", "pganalyze", "rwx", "gmail", "notion", "ynab", "gcp", "suno", "amazon", "jira", "confluence", "readarr", "salesforce", "cloudflare", "digitalocean", "fly", "snowflake", "acp", "web", "botidentity", "x"} {
 		ic, ok := m.cfg.Integrations[name]
 		assert.True(t, ok, "missing default integration: %s", name)
 		assert.False(t, ic.Enabled)

--- a/integrations/acp/acp.go
+++ b/integrations/acp/acp.go
@@ -196,6 +196,7 @@ func handleRunAgent(ctx context.Context, a *acpIntegration, args map[string]any)
 	r := mcp.NewArgs(args)
 	agentName := r.Str("agent_name")
 	input := r.Str("input")
+	sessionID := r.Str("session_id")
 	if err := r.Err(); err != nil {
 		return mcp.ErrResult(err)
 	}
@@ -205,8 +206,6 @@ func handleRunAgent(ctx context.Context, a *acpIntegration, args map[string]any)
 	if input == "" {
 		return mcp.ErrResult(fmt.Errorf("input is required"))
 	}
-
-	sessionID, _ := mcp.ArgStr(args, "session_id")
 
 	c, err := a.resolveClient(args)
 	if err != nil {

--- a/integrations/acp/client.go
+++ b/integrations/acp/client.go
@@ -188,7 +188,7 @@ func (c *client) doStream(ctx context.Context, url string, body any) (<-chan Eve
 		return nil, c.readError(resp)
 	}
 
-	return parseStream(resp.Body), nil
+	return parseStream(ctx, resp.Body), nil
 }
 
 func (c *client) setHeaders(req *http.Request) {
@@ -207,7 +207,7 @@ func (c *client) readError(resp *http.Response) error {
 }
 
 // parseStream reads an NDJSON stream and emits typed events.
-func parseStream(r io.ReadCloser) <-chan Event {
+func parseStream(ctx context.Context, r io.ReadCloser) <-chan Event {
 	ch := make(chan Event, 16)
 	go func() {
 		defer close(ch)
@@ -216,6 +216,12 @@ func parseStream(r io.ReadCloser) <-chan Event {
 		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 
 		for scanner.Scan() {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
 			line := scanner.Text()
 			if line == "" {
 				continue


### PR DESCRIPTION
## Summary

- Add ACP (Agent Communication Protocol) client integration that connects to remote ACP servers to discover and invoke AI agents
- Supports both pre-configured servers (via JSON config credential / `ACP_CONFIG` env var) and inline `server_url`/`server_headers` parameters for dynamic server targeting by the calling MCP client
- Three tools: `acp_list_agents`, `acp_run_agent`, `acp_resume_run` — stream-first with sync fallback, NDJSON event parsing, multi-turn sessions, and awaiting/resume flow

## Test plan

- [x] 46 unit tests covering all handlers, client HTTP, inline server URL, headers, stream/sync modes, awaiting/resume, multi-server, type helpers
- [x] Dispatch map parity tests (all tools covered, no orphans)
- [x] Configure success/failure tests including empty config (optional credentials)
- [x] `make build`, `make vet`, `make test-race`, `make lint`, `make security` all pass


🐙 Generated with [Crush](https://charm.sh/crush)