### PR TITLE
Add App Platform management tools to DigitalOcean integration

### DIFF
--- a/integrations/digitalocean/apps.go
+++ b/integrations/digitalocean/apps.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	mcp "github.com/daltoniam/switchboard"
 )
@@ -180,13 +181,15 @@ func getAppLogs(ctx context.Context, d *integration, args map[string]any) (*mcp.
 	logType, _ := mcp.ArgStr(args, "log_type")
 
 	path := fmt.Sprintf("/v2/apps/%s/deployments/%s/logs", appID, deployID)
-	sep := "?"
+	params := url.Values{}
 	if component != "" {
-		path += sep + "component_name=" + component
-		sep = "&"
+		params.Set("component_name", component)
 	}
 	if logType != "" {
-		path += sep + "type=" + logType
+		params.Set("type", logType)
+	}
+	if len(params) > 0 {
+		path += "?" + params.Encode()
 	}
 
 	data, err := d.doGet(ctx, "%s", path)

--- a/integrations/digitalocean/apps.go
+++ b/integrations/digitalocean/apps.go
@@ -1,0 +1,238 @@
+package digitalocean
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+func listApps(ctx context.Context, d *integration, args map[string]any) (*mcp.ToolResult, error) {
+	page := mcp.OptInt(args, "page", 1)
+	perPage := mcp.OptInt(args, "per_page", 20)
+	data, err := d.doGet(ctx, "/v2/apps?page=%d&per_page=%d", page, perPage)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func getApp(ctx context.Context, d *integration, args map[string]any) (*mcp.ToolResult, error) {
+	id, err := mcp.ArgStr(args, "app_id")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := d.doGet(ctx, "/v2/apps/%s", id)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func createApp(ctx context.Context, d *integration, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	specStr := r.Str("spec")
+	projectID := r.Str("project_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	var spec json.RawMessage
+	if err := json.Unmarshal([]byte(specStr), &spec); err != nil {
+		return mcp.ErrResult(fmt.Errorf("invalid spec JSON: %w", err))
+	}
+
+	body := map[string]any{"spec": spec}
+	if projectID != "" {
+		body["project_id"] = projectID
+	}
+
+	data, err := d.doPost(ctx, "/v2/apps", body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func updateApp(ctx context.Context, d *integration, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("app_id")
+	specStr := r.Str("spec")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	var spec json.RawMessage
+	if err := json.Unmarshal([]byte(specStr), &spec); err != nil {
+		return mcp.ErrResult(fmt.Errorf("invalid spec JSON: %w", err))
+	}
+
+	data, err := d.doPut(ctx, fmt.Sprintf("/v2/apps/%s", id), map[string]any{"spec": spec})
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func deleteApp(ctx context.Context, d *integration, args map[string]any) (*mcp.ToolResult, error) {
+	id, err := mcp.ArgStr(args, "app_id")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := d.doDel(ctx, "/v2/apps/%s", id)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func restartApp(ctx context.Context, d *integration, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("app_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	body := map[string]any{}
+	components, _ := mcp.ArgStrSlice(args, "components")
+	if len(components) > 0 {
+		body["components"] = components
+	}
+
+	data, err := d.doPost(ctx, fmt.Sprintf("/v2/apps/%s/restart", id), body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func listAppDeployments(ctx context.Context, d *integration, args map[string]any) (*mcp.ToolResult, error) {
+	id, err := mcp.ArgStr(args, "app_id")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	page := mcp.OptInt(args, "page", 1)
+	perPage := mcp.OptInt(args, "per_page", 20)
+	data, err := d.doGet(ctx, "/v2/apps/%s/deployments?page=%d&per_page=%d", id, page, perPage)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func getAppDeployment(ctx context.Context, d *integration, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	appID := r.Str("app_id")
+	deployID := r.Str("deployment_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := d.doGet(ctx, "/v2/apps/%s/deployments/%s", appID, deployID)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func createAppDeployment(ctx context.Context, d *integration, args map[string]any) (*mcp.ToolResult, error) {
+	id, err := mcp.ArgStr(args, "app_id")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	body := map[string]any{}
+	forceBuild, _ := mcp.ArgBool(args, "force_build")
+	if forceBuild {
+		body["force_build"] = true
+	}
+
+	data, err := d.doPost(ctx, fmt.Sprintf("/v2/apps/%s/deployments", id), body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func cancelAppDeployment(ctx context.Context, d *integration, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	appID := r.Str("app_id")
+	deployID := r.Str("deployment_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := d.doPost(ctx, fmt.Sprintf("/v2/apps/%s/deployments/%s/cancel", appID, deployID), nil)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func getAppLogs(ctx context.Context, d *integration, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	appID := r.Str("app_id")
+	deployID := r.Str("deployment_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	component, _ := mcp.ArgStr(args, "component")
+	logType, _ := mcp.ArgStr(args, "log_type")
+
+	path := fmt.Sprintf("/v2/apps/%s/deployments/%s/logs", appID, deployID)
+	sep := "?"
+	if component != "" {
+		path += sep + "component_name=" + component
+		sep = "&"
+	}
+	if logType != "" {
+		path += sep + "type=" + logType
+	}
+
+	data, err := d.doGet(ctx, "%s", path)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func getAppHealth(ctx context.Context, d *integration, args map[string]any) (*mcp.ToolResult, error) {
+	id, err := mcp.ArgStr(args, "app_id")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := d.doGet(ctx, "/v2/apps/%s/health", id)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func listAppAlerts(ctx context.Context, d *integration, args map[string]any) (*mcp.ToolResult, error) {
+	id, err := mcp.ArgStr(args, "app_id")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := d.doGet(ctx, "/v2/apps/%s/alerts", id)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func rollbackApp(ctx context.Context, d *integration, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	appID := r.Str("app_id")
+	deployID := r.Str("deployment_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	body := map[string]any{"deployment_id": deployID}
+
+	data, err := d.doPost(ctx, fmt.Sprintf("/v2/apps/%s/rollback", appID), body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}

--- a/integrations/digitalocean/digitalocean.go
+++ b/integrations/digitalocean/digitalocean.go
@@ -1,10 +1,14 @@
 package digitalocean
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/digitalocean/godo"
 	"golang.org/x/oauth2"
@@ -14,12 +18,20 @@ import (
 
 var _ mcp.Integration = (*integration)(nil)
 
+const maxResponseSize = 10 * 1024 * 1024 // 10 MB
+
 type integration struct {
-	client *godo.Client
+	client     *godo.Client
+	token      string
+	httpClient *http.Client
+	baseURL    string
 }
 
 func New() mcp.Integration {
-	return &integration{}
+	return &integration{
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+		baseURL:    "https://api.digitalocean.com",
+	}
 }
 
 func (d *integration) Name() string { return "digitalocean" }
@@ -30,12 +42,15 @@ func (d *integration) Configure(ctx context.Context, creds mcp.Credentials) erro
 		return fmt.Errorf("digitalocean: api_token is required")
 	}
 
+	d.token = token
+
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 	oauthClient := oauth2.NewClient(ctx, ts)
 	d.client = godo.NewClient(oauthClient)
 
 	if v := creds["base_url"]; v != "" {
-		d.client.BaseURL, _ = d.client.BaseURL.Parse(strings.TrimRight(v, "/") + "/")
+		d.baseURL = strings.TrimRight(v, "/")
+		d.client.BaseURL, _ = d.client.BaseURL.Parse(d.baseURL + "/")
 	}
 
 	return nil
@@ -89,6 +104,67 @@ func listOpts(args map[string]any) *godo.ListOptions {
 	}
 }
 
+// --- HTTP helpers (used by App Platform handlers) ---
+
+func (d *integration) doRequest(ctx context.Context, method, path string, body any) (json.RawMessage, error) {
+	var bodyReader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return nil, err
+		}
+		bodyReader = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, d.baseURL+path, bodyReader)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+d.token)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := d.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 {
+		re := &mcp.RetryableError{StatusCode: resp.StatusCode, Err: fmt.Errorf("digitalocean API error (%d): %s", resp.StatusCode, string(data))}
+		re.RetryAfter = mcp.ParseRetryAfter(resp.Header.Get("Retry-After"))
+		return nil, re
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("digitalocean API error (%d): %s", resp.StatusCode, string(data))
+	}
+	if resp.StatusCode == 204 || len(data) == 0 {
+		return json.RawMessage(`{"status":"success"}`), nil
+	}
+	return json.RawMessage(data), nil
+}
+
+func (d *integration) doGet(ctx context.Context, pathFmt string, args ...any) (json.RawMessage, error) {
+	return d.doRequest(ctx, "GET", fmt.Sprintf(pathFmt, args...), nil)
+}
+
+func (d *integration) doPost(ctx context.Context, path string, body any) (json.RawMessage, error) {
+	return d.doRequest(ctx, "POST", path, body)
+}
+
+func (d *integration) doPut(ctx context.Context, path string, body any) (json.RawMessage, error) {
+	return d.doRequest(ctx, "PUT", path, body)
+}
+
+func (d *integration) doDel(ctx context.Context, pathFmt string, args ...any) (json.RawMessage, error) {
+	return d.doRequest(ctx, "DELETE", fmt.Sprintf(pathFmt, args...), nil)
+}
+
 // --- Dispatch map ---
 
 var dispatch = map[string]handlerFunc{
@@ -132,8 +208,20 @@ var dispatch = map[string]handlerFunc{
 	"digitalocean_get_volume":   getVolume,
 
 	// Apps
-	"digitalocean_list_apps": listApps,
-	"digitalocean_get_app":   getApp,
+	"digitalocean_list_apps":             listApps,
+	"digitalocean_get_app":               getApp,
+	"digitalocean_create_app":            createApp,
+	"digitalocean_update_app":            updateApp,
+	"digitalocean_delete_app":            deleteApp,
+	"digitalocean_restart_app":           restartApp,
+	"digitalocean_list_app_deployments":  listAppDeployments,
+	"digitalocean_get_app_deployment":    getAppDeployment,
+	"digitalocean_create_app_deployment": createAppDeployment,
+	"digitalocean_cancel_app_deployment": cancelAppDeployment,
+	"digitalocean_get_app_logs":          getAppLogs,
+	"digitalocean_get_app_health":        getAppHealth,
+	"digitalocean_list_app_alerts":       listAppAlerts,
+	"digitalocean_rollback_app":          rollbackApp,
 
 	// Extras
 	"digitalocean_list_regions":       listRegions,

--- a/integrations/digitalocean/digitalocean_test.go
+++ b/integrations/digitalocean/digitalocean_test.go
@@ -2,9 +2,12 @@ package digitalocean
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/digitalocean/godo"
 
@@ -139,4 +142,134 @@ func TestWrapRetryable_NonRetryable(t *testing.T) {
 
 func TestWrapRetryable_Nil(t *testing.T) {
 	assert.Nil(t, wrapRetryable(nil))
+}
+
+// --- HTTP helper tests ---
+
+func TestDoRequest_BearerAuth(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"id":"123"}`))
+	}))
+	defer ts.Close()
+
+	d := &integration{token: "test-token", httpClient: ts.Client(), baseURL: ts.URL}
+	data, err := d.doGet(context.Background(), "/test")
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "123")
+}
+
+func TestDoRequest_APIError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(403)
+		w.Write([]byte(`{"error":"forbidden"}`))
+	}))
+	defer ts.Close()
+
+	d := &integration{token: "bad", httpClient: ts.Client(), baseURL: ts.URL}
+	_, err := d.doGet(context.Background(), "/test")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "digitalocean API error (403)")
+}
+
+func TestDoRequest_204NoContent(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(204)
+	}))
+	defer ts.Close()
+
+	d := &integration{token: "tok", httpClient: ts.Client(), baseURL: ts.URL}
+	data, err := d.doRequest(context.Background(), "DELETE", "/test", nil)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "success")
+}
+
+func TestDoRequest_Post(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		var body map[string]string
+		json.NewDecoder(r.Body).Decode(&body)
+		assert.Equal(t, "val", body["key"])
+		w.Write([]byte(`{"created":true}`))
+	}))
+	defer ts.Close()
+
+	d := &integration{token: "tok", httpClient: ts.Client(), baseURL: ts.URL}
+	data, err := d.doPost(context.Background(), "/test", map[string]string{"key": "val"})
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "created")
+}
+
+func TestDoRequest_Put(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PUT", r.Method)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		w.Write([]byte(`{"updated":true}`))
+	}))
+	defer ts.Close()
+
+	d := &integration{token: "tok", httpClient: ts.Client(), baseURL: ts.URL}
+	data, err := d.doPut(context.Background(), "/test", map[string]string{"key": "val"})
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "updated")
+}
+
+func TestDoRequest_Delete(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method)
+		w.WriteHeader(204)
+	}))
+	defer ts.Close()
+
+	d := &integration{token: "tok", httpClient: ts.Client(), baseURL: ts.URL}
+	data, err := d.doDel(context.Background(), "/test")
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "success")
+}
+
+func TestDoRequest_RetryableOn429(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "30")
+		w.WriteHeader(429)
+		w.Write([]byte(`{"error":"rate limited"}`))
+	}))
+	defer ts.Close()
+
+	d := &integration{token: "tok", httpClient: ts.Client(), baseURL: ts.URL}
+	_, err := d.doGet(context.Background(), "/test")
+	require.Error(t, err)
+	assert.True(t, mcp.IsRetryable(err), "429 should produce RetryableError")
+
+	var re *mcp.RetryableError
+	require.ErrorAs(t, err, &re)
+	assert.Equal(t, 429, re.StatusCode)
+	assert.Equal(t, 30*time.Second, re.RetryAfter)
+}
+
+func TestDoRequest_RetryableOn5xx(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(503)
+		w.Write([]byte(`service unavailable`))
+	}))
+	defer ts.Close()
+
+	d := &integration{token: "tok", httpClient: ts.Client(), baseURL: ts.URL}
+	_, err := d.doGet(context.Background(), "/test")
+	require.Error(t, err)
+	assert.True(t, mcp.IsRetryable(err), "503 should produce RetryableError")
+}
+
+func TestDoRequest_NonRetryableOn4xx(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(404)
+		w.Write([]byte(`not found`))
+	}))
+	defer ts.Close()
+
+	d := &integration{token: "tok", httpClient: ts.Client(), baseURL: ts.URL}
+	_, err := d.doGet(context.Background(), "/test")
+	require.Error(t, err)
+	assert.False(t, mcp.IsRetryable(err), "404 should NOT be retryable")
 }

--- a/integrations/digitalocean/extras.go
+++ b/integrations/digitalocean/extras.go
@@ -16,26 +16,6 @@ func getAccount(ctx context.Context, d *integration, _ map[string]any) (*mcp.Too
 	return mcp.JSONResult(acct)
 }
 
-func listApps(ctx context.Context, d *integration, args map[string]any) (*mcp.ToolResult, error) {
-	apps, _, err := d.client.Apps.List(ctx, listOpts(args))
-	if err != nil {
-		return errResult(err)
-	}
-	return mcp.JSONResult(apps)
-}
-
-func getApp(ctx context.Context, d *integration, args map[string]any) (*mcp.ToolResult, error) {
-	id, err := mcp.ArgStr(args, "app_id")
-	if err != nil {
-		return mcp.ErrResult(err)
-	}
-	app, _, err := d.client.Apps.Get(ctx, id)
-	if err != nil {
-		return errResult(err)
-	}
-	return mcp.JSONResult(app)
-}
-
 func listRegions(ctx context.Context, d *integration, _ map[string]any) (*mcp.ToolResult, error) {
 	regions, _, err := d.client.Regions.List(ctx, &godo.ListOptions{PerPage: 200})
 	if err != nil {

--- a/integrations/digitalocean/tools.go
+++ b/integrations/digitalocean/tools.go
@@ -147,9 +147,69 @@ var tools = []mcp.ToolDefinition{
 		Parameters: map[string]string{"page": "Page number", "per_page": "Results per page"},
 	},
 	{
-		Name: "digitalocean_get_app", Description: "Get details of an App Platform app",
+		Name: "digitalocean_get_app", Description: "Get details of an App Platform app including its spec, active deployment, and domain info",
 		Parameters: map[string]string{"app_id": "App UUID"},
 		Required:   []string{"app_id"},
+	},
+	{
+		Name: "digitalocean_create_app", Description: "Create a new App Platform app from a JSON spec. The spec defines services, workers, jobs, databases, and static sites",
+		Parameters: map[string]string{"spec": "App spec as JSON string (see DO App Spec reference)", "project_id": "Optional project UUID to assign the app to"},
+		Required:   []string{"spec"},
+	},
+	{
+		Name: "digitalocean_update_app", Description: "Update an App Platform app's spec. Triggers a new deployment with the updated configuration",
+		Parameters: map[string]string{"app_id": "App UUID", "spec": "Updated app spec as JSON string"},
+		Required:   []string{"app_id", "spec"},
+	},
+	{
+		Name: "digitalocean_delete_app", Description: "Delete an App Platform app and all its resources",
+		Parameters: map[string]string{"app_id": "App UUID"},
+		Required:   []string{"app_id"},
+	},
+	{
+		Name: "digitalocean_restart_app", Description: "Restart an App Platform app. Optionally restart only specific components",
+		Parameters: map[string]string{"app_id": "App UUID", "components": "Comma-separated component names to restart (omit to restart all)"},
+		Required:   []string{"app_id"},
+	},
+	{
+		Name: "digitalocean_list_app_deployments", Description: "List deployment history for an App Platform app",
+		Parameters: map[string]string{"app_id": "App UUID", "page": "Page number", "per_page": "Results per page"},
+		Required:   []string{"app_id"},
+	},
+	{
+		Name: "digitalocean_get_app_deployment", Description: "Get details of a specific deployment including phase, progress, and timing",
+		Parameters: map[string]string{"app_id": "App UUID", "deployment_id": "Deployment UUID"},
+		Required:   []string{"app_id", "deployment_id"},
+	},
+	{
+		Name: "digitalocean_create_app_deployment", Description: "Trigger a new deployment for an App Platform app",
+		Parameters: map[string]string{"app_id": "App UUID", "force_build": "Force rebuild even if no changes detected (true/false)"},
+		Required:   []string{"app_id"},
+	},
+	{
+		Name: "digitalocean_cancel_app_deployment", Description: "Cancel an in-progress deployment",
+		Parameters: map[string]string{"app_id": "App UUID", "deployment_id": "Deployment UUID"},
+		Required:   []string{"app_id", "deployment_id"},
+	},
+	{
+		Name: "digitalocean_get_app_logs", Description: "Get logs for a specific deployment. Use digitalocean_list_app_deployments to find deployment IDs",
+		Parameters: map[string]string{"app_id": "App UUID", "deployment_id": "Deployment UUID", "component": "Component name to filter logs", "log_type": "Log type: BUILD, DEPLOY, or RUN (defaults to RUN)"},
+		Required:   []string{"app_id", "deployment_id"},
+	},
+	{
+		Name: "digitalocean_get_app_health", Description: "Get health status of an App Platform app and its components",
+		Parameters: map[string]string{"app_id": "App UUID"},
+		Required:   []string{"app_id"},
+	},
+	{
+		Name: "digitalocean_list_app_alerts", Description: "List all configured alerts for an App Platform app",
+		Parameters: map[string]string{"app_id": "App UUID"},
+		Required:   []string{"app_id"},
+	},
+	{
+		Name: "digitalocean_rollback_app", Description: "Rollback an App Platform app to a previous deployment",
+		Parameters: map[string]string{"app_id": "App UUID", "deployment_id": "Deployment UUID to rollback to"},
+		Required:   []string{"app_id", "deployment_id"},
 	},
 
 	// ── Extras ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds 12 new App Platform tools to the DigitalOcean integration using the REST API directly (raw HTTP, not godo SDK)
- Rewrites existing `list_apps` and `get_app` to use the REST API
- Adds HTTP helper infrastructure (`doRequest`, `doGet`, `doPost`, `doPut`, `doDel`) to the integration for direct API calls

### New tools
| Tool | Description |
|------|-------------|
| `digitalocean_create_app` | Create app from JSON spec |
| `digitalocean_update_app` | Update app configuration |
| `digitalocean_delete_app` | Delete an app |
| `digitalocean_restart_app` | Restart app (optionally specific components) |
| `digitalocean_list_app_deployments` | List deployment history |
| `digitalocean_get_app_deployment` | Get deployment details |
| `digitalocean_create_app_deployment` | Trigger new deployment |
| `digitalocean_cancel_app_deployment` | Cancel in-progress deployment |
| `digitalocean_get_app_logs` | Get deployment logs |
| `digitalocean_get_app_health` | Get app health status |
| `digitalocean_list_app_alerts` | List app alerts |
| `digitalocean_rollback_app` | Rollback to previous deployment |

## Test plan
- [x] `go test -race ./integrations/digitalocean/...` passes
- [x] `go vet ./integrations/digitalocean/...` passes
- [x] `golangci-lint run ./integrations/digitalocean/...` — 0 issues
- [x] Dispatch parity tests verify all 64 tools have handlers and no orphans
- [ ] Manual smoke test against a DigitalOcean account with App Platform apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)