### PR TITLE
Add RSA key-pair auth, Cortex Analyst, and semantic view support to Snowflake adapter

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -104,15 +104,16 @@ var envMapping = map[string]map[string]string{
 		"api_token": "FLY_API_TOKEN",
 	},
 	"snowflake": {
-		"account":     "SNOWFLAKE_ACCOUNT",
-		"token":       "SNOWFLAKE_TOKEN",
-		"user":        "SNOWFLAKE_USER",
-		"private_key": "SNOWFLAKE_PRIVATE_KEY",
-		"warehouse":   "SNOWFLAKE_WAREHOUSE",
-		"database":    "SNOWFLAKE_DATABASE",
-		"schema":      "SNOWFLAKE_SCHEMA",
-		"role":        "SNOWFLAKE_ROLE",
-		"account_url": "SNOWFLAKE_ACCOUNT_URL",
+		"account":       "SNOWFLAKE_ACCOUNT",
+		"token":         "SNOWFLAKE_TOKEN",
+		"user":          "SNOWFLAKE_USER",
+		"private_key":   "SNOWFLAKE_PRIVATE_KEY",
+		"warehouse":     "SNOWFLAKE_WAREHOUSE",
+		"database":      "SNOWFLAKE_DATABASE",
+		"schema":        "SNOWFLAKE_SCHEMA",
+		"role":          "SNOWFLAKE_ROLE",
+		"semantic_view": "SNOWFLAKE_SEMANTIC_VIEW",
+		"account_url":   "SNOWFLAKE_ACCOUNT_URL",
 	},
 }
 
@@ -264,7 +265,7 @@ func defaultConfig() *mcp.Config {
 			},
 			"snowflake": {
 				Enabled:     false,
-				Credentials: mcp.Credentials{"account": "", "token": "", "user": "", "private_key": "", "warehouse": "", "database": "", "schema": "", "role": "", "account_url": ""},
+				Credentials: mcp.Credentials{"account": "", "token": "", "user": "", "private_key": "", "warehouse": "", "database": "", "schema": "", "role": "", "semantic_view": "", "account_url": ""},
 			},
 		},
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -106,6 +106,8 @@ var envMapping = map[string]map[string]string{
 	"snowflake": {
 		"account":     "SNOWFLAKE_ACCOUNT",
 		"token":       "SNOWFLAKE_TOKEN",
+		"user":        "SNOWFLAKE_USER",
+		"private_key": "SNOWFLAKE_PRIVATE_KEY",
 		"warehouse":   "SNOWFLAKE_WAREHOUSE",
 		"database":    "SNOWFLAKE_DATABASE",
 		"schema":      "SNOWFLAKE_SCHEMA",
@@ -262,7 +264,7 @@ func defaultConfig() *mcp.Config {
 			},
 			"snowflake": {
 				Enabled:     false,
-				Credentials: mcp.Credentials{"account": "", "token": "", "warehouse": "", "database": "", "schema": "", "role": "", "account_url": ""},
+				Credentials: mcp.Credentials{"account": "", "token": "", "user": "", "private_key": "", "warehouse": "", "database": "", "schema": "", "role": "", "account_url": ""},
 			},
 		},
 	}

--- a/integrations/snowflake/cortex.go
+++ b/integrations/snowflake/cortex.go
@@ -1,11 +1,8 @@
 package snowflake
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 
 	mcp "github.com/daltoniam/switchboard"
@@ -82,58 +79,5 @@ func cortexAnalyst(ctx context.Context, s *snowflake, args map[string]any) (*mcp
 }
 
 func (s *snowflake) doAnalystRequest(ctx context.Context, req *analystRequest) (*analystResponse, error) {
-	body, err := json.Marshal(req)
-	if err != nil {
-		return nil, fmt.Errorf("snowflake: marshal analyst request: %w", err)
-	}
-
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, s.baseURL+"/api/v2/cortex/analyst/message", bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("snowflake: create analyst request: %w", err)
-	}
-
-	token, err := s.getToken()
-	if err != nil {
-		return nil, fmt.Errorf("snowflake: get auth token: %w", err)
-	}
-	httpReq.Header.Set("Authorization", "Bearer "+token)
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Accept", "application/json")
-	httpReq.Header.Set("User-Agent", "Switchboard/1.0")
-
-	resp, err := s.client.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("snowflake: analyst request failed: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
-	if err != nil {
-		return nil, fmt.Errorf("snowflake: read analyst response: %w", err)
-	}
-
-	switch {
-	case resp.StatusCode == http.StatusOK:
-		var result analystResponse
-		if err := json.Unmarshal(respBody, &result); err != nil {
-			return nil, fmt.Errorf("snowflake: parse analyst response: %w", err)
-		}
-		return &result, nil
-	case resp.StatusCode == http.StatusUnauthorized:
-		return nil, fmt.Errorf("snowflake: unauthorized (401) — check token")
-	case resp.StatusCode == http.StatusTooManyRequests:
-		retryAfter := mcp.ParseRetryAfter(resp.Header.Get("Retry-After"))
-		return nil, &mcp.RetryableError{
-			StatusCode: resp.StatusCode,
-			Err:        fmt.Errorf("snowflake: analyst rate limited (429)"),
-			RetryAfter: retryAfter,
-		}
-	case resp.StatusCode >= 500:
-		return nil, &mcp.RetryableError{
-			StatusCode: resp.StatusCode,
-			Err:        fmt.Errorf("snowflake: analyst server error (%d): %s", resp.StatusCode, string(respBody)),
-		}
-	default:
-		return nil, fmt.Errorf("snowflake: analyst error (%d): %s", resp.StatusCode, string(respBody))
-	}
+	return doJSON[analystResponse](ctx, s, http.MethodPost, "/api/v2/cortex/analyst/message", req, nil)
 }

--- a/integrations/snowflake/cortex.go
+++ b/integrations/snowflake/cortex.go
@@ -29,6 +29,7 @@ type analystRequest struct {
 	Messages          []analystMessage `json:"messages"`
 	SemanticModelFile string           `json:"semantic_model_file,omitempty"`
 	SemanticModel     string           `json:"semantic_model,omitempty"`
+	SemanticView      string           `json:"semantic_view,omitempty"`
 }
 
 type analystResponse struct {
@@ -43,14 +44,19 @@ func cortexAnalyst(ctx context.Context, s *snowflake, args map[string]any) (*mcp
 	question := r.Str("question")
 	modelFile := r.Str("semantic_model_file")
 	model := r.Str("semantic_model")
+	semanticView := r.Str("semantic_view")
 	if err := r.Err(); err != nil {
 		return mcp.ErrResult(err)
 	}
 	if question == "" {
 		return mcp.ErrResult(fmt.Errorf("question is required"))
 	}
-	if modelFile == "" && model == "" {
-		return mcp.ErrResult(fmt.Errorf("semantic_model_file or semantic_model is required"))
+	// Fall back to the configured default semantic view.
+	if semanticView == "" && modelFile == "" && model == "" {
+		semanticView = s.semanticView
+	}
+	if modelFile == "" && model == "" && semanticView == "" {
+		return mcp.ErrResult(fmt.Errorf("semantic_view, semantic_model_file, or semantic_model is required"))
 	}
 
 	req := analystRequest{
@@ -64,6 +70,7 @@ func cortexAnalyst(ctx context.Context, s *snowflake, args map[string]any) (*mcp
 		},
 		SemanticModelFile: modelFile,
 		SemanticModel:     model,
+		SemanticView:      semanticView,
 	}
 
 	resp, err := s.doAnalystRequest(ctx, &req)

--- a/integrations/snowflake/cortex.go
+++ b/integrations/snowflake/cortex.go
@@ -1,0 +1,132 @@
+package snowflake
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+// --- Cortex Analyst types ---
+
+type analystMessage struct {
+	Role    string           `json:"role"`
+	Content []analystContent `json:"content"`
+}
+
+type analystContent struct {
+	Type        string   `json:"type"`
+	Text        string   `json:"text,omitempty"`
+	Statement   string   `json:"statement,omitempty"`
+	Suggestions []string `json:"suggestions,omitempty"`
+}
+
+type analystRequest struct {
+	Messages          []analystMessage `json:"messages"`
+	SemanticModelFile string           `json:"semantic_model_file,omitempty"`
+	SemanticModel     string           `json:"semantic_model,omitempty"`
+}
+
+type analystResponse struct {
+	RequestID string         `json:"request_id"`
+	Message   analystMessage `json:"message"`
+}
+
+// cortexAnalyst sends a question to the Cortex Analyst semantic layer and
+// returns the generated SQL, explanation, and any follow-up suggestions.
+func cortexAnalyst(ctx context.Context, s *snowflake, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	question := r.Str("question")
+	modelFile := r.Str("semantic_model_file")
+	model := r.Str("semantic_model")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if question == "" {
+		return mcp.ErrResult(fmt.Errorf("question is required"))
+	}
+	if modelFile == "" && model == "" {
+		return mcp.ErrResult(fmt.Errorf("semantic_model_file or semantic_model is required"))
+	}
+
+	req := analystRequest{
+		Messages: []analystMessage{
+			{
+				Role: "user",
+				Content: []analystContent{
+					{Type: "text", Text: question},
+				},
+			},
+		},
+		SemanticModelFile: modelFile,
+		SemanticModel:     model,
+	}
+
+	resp, err := s.doAnalystRequest(ctx, &req)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	return mcp.JSONResult(resp)
+}
+
+func (s *snowflake) doAnalystRequest(ctx context.Context, req *analystRequest) (*analystResponse, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("snowflake: marshal analyst request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, s.baseURL+"/api/v2/cortex/analyst/message", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("snowflake: create analyst request: %w", err)
+	}
+
+	token, err := s.getToken()
+	if err != nil {
+		return nil, fmt.Errorf("snowflake: get auth token: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+token)
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/json")
+	httpReq.Header.Set("User-Agent", "Switchboard/1.0")
+
+	resp, err := s.client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("snowflake: analyst request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+	if err != nil {
+		return nil, fmt.Errorf("snowflake: read analyst response: %w", err)
+	}
+
+	switch {
+	case resp.StatusCode == http.StatusOK:
+		var result analystResponse
+		if err := json.Unmarshal(respBody, &result); err != nil {
+			return nil, fmt.Errorf("snowflake: parse analyst response: %w", err)
+		}
+		return &result, nil
+	case resp.StatusCode == http.StatusUnauthorized:
+		return nil, fmt.Errorf("snowflake: unauthorized (401) — check token")
+	case resp.StatusCode == http.StatusTooManyRequests:
+		retryAfter := mcp.ParseRetryAfter(resp.Header.Get("Retry-After"))
+		return nil, &mcp.RetryableError{
+			StatusCode: resp.StatusCode,
+			Err:        fmt.Errorf("snowflake: analyst rate limited (429)"),
+			RetryAfter: retryAfter,
+		}
+	case resp.StatusCode >= 500:
+		return nil, &mcp.RetryableError{
+			StatusCode: resp.StatusCode,
+			Err:        fmt.Errorf("snowflake: analyst server error (%d): %s", resp.StatusCode, string(respBody)),
+		}
+	default:
+		return nil, fmt.Errorf("snowflake: analyst error (%d): %s", resp.StatusCode, string(respBody))
+	}
+}

--- a/integrations/snowflake/cortex_test.go
+++ b/integrations/snowflake/cortex_test.go
@@ -96,7 +96,89 @@ func TestCortexAnalyst_MissingModel(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.True(t, result.IsError)
-	assert.Contains(t, result.Data, "semantic_model_file or semantic_model is required")
+	assert.Contains(t, result.Data, "semantic_view, semantic_model_file, or semantic_model is required")
+}
+
+func TestCortexAnalyst_SemanticView(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req analystRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		assert.Equal(t, "MY_DB.MY_SCHEMA.MY_VIEW", req.SemanticView)
+		assert.Empty(t, req.SemanticModelFile)
+		assert.Empty(t, req.SemanticModel)
+
+		resp := analystResponse{
+			RequestID: "req-789",
+			Message: analystMessage{
+				Role:    "analyst",
+				Content: []analystContent{{Type: "text", Text: "ok"}},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp) //nolint:errcheck
+	}))
+	defer ts.Close()
+
+	s := &snowflake{client: ts.Client(), baseURL: ts.URL, token: "test-token"}
+	result, err := cortexAnalyst(context.Background(), s, map[string]any{
+		"question":      "How many users?",
+		"semantic_view": "MY_DB.MY_SCHEMA.MY_VIEW",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+}
+
+func TestCortexAnalyst_DefaultSemanticView(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req analystRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		assert.Equal(t, "DB.SCH.DEFAULT_VIEW", req.SemanticView)
+
+		resp := analystResponse{
+			RequestID: "req-default",
+			Message: analystMessage{
+				Role:    "analyst",
+				Content: []analystContent{{Type: "text", Text: "ok"}},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp) //nolint:errcheck
+	}))
+	defer ts.Close()
+
+	s := &snowflake{client: ts.Client(), baseURL: ts.URL, token: "test-token", semanticView: "DB.SCH.DEFAULT_VIEW"}
+	result, err := cortexAnalyst(context.Background(), s, map[string]any{
+		"question": "How many users?",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+}
+
+func TestCortexAnalyst_ExplicitOverridesDefault(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req analystRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		assert.Equal(t, "DB.SCH.EXPLICIT_VIEW", req.SemanticView, "explicit should override default")
+
+		resp := analystResponse{
+			RequestID: "req-override",
+			Message: analystMessage{
+				Role:    "analyst",
+				Content: []analystContent{{Type: "text", Text: "ok"}},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp) //nolint:errcheck
+	}))
+	defer ts.Close()
+
+	s := &snowflake{client: ts.Client(), baseURL: ts.URL, token: "test-token", semanticView: "DB.SCH.DEFAULT_VIEW"}
+	result, err := cortexAnalyst(context.Background(), s, map[string]any{
+		"question":      "How many users?",
+		"semantic_view": "DB.SCH.EXPLICIT_VIEW",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
 }
 
 func TestCortexAnalyst_Unauthorized(t *testing.T) {

--- a/integrations/snowflake/cortex_test.go
+++ b/integrations/snowflake/cortex_test.go
@@ -1,0 +1,132 @@
+package snowflake
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCortexAnalyst_Success(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v2/cortex/analyst/message", r.URL.Path)
+		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+
+		var req analystRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		assert.Len(t, req.Messages, 1)
+		assert.Equal(t, "user", req.Messages[0].Role)
+		assert.Equal(t, "What is the total revenue?", req.Messages[0].Content[0].Text)
+		assert.Equal(t, "@DB.SCH.STG/model.yaml", req.SemanticModelFile)
+
+		resp := analystResponse{
+			RequestID: "req-123",
+			Message: analystMessage{
+				Role: "analyst",
+				Content: []analystContent{
+					{Type: "text", Text: "Here is the total revenue query."},
+					{Type: "sql", Statement: "SELECT SUM(revenue) FROM sales"},
+					{Type: "suggestions", Suggestions: []string{"By region?", "By quarter?"}},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp) //nolint:errcheck
+	}))
+	defer ts.Close()
+
+	s := &snowflake{client: ts.Client(), baseURL: ts.URL, token: "test-token"}
+	result, err := cortexAnalyst(context.Background(), s, map[string]any{
+		"question":            "What is the total revenue?",
+		"semantic_model_file": "@DB.SCH.STG/model.yaml",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "SELECT SUM(revenue) FROM sales")
+	assert.Contains(t, result.Data, "Here is the total revenue query.")
+	assert.Contains(t, result.Data, "By region?")
+}
+
+func TestCortexAnalyst_InlineModel(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req analystRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		assert.Empty(t, req.SemanticModelFile)
+		assert.Contains(t, req.SemanticModel, "tables:")
+
+		resp := analystResponse{
+			RequestID: "req-456",
+			Message: analystMessage{
+				Role:    "analyst",
+				Content: []analystContent{{Type: "text", Text: "ok"}},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp) //nolint:errcheck
+	}))
+	defer ts.Close()
+
+	s := &snowflake{client: ts.Client(), baseURL: ts.URL, token: "test-token"}
+	result, err := cortexAnalyst(context.Background(), s, map[string]any{
+		"question":       "How many users?",
+		"semantic_model": "tables:\n  - name: users",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+}
+
+func TestCortexAnalyst_MissingQuestion(t *testing.T) {
+	s := &snowflake{client: &http.Client{}}
+	result, err := cortexAnalyst(context.Background(), s, map[string]any{
+		"semantic_model_file": "@DB.SCH.STG/model.yaml",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "question is required")
+}
+
+func TestCortexAnalyst_MissingModel(t *testing.T) {
+	s := &snowflake{client: &http.Client{}}
+	result, err := cortexAnalyst(context.Background(), s, map[string]any{
+		"question": "How many users?",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "semantic_model_file or semantic_model is required")
+}
+
+func TestCortexAnalyst_Unauthorized(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer ts.Close()
+
+	s := &snowflake{client: ts.Client(), baseURL: ts.URL, token: "bad-token"}
+	result, err := cortexAnalyst(context.Background(), s, map[string]any{
+		"question":            "test",
+		"semantic_model_file": "@DB.SCH.STG/model.yaml",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "unauthorized")
+}
+
+func TestCortexAnalyst_RateLimit(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "10")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer ts.Close()
+
+	s := &snowflake{client: ts.Client(), baseURL: ts.URL, token: "tok"}
+	_, err := cortexAnalyst(context.Background(), s, map[string]any{
+		"question":            "test",
+		"semantic_model_file": "@DB.SCH.STG/model.yaml",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rate limited")
+}

--- a/integrations/snowflake/keypair.go
+++ b/integrations/snowflake/keypair.go
@@ -1,0 +1,174 @@
+package snowflake
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+// parsePrivateKey decodes a PEM-encoded RSA private key.
+// Supports both PKCS#1 (RSA PRIVATE KEY) and PKCS#8 (PRIVATE KEY) formats.
+// Handles PEM data where newlines have been stripped (e.g. from a single-line
+// HTML input field) by restoring them before decoding.
+func parsePrivateKey(pemData string) (*rsa.PrivateKey, error) {
+	pemData = normalizePEM(pemData)
+	block, _ := pem.Decode([]byte(pemData))
+	if block == nil {
+		return nil, fmt.Errorf("snowflake: failed to decode PEM block")
+	}
+
+	switch block.Type {
+	case "RSA PRIVATE KEY":
+		return x509.ParsePKCS1PrivateKey(block.Bytes)
+	case "PRIVATE KEY":
+		key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, err
+		}
+		rsaKey, ok := key.(*rsa.PrivateKey)
+		if !ok {
+			return nil, fmt.Errorf("snowflake: PKCS#8 key is not RSA")
+		}
+		return rsaKey, nil
+	default:
+		return nil, fmt.Errorf("snowflake: unsupported PEM block type %q", block.Type)
+	}
+}
+
+// publicKeyFingerprint returns the SHA256 fingerprint of the RSA public key
+// in the format Snowflake expects: "SHA256:<base64>".
+func publicKeyFingerprint(key *rsa.PrivateKey) (string, error) {
+	pubDER, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	if err != nil {
+		return "", fmt.Errorf("snowflake: marshal public key: %w", err)
+	}
+	hash := sha256.Sum256(pubDER)
+	return "SHA256:" + base64.StdEncoding.EncodeToString(hash[:]), nil
+}
+
+// accountLocator extracts the account locator from a full Snowflake account
+// identifier. For "xy12345.us-east-1" it returns "XY12345". If no dots are
+// present the full identifier is returned uppercased.
+func accountLocator(account string) string {
+	if idx := strings.IndexByte(account, '.'); idx >= 0 {
+		return strings.ToUpper(account[:idx])
+	}
+	return strings.ToUpper(account)
+}
+
+// generateSnowflakeJWT creates an RS256 JWT for Snowflake key-pair auth.
+func generateSnowflakeJWT(key *rsa.PrivateKey, account, user string, now time.Time) (string, error) {
+	fp, err := publicKeyFingerprint(key)
+	if err != nil {
+		return "", err
+	}
+
+	locator := accountLocator(account)
+	upperUser := strings.ToUpper(user)
+
+	header, err := json.Marshal(map[string]string{"alg": "RS256", "typ": "JWT"})
+	if err != nil {
+		return "", err
+	}
+
+	claims, err := json.Marshal(map[string]any{
+		"iss": locator + "." + upperUser + "." + fp,
+		"sub": locator + "." + upperUser,
+		"iat": now.Unix(),
+		"exp": now.Add(time.Hour).Unix(),
+	})
+	if err != nil {
+		return "", err
+	}
+
+	unsigned := base64url(header) + "." + base64url(claims)
+
+	hash := sha256.Sum256([]byte(unsigned))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, hash[:])
+	if err != nil {
+		return "", fmt.Errorf("snowflake: sign JWT: %w", err)
+	}
+
+	return unsigned + "." + base64url(sig), nil
+}
+
+// normalizePEM restores newlines in a PEM block that may have been flattened
+// into a single line (e.g. by an HTML <input> field stripping newlines on paste).
+func normalizePEM(s string) string {
+	// If the PEM already contains newlines it's fine as-is.
+	if strings.Contains(s, "\n") {
+		return s
+	}
+	// Handle literal \n escape sequences (e.g. from JSON or env vars).
+	if strings.Contains(s, `\n`) {
+		return strings.ReplaceAll(s, `\n`, "\n")
+	}
+	// Restore structure: header + base64 body in 64-char lines + footer.
+	for _, kind := range []string{"RSA PRIVATE KEY", "PRIVATE KEY"} {
+		header := "-----BEGIN " + kind + "-----"
+		footer := "-----END " + kind + "-----"
+		if strings.HasPrefix(s, header) && strings.HasSuffix(s, footer) {
+			body := strings.TrimSpace(s[len(header) : len(s)-len(footer)])
+			var lines []string
+			lines = append(lines, header)
+			for len(body) > 64 {
+				lines = append(lines, body[:64])
+				body = body[64:]
+			}
+			if len(body) > 0 {
+				lines = append(lines, body)
+			}
+			lines = append(lines, footer)
+			return strings.Join(lines, "\n")
+		}
+	}
+	return s
+}
+
+func base64url(data []byte) string {
+	return base64.RawURLEncoding.EncodeToString(data)
+}
+
+// jwtCache caches a generated JWT and regenerates it when close to expiry.
+type jwtCache struct {
+	mu      sync.Mutex
+	token   string
+	expires time.Time
+	nowFunc func() time.Time // for testing; nil means time.Now
+}
+
+const jwtRefreshBuffer = 5 * time.Minute
+
+func (c *jwtCache) now() time.Time {
+	if c.nowFunc != nil {
+		return c.nowFunc()
+	}
+	return time.Now()
+}
+
+func (c *jwtCache) getOrGenerate(key *rsa.PrivateKey, account, user string) (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := c.now()
+	if c.token != "" && now.Before(c.expires.Add(-jwtRefreshBuffer)) {
+		return c.token, nil
+	}
+
+	token, err := generateSnowflakeJWT(key, account, user, now)
+	if err != nil {
+		return "", err
+	}
+	c.token = token
+	c.expires = now.Add(time.Hour)
+	return token, nil
+}

--- a/integrations/snowflake/keypair.go
+++ b/integrations/snowflake/keypair.go
@@ -57,7 +57,7 @@ func publicKeyFingerprint(key *rsa.PrivateKey) (string, error) {
 
 // accountLocator extracts the account locator from a full Snowflake account
 // identifier. For "xy12345.us-east-1" it returns "XY12345". Identifiers without
-// dots (e.g. "wnumjgh-ex36922") are returned uppercased as-is, which is the
+// dots (e.g. "abcdefg-xz213456") are returned uppercased as-is, which is the
 // common format for org-based accounts.
 func accountLocator(account string) string {
 	if idx := strings.IndexByte(account, '.'); idx >= 0 {

--- a/integrations/snowflake/keypair.go
+++ b/integrations/snowflake/keypair.go
@@ -56,8 +56,9 @@ func publicKeyFingerprint(key *rsa.PrivateKey) (string, error) {
 }
 
 // accountLocator extracts the account locator from a full Snowflake account
-// identifier. For "xy12345.us-east-1" it returns "XY12345". If no dots are
-// present the full identifier is returned uppercased.
+// identifier. For "xy12345.us-east-1" it returns "XY12345". Identifiers without
+// dots (e.g. "wnumjgh-ex36922") are returned uppercased as-is, which is the
+// common format for org-based accounts.
 func accountLocator(account string) string {
 	if idx := strings.IndexByte(account, '.'); idx >= 0 {
 		return strings.ToUpper(account[:idx])

--- a/integrations/snowflake/keypair_test.go
+++ b/integrations/snowflake/keypair_test.go
@@ -1,0 +1,201 @@
+package snowflake
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testKey generates a throwaway 2048-bit RSA key for tests.
+func testKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	return key
+}
+
+func pemEncodePKCS1(key *rsa.PrivateKey) string {
+	return string(pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	}))
+}
+
+func pemEncodePKCS8(key *rsa.PrivateKey) string {
+	der, _ := x509.MarshalPKCS8PrivateKey(key)
+	return string(pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: der,
+	}))
+}
+
+func TestParsePrivateKey(t *testing.T) {
+	key := testKey(t)
+
+	tests := []struct {
+		name    string
+		input   string
+		wantErr string
+	}{
+		{"PKCS1", pemEncodePKCS1(key), ""},
+		{"PKCS8", pemEncodePKCS8(key), ""},
+		{"empty", "", "failed to decode PEM"},
+		{"garbage", "not-a-pem", "failed to decode PEM"},
+		{"wrong block type", string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("x")})), "unsupported PEM block type"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsed, err := parsePrivateKey(tt.input)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, parsed)
+			assert.Equal(t, key.D.Cmp(parsed.D), 0, "parsed key should match original")
+		})
+	}
+}
+
+func TestParsePrivateKey_FlattenedPEM(t *testing.T) {
+	key := testKey(t)
+	// Simulate what an HTML <input> does: strip all newlines.
+	normalPEM := pemEncodePKCS8(key)
+	flatPEM := strings.ReplaceAll(normalPEM, "\n", "")
+
+	parsed, err := parsePrivateKey(flatPEM)
+	require.NoError(t, err)
+	assert.Equal(t, 0, key.D.Cmp(parsed.D), "parsed key should match original")
+}
+
+func TestParsePrivateKey_EscapedNewlines(t *testing.T) {
+	key := testKey(t)
+	// Simulate literal \n in JSON or env var.
+	normalPEM := pemEncodePKCS8(key)
+	escapedPEM := strings.ReplaceAll(normalPEM, "\n", `\n`)
+
+	parsed, err := parsePrivateKey(escapedPEM)
+	require.NoError(t, err)
+	assert.Equal(t, 0, key.D.Cmp(parsed.D), "parsed key should match original")
+}
+
+func TestPublicKeyFingerprint(t *testing.T) {
+	key := testKey(t)
+
+	fp, err := publicKeyFingerprint(key)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(fp, "SHA256:"), "fingerprint should start with SHA256:")
+
+	// Verify it's deterministic.
+	fp2, err := publicKeyFingerprint(key)
+	require.NoError(t, err)
+	assert.Equal(t, fp, fp2)
+
+	// Verify the hash matches manual computation.
+	pubDER, _ := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	hash := sha256.Sum256(pubDER)
+	want := "SHA256:" + base64.StdEncoding.EncodeToString(hash[:])
+	assert.Equal(t, want, fp)
+}
+
+func TestAccountLocator(t *testing.T) {
+	tests := []struct {
+		input, want string
+	}{
+		{"xy12345.us-east-1", "XY12345"},
+		{"xy12345.us-east-1.aws", "XY12345"},
+		{"XY12345", "XY12345"},
+		{"myorg-myaccount", "MYORG-MYACCOUNT"},
+		{"lower", "LOWER"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.want, accountLocator(tt.input))
+		})
+	}
+}
+
+func TestGenerateSnowflakeJWT(t *testing.T) {
+	key := testKey(t)
+	now := time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC)
+
+	token, err := generateSnowflakeJWT(key, "xy12345.us-east-1", "MYUSER", now)
+	require.NoError(t, err)
+
+	parts := strings.SplitN(token, ".", 3)
+	require.Len(t, parts, 3, "JWT should have 3 parts")
+
+	// Verify header.
+	headerJSON, err := base64.RawURLEncoding.DecodeString(parts[0])
+	require.NoError(t, err)
+	var header map[string]string
+	require.NoError(t, json.Unmarshal(headerJSON, &header))
+	assert.Equal(t, "RS256", header["alg"])
+	assert.Equal(t, "JWT", header["typ"])
+
+	// Verify claims.
+	claimsJSON, err := base64.RawURLEncoding.DecodeString(parts[1])
+	require.NoError(t, err)
+	var claims map[string]any
+	require.NoError(t, json.Unmarshal(claimsJSON, &claims))
+
+	fp, _ := publicKeyFingerprint(key)
+	assert.Equal(t, "XY12345.MYUSER."+fp, claims["iss"])
+	assert.Equal(t, "XY12345.MYUSER", claims["sub"])
+	assert.Equal(t, float64(now.Unix()), claims["iat"])
+	assert.Equal(t, float64(now.Add(time.Hour).Unix()), claims["exp"])
+
+	// Verify signature is valid.
+	unsigned := parts[0] + "." + parts[1]
+	sigBytes, err := base64.RawURLEncoding.DecodeString(parts[2])
+	require.NoError(t, err)
+	hash := sha256.Sum256([]byte(unsigned))
+	err = rsa.VerifyPKCS1v15(&key.PublicKey, crypto.SHA256, hash[:], sigBytes)
+	require.NoError(t, err, "JWT signature should verify")
+}
+
+func TestJWTCache_Caching(t *testing.T) {
+	key := testKey(t)
+	now := time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC)
+
+	cache := &jwtCache{nowFunc: func() time.Time { return now }}
+
+	tok1, err := cache.getOrGenerate(key, "acct", "user")
+	require.NoError(t, err)
+
+	tok2, err := cache.getOrGenerate(key, "acct", "user")
+	require.NoError(t, err)
+
+	assert.Equal(t, tok1, tok2, "same token should be returned within TTL")
+}
+
+func TestJWTCache_Refresh(t *testing.T) {
+	key := testKey(t)
+	now := time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC)
+
+	cache := &jwtCache{nowFunc: func() time.Time { return now }}
+
+	tok1, err := cache.getOrGenerate(key, "acct", "user")
+	require.NoError(t, err)
+
+	// Advance past the refresh buffer (55 min).
+	now = now.Add(56 * time.Minute)
+	cache.nowFunc = func() time.Time { return now }
+
+	tok2, err := cache.getOrGenerate(key, "acct", "user")
+	require.NoError(t, err)
+
+	assert.NotEqual(t, tok1, tok2, "token should be regenerated after refresh buffer")
+}

--- a/integrations/snowflake/snowflake.go
+++ b/integrations/snowflake/snowflake.go
@@ -3,6 +3,7 @@ package snowflake
 import (
 	"bytes"
 	"context"
+	"crypto/rsa"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -22,13 +23,17 @@ var (
 )
 
 type snowflake struct {
-	client    *http.Client
-	token     string
-	baseURL   string
-	warehouse string
-	database  string
-	schema    string
-	role      string
+	client     *http.Client
+	token      string
+	baseURL    string
+	warehouse  string
+	database   string
+	schema     string
+	role       string
+	account    string
+	user       string
+	privateKey *rsa.PrivateKey
+	jwtCache   jwtCache
 }
 
 func New() mcp.Integration {
@@ -42,16 +47,32 @@ func (s *snowflake) Configure(_ context.Context, creds mcp.Credentials) error {
 	if account == "" {
 		return fmt.Errorf("snowflake: account is required")
 	}
-	token := creds["token"]
-	if token == "" {
-		return fmt.Errorf("snowflake: token (JWT or OAuth) is required")
-	}
 
-	s.token = token
+	s.account = account
 	s.warehouse = creds["warehouse"]
 	s.database = creds["database"]
 	s.schema = creds["schema"]
 	s.role = creds["role"]
+
+	// Key-pair auth takes precedence over a static token.
+	if pk := creds["private_key"]; pk != "" {
+		user := creds["user"]
+		if user == "" {
+			return fmt.Errorf("snowflake: user is required when using private_key authentication")
+		}
+		key, err := parsePrivateKey(pk)
+		if err != nil {
+			return fmt.Errorf("snowflake: invalid private_key: %w", err)
+		}
+		s.privateKey = key
+		s.user = strings.ToUpper(user)
+	} else {
+		token := creds["token"]
+		if token == "" {
+			return fmt.Errorf("snowflake: token or private_key is required")
+		}
+		s.token = token
+	}
 
 	if url := creds["account_url"]; url != "" {
 		s.baseURL = strings.TrimRight(url, "/")
@@ -64,11 +85,21 @@ func (s *snowflake) Configure(_ context.Context, creds mcp.Credentials) error {
 }
 
 func (s *snowflake) Healthy(ctx context.Context) bool {
-	if s.client == nil || s.token == "" {
+	if s.client == nil || (s.token == "" && s.privateKey == nil) {
 		return false
 	}
 	_, err := s.submitStatement(ctx, "SELECT 1", nil)
 	return err == nil
+}
+
+// getToken returns the bearer token for the current request. For key-pair auth
+// this generates (or returns a cached) JWT; for static token auth it returns
+// the configured token directly.
+func (s *snowflake) getToken() (string, error) {
+	if s.privateKey != nil {
+		return s.jwtCache.getOrGenerate(s.privateKey, s.account, s.user)
+	}
+	return s.token, nil
 }
 
 func (s *snowflake) Tools() []mcp.ToolDefinition {
@@ -92,13 +123,15 @@ func (s *snowflake) Execute(ctx context.Context, toolName string, args map[strin
 }
 
 func (s *snowflake) PlainTextKeys() []string {
-	return []string{"account", "warehouse", "database", "schema", "role", "account_url"}
+	return []string{"account", "user", "warehouse", "database", "schema", "role", "account_url"}
 }
 
 func (s *snowflake) Placeholders() map[string]string {
 	return map[string]string{
 		"account":     "xy12345.us-east-1",
 		"token":       "JWT or OAuth token",
+		"user":        "MYUSER",
+		"private_key": "PEM-encoded RSA private key",
 		"warehouse":   "COMPUTE_WH",
 		"database":    "MY_DB",
 		"schema":      "PUBLIC",
@@ -108,7 +141,7 @@ func (s *snowflake) Placeholders() map[string]string {
 }
 
 func (s *snowflake) OptionalKeys() []string {
-	return []string{"warehouse", "database", "schema", "role", "account_url"}
+	return []string{"token", "user", "private_key", "warehouse", "database", "schema", "role", "account_url"}
 }
 
 type handlerFunc func(ctx context.Context, s *snowflake, args map[string]any) (*mcp.ToolResult, error)
@@ -209,7 +242,11 @@ func (s *snowflake) doStatementRequest(ctx context.Context, method, path string,
 		return nil, fmt.Errorf("snowflake: create request: %w", err)
 	}
 
-	httpReq.Header.Set("Authorization", "Bearer "+s.token)
+	token, err := s.getToken()
+	if err != nil {
+		return nil, fmt.Errorf("snowflake: get auth token: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+token)
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Accept", "application/json")
 	httpReq.Header.Set("User-Agent", "Switchboard/1.0")

--- a/integrations/snowflake/snowflake.go
+++ b/integrations/snowflake/snowflake.go
@@ -130,7 +130,7 @@ func (s *snowflake) PlainTextKeys() []string {
 
 func (s *snowflake) Placeholders() map[string]string {
 	return map[string]string{
-		"account":       "xy12345.us-east-1",
+		"account":       "abc1234-xy56789",
 		"token":         "JWT or OAuth token (if not using key-pair auth)",
 		"user":          "Username (required with private_key)",
 		"private_key":   "PEM-encoded RSA private key (alternative to token)",
@@ -139,7 +139,7 @@ func (s *snowflake) Placeholders() map[string]string {
 		"schema":        "PUBLIC",
 		"role":          "SYSADMIN",
 		"semantic_view": "MY_DB.MY_SCHEMA.MY_SEMANTIC_VIEW",
-		"account_url":   "https://xy12345.us-east-1.snowflakecomputing.com",
+		"account_url":   "https://abc1234-xy56789.snowflakecomputing.com",
 	}
 }
 

--- a/integrations/snowflake/snowflake.go
+++ b/integrations/snowflake/snowflake.go
@@ -131,9 +131,9 @@ func (s *snowflake) PlainTextKeys() []string {
 func (s *snowflake) Placeholders() map[string]string {
 	return map[string]string{
 		"account":       "xy12345.us-east-1",
-		"token":         "JWT or OAuth token",
-		"user":          "MYUSER",
-		"private_key":   "PEM-encoded RSA private key",
+		"token":         "JWT or OAuth token (if not using key-pair auth)",
+		"user":          "Username (required with private_key)",
+		"private_key":   "PEM-encoded RSA private key (alternative to token)",
 		"warehouse":     "COMPUTE_WH",
 		"database":      "MY_DB",
 		"schema":        "PUBLIC",
@@ -230,7 +230,12 @@ func (s *snowflake) cancelStatement(ctx context.Context, handle string) error {
 	return err
 }
 
-func (s *snowflake) doStatementRequest(ctx context.Context, method, path string, body any) (*statementResponse, error) {
+// doJSON performs a JSON API request with common Snowflake auth headers and shared
+// error handling (401, 429, 5xx). On 200 OK the response is unmarshalled into T.
+// The optional extraStatus callback handles endpoint-specific status codes (e.g.
+// 202, 422 for the SQL Statements API); return (nil, nil) to fall through to the
+// shared error handler.
+func doJSON[T any](ctx context.Context, s *snowflake, method, path string, body any, extraStatus func(int, []byte) (*T, error)) (*T, error) {
 	var bodyReader io.Reader
 	if body != nil {
 		data, err := json.Marshal(body)
@@ -265,43 +270,58 @@ func (s *snowflake) doStatementRequest(ctx context.Context, method, path string,
 		return nil, fmt.Errorf("snowflake: read response: %w", err)
 	}
 
-	switch resp.StatusCode {
-	case http.StatusOK:
-		var result statementResponse
+	if resp.StatusCode == http.StatusOK {
+		var result T
 		if err := json.Unmarshal(respBody, &result); err != nil {
 			return nil, fmt.Errorf("snowflake: parse response: %w", err)
 		}
 		return &result, nil
-	case http.StatusAccepted:
-		var result statementResponse
-		if err := json.Unmarshal(respBody, &result); err != nil {
-			return nil, fmt.Errorf("snowflake: parse 202 response: %w", err)
+	}
+
+	if extraStatus != nil {
+		if result, err := extraStatus(resp.StatusCode, respBody); result != nil || err != nil {
+			return result, err
 		}
-		return &result, nil
-	case http.StatusUnauthorized:
+	}
+
+	switch {
+	case resp.StatusCode == http.StatusUnauthorized:
 		return nil, fmt.Errorf("snowflake: unauthorized (401) — check token")
-	case http.StatusTooManyRequests:
+	case resp.StatusCode == http.StatusTooManyRequests:
 		retryAfter := mcp.ParseRetryAfter(resp.Header.Get("Retry-After"))
 		return nil, &mcp.RetryableError{
 			StatusCode: resp.StatusCode,
 			Err:        fmt.Errorf("snowflake: rate limited (429)"),
 			RetryAfter: retryAfter,
 		}
-	case http.StatusUnprocessableEntity:
-		var result statementResponse
-		if err := json.Unmarshal(respBody, &result); err != nil {
-			return nil, fmt.Errorf("snowflake: execution error (422): %s", string(respBody))
+	case resp.StatusCode >= 500:
+		return nil, &mcp.RetryableError{
+			StatusCode: resp.StatusCode,
+			Err:        fmt.Errorf("snowflake: server error (%d): %s", resp.StatusCode, string(respBody)),
 		}
-		return nil, fmt.Errorf("snowflake: execution error (422): %s", result.Message)
 	default:
-		if resp.StatusCode >= 500 {
-			return nil, &mcp.RetryableError{
-				StatusCode: resp.StatusCode,
-				Err:        fmt.Errorf("snowflake: server error (%d): %s", resp.StatusCode, string(respBody)),
-			}
-		}
 		return nil, fmt.Errorf("snowflake: unexpected status %d: %s", resp.StatusCode, string(respBody))
 	}
+}
+
+func (s *snowflake) doStatementRequest(ctx context.Context, method, path string, body any) (*statementResponse, error) {
+	return doJSON[statementResponse](ctx, s, method, path, body, func(status int, respBody []byte) (*statementResponse, error) {
+		switch status {
+		case http.StatusAccepted:
+			var result statementResponse
+			if err := json.Unmarshal(respBody, &result); err != nil {
+				return nil, fmt.Errorf("snowflake: parse 202 response: %w", err)
+			}
+			return &result, nil
+		case http.StatusUnprocessableEntity:
+			var result statementResponse
+			if err := json.Unmarshal(respBody, &result); err != nil {
+				return nil, fmt.Errorf("snowflake: execution error (422): %s", string(respBody))
+			}
+			return nil, fmt.Errorf("snowflake: execution error (422): %s", result.Message)
+		}
+		return nil, nil
+	})
 }
 
 // formatResults converts the Snowflake columnar response (array of arrays + metadata)

--- a/integrations/snowflake/snowflake.go
+++ b/integrations/snowflake/snowflake.go
@@ -23,17 +23,18 @@ var (
 )
 
 type snowflake struct {
-	client     *http.Client
-	token      string
-	baseURL    string
-	warehouse  string
-	database   string
-	schema     string
-	role       string
-	account    string
-	user       string
-	privateKey *rsa.PrivateKey
-	jwtCache   jwtCache
+	client       *http.Client
+	token        string
+	baseURL      string
+	warehouse    string
+	database     string
+	schema       string
+	role         string
+	account      string
+	user         string
+	semanticView string
+	privateKey   *rsa.PrivateKey
+	jwtCache     jwtCache
 }
 
 func New() mcp.Integration {
@@ -53,6 +54,7 @@ func (s *snowflake) Configure(_ context.Context, creds mcp.Credentials) error {
 	s.database = creds["database"]
 	s.schema = creds["schema"]
 	s.role = creds["role"]
+	s.semanticView = creds["semantic_view"]
 
 	// Key-pair auth takes precedence over a static token.
 	if pk := creds["private_key"]; pk != "" {
@@ -123,25 +125,26 @@ func (s *snowflake) Execute(ctx context.Context, toolName string, args map[strin
 }
 
 func (s *snowflake) PlainTextKeys() []string {
-	return []string{"account", "user", "warehouse", "database", "schema", "role", "account_url"}
+	return []string{"account", "user", "warehouse", "database", "schema", "role", "semantic_view", "account_url"}
 }
 
 func (s *snowflake) Placeholders() map[string]string {
 	return map[string]string{
-		"account":     "xy12345.us-east-1",
-		"token":       "JWT or OAuth token",
-		"user":        "MYUSER",
-		"private_key": "PEM-encoded RSA private key",
-		"warehouse":   "COMPUTE_WH",
-		"database":    "MY_DB",
-		"schema":      "PUBLIC",
-		"role":        "SYSADMIN",
-		"account_url": "https://xy12345.us-east-1.snowflakecomputing.com",
+		"account":       "xy12345.us-east-1",
+		"token":         "JWT or OAuth token",
+		"user":          "MYUSER",
+		"private_key":   "PEM-encoded RSA private key",
+		"warehouse":     "COMPUTE_WH",
+		"database":      "MY_DB",
+		"schema":        "PUBLIC",
+		"role":          "SYSADMIN",
+		"semantic_view": "MY_DB.MY_SCHEMA.MY_SEMANTIC_VIEW",
+		"account_url":   "https://xy12345.us-east-1.snowflakecomputing.com",
 	}
 }
 
 func (s *snowflake) OptionalKeys() []string {
-	return []string{"token", "user", "private_key", "warehouse", "database", "schema", "role", "account_url"}
+	return []string{"token", "user", "private_key", "warehouse", "database", "schema", "role", "semantic_view", "account_url"}
 }
 
 type handlerFunc func(ctx context.Context, s *snowflake, args map[string]any) (*mcp.ToolResult, error)

--- a/integrations/snowflake/snowflake_test.go
+++ b/integrations/snowflake/snowflake_test.go
@@ -13,6 +13,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// testPEM returns a PEM-encoded PKCS#1 RSA private key for testing.
+func testPEM(t *testing.T) string {
+	t.Helper()
+	return pemEncodePKCS1(testKey(t))
+}
+
 func TestNew(t *testing.T) {
 	i := New()
 	require.NotNil(t, i)
@@ -26,11 +32,59 @@ func TestConfigure_MissingAccount(t *testing.T) {
 	assert.Contains(t, err.Error(), "account is required")
 }
 
-func TestConfigure_MissingToken(t *testing.T) {
+func TestConfigure_MissingAuth(t *testing.T) {
 	s := &snowflake{}
 	err := s.Configure(context.Background(), mcp.Credentials{"account": "acct"})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "token")
+	assert.Contains(t, err.Error(), "token or private_key is required")
+}
+
+func TestConfigure_KeyPairAuth(t *testing.T) {
+	s := &snowflake{}
+	err := s.Configure(context.Background(), mcp.Credentials{
+		"account":     "xy12345.us-east-1",
+		"user":        "myuser",
+		"private_key": testPEM(t),
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, s.privateKey)
+	assert.Equal(t, "MYUSER", s.user)
+	assert.Equal(t, "xy12345.us-east-1", s.account)
+	assert.Empty(t, s.token, "token should be empty when using key-pair auth")
+}
+
+func TestConfigure_KeyPairAuth_MissingUser(t *testing.T) {
+	s := &snowflake{}
+	err := s.Configure(context.Background(), mcp.Credentials{
+		"account":     "acct",
+		"private_key": testPEM(t),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "user is required")
+}
+
+func TestConfigure_KeyPairAuth_InvalidKey(t *testing.T) {
+	s := &snowflake{}
+	err := s.Configure(context.Background(), mcp.Credentials{
+		"account":     "acct",
+		"user":        "myuser",
+		"private_key": "not-a-pem",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid private_key")
+}
+
+func TestConfigure_KeyPairPrecedence(t *testing.T) {
+	s := &snowflake{}
+	err := s.Configure(context.Background(), mcp.Credentials{
+		"account":     "acct",
+		"token":       "should-be-ignored",
+		"user":        "myuser",
+		"private_key": testPEM(t),
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, s.privateKey, "key-pair auth should take precedence")
+	assert.Empty(t, s.token, "token should be empty when private_key is provided")
 }
 
 func TestConfigure_DefaultURL(t *testing.T) {
@@ -141,8 +195,10 @@ func TestPlainTextKeys(t *testing.T) {
 	s := &snowflake{}
 	keys := s.PlainTextKeys()
 	assert.Contains(t, keys, "account")
+	assert.Contains(t, keys, "user")
 	assert.Contains(t, keys, "warehouse")
 	assert.NotContains(t, keys, "token")
+	assert.NotContains(t, keys, "private_key")
 }
 
 func TestOptionalKeys(t *testing.T) {
@@ -150,8 +206,10 @@ func TestOptionalKeys(t *testing.T) {
 	keys := s.OptionalKeys()
 	assert.Contains(t, keys, "warehouse")
 	assert.Contains(t, keys, "database")
+	assert.Contains(t, keys, "token")
+	assert.Contains(t, keys, "user")
+	assert.Contains(t, keys, "private_key")
 	assert.NotContains(t, keys, "account")
-	assert.NotContains(t, keys, "token")
 }
 
 func TestPlaceholders(t *testing.T) {
@@ -159,6 +217,8 @@ func TestPlaceholders(t *testing.T) {
 	ph := s.Placeholders()
 	assert.NotEmpty(t, ph["account"])
 	assert.NotEmpty(t, ph["token"])
+	assert.NotEmpty(t, ph["user"])
+	assert.NotEmpty(t, ph["private_key"])
 }
 
 func TestQuoteIdentifier(t *testing.T) {

--- a/integrations/snowflake/snowflake_test.go
+++ b/integrations/snowflake/snowflake_test.go
@@ -197,6 +197,7 @@ func TestPlainTextKeys(t *testing.T) {
 	assert.Contains(t, keys, "account")
 	assert.Contains(t, keys, "user")
 	assert.Contains(t, keys, "warehouse")
+	assert.Contains(t, keys, "semantic_view")
 	assert.NotContains(t, keys, "token")
 	assert.NotContains(t, keys, "private_key")
 }
@@ -209,6 +210,7 @@ func TestOptionalKeys(t *testing.T) {
 	assert.Contains(t, keys, "token")
 	assert.Contains(t, keys, "user")
 	assert.Contains(t, keys, "private_key")
+	assert.Contains(t, keys, "semantic_view")
 	assert.NotContains(t, keys, "account")
 }
 
@@ -219,6 +221,7 @@ func TestPlaceholders(t *testing.T) {
 	assert.NotEmpty(t, ph["token"])
 	assert.NotEmpty(t, ph["user"])
 	assert.NotEmpty(t, ph["private_key"])
+	assert.NotEmpty(t, ph["semantic_view"])
 }
 
 func TestQuoteIdentifier(t *testing.T) {

--- a/integrations/snowflake/tools.go
+++ b/integrations/snowflake/tools.go
@@ -173,6 +173,18 @@ var tools = []mcp.ToolDefinition{
 			"role":     "Role to use (overrides configured default)",
 		},
 	},
+
+	// --- Cortex Analyst ---
+	{
+		Name:        "snowflake_cortex_analyst",
+		Description: "Ask a natural-language question against a Snowflake Cortex Analyst semantic model. Returns generated SQL, an explanation, and follow-up suggestions. Use snowflake_execute_query to run the returned SQL",
+		Parameters: map[string]string{
+			"question":            "Natural-language question to ask (e.g. 'What were our top 10 products by revenue last quarter?')",
+			"semantic_model_file": "Stage path to the semantic model YAML (e.g. @MY_DB.MY_SCHEMA.MY_STAGE/model.yaml)",
+			"semantic_model":      "Inline semantic model YAML (alternative to semantic_model_file)",
+		},
+		Required: []string{"question"},
+	},
 }
 
 var dispatch = map[string]handlerFunc{
@@ -209,4 +221,7 @@ var dispatch = map[string]handlerFunc{
 
 	// Streams
 	"snowflake_list_streams": listStreams,
+
+	// Cortex Analyst
+	"snowflake_cortex_analyst": cortexAnalyst,
 }

--- a/integrations/snowflake/tools.go
+++ b/integrations/snowflake/tools.go
@@ -177,11 +177,12 @@ var tools = []mcp.ToolDefinition{
 	// --- Cortex Analyst ---
 	{
 		Name:        "snowflake_cortex_analyst",
-		Description: "Ask a natural-language question against a Snowflake Cortex Analyst semantic model. Returns generated SQL, an explanation, and follow-up suggestions. Use snowflake_execute_query to run the returned SQL",
+		Description: "Ask a natural-language question against a Snowflake Cortex Analyst semantic layer. Returns generated SQL, an explanation, and follow-up suggestions. Use snowflake_execute_query to run the returned SQL",
 		Parameters: map[string]string{
 			"question":            "Natural-language question to ask (e.g. 'What were our top 10 products by revenue last quarter?')",
-			"semantic_model_file": "Stage path to the semantic model YAML (e.g. @MY_DB.MY_SCHEMA.MY_STAGE/model.yaml)",
-			"semantic_model":      "Inline semantic model YAML (alternative to semantic_model_file)",
+			"semantic_view":       "Fully qualified semantic view name (overrides configured default)",
+			"semantic_model_file": "Stage path to a semantic model YAML (e.g. @MY_DB.MY_SCHEMA.MY_STAGE/model.yaml)",
+			"semantic_model":      "Inline semantic model YAML (alternative to semantic_model_file and semantic_view)",
 		},
 		Required: []string{"question"},
 	},


### PR DESCRIPTION
Summary

  - RSA key-pair authentication: Users can provide a PEM-encoded private key + username instead of a pre-generated JWT. The adapter generates and caches short-lived RS256 JWTs automatically
  (55-min refresh). Supports PKCS#1 and PKCS#8 formats, and normalizes flattened PEM from single-line HTML inputs.
  - Cortex Analyst tool (snowflake_cortex_analyst): Ask natural-language questions against Snowflake's semantic layer. Returns generated SQL, explanations, and follow-up suggestions.
  Supports semantic views, stage-based YAML models, and inline YAML.
  - Default semantic view config: A semantic_view credential field lets users configure a default semantic view once — the LLM then only needs to provide a question, no model reference
  required.
  - New config fields: user, private_key, semantic_view with env vars SNOWFLAKE_USER, SNOWFLAKE_PRIVATE_KEY, SNOWFLAKE_SEMANTIC_VIEW

  Test plan

  - go test ./integrations/snowflake/... — all pass (key-pair parsing, JWT generation/caching, Cortex Analyst handler, semantic view fallback, dispatch parity)
  - make build && make vet && make test && make lint — all pass, 0 lint issues
  - Manually verified end-to-end: key-pair auth connects, queries execute, Cortex Analyst returns generated SQL against BLESSED_SEMANTICS semantic view