### PR TITLE
Add App Platform support to DigitalOcean integration

### DIFF
--- a/integrations/digitalocean/apps.go
+++ b/integrations/digitalocean/apps.go
@@ -103,11 +103,11 @@ func getAppLogs(ctx context.Context, d *integration, args map[string]any) (*mcp.
 	r := mcp.NewArgs(args)
 	appID := r.Str("app_id")
 	logType := r.Str("log_type")
+	deploymentID := r.Str("deployment_id")
+	component := r.Str("component")
 	if err := r.Err(); err != nil {
 		return mcp.ErrResult(err)
 	}
-	deploymentID, _ := mcp.ArgStr(args, "deployment_id")
-	component, _ := mcp.ArgStr(args, "component")
 	tailLines := mcp.OptInt(args, "tail_lines", 100)
 	logs, _, err := d.client.Apps.GetLogs(ctx, appID, deploymentID, component, godo.AppLogType(logType), false, tailLines)
 	if err != nil {

--- a/integrations/digitalocean/apps.go
+++ b/integrations/digitalocean/apps.go
@@ -1,0 +1,141 @@
+package digitalocean
+
+import (
+	"context"
+
+	"github.com/digitalocean/godo"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+func listApps(ctx context.Context, d *integration, args map[string]any) (*mcp.ToolResult, error) {
+	apps, _, err := d.client.Apps.List(ctx, listOpts(args))
+	if err != nil {
+		return errResult(err)
+	}
+	return mcp.JSONResult(apps)
+}
+
+func getApp(ctx context.Context, d *integration, args map[string]any) (*mcp.ToolResult, error) {
+	id, err := mcp.ArgStr(args, "app_id")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	app, _, err := d.client.Apps.Get(ctx, id)
+	if err != nil {
+		return errResult(err)
+	}
+	return mcp.JSONResult(app)
+}
+
+func deleteApp(ctx context.Context, d *integration, args map[string]any) (*mcp.ToolResult, error) {
+	id, err := mcp.ArgStr(args, "app_id")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	_, err = d.client.Apps.Delete(ctx, id)
+	if err != nil {
+		return errResult(err)
+	}
+	return mcp.JSONResult(map[string]string{"status": "deleted", "app_id": id})
+}
+
+func restartApp(ctx context.Context, d *integration, args map[string]any) (*mcp.ToolResult, error) {
+	id, err := mcp.ArgStr(args, "app_id")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	components, _ := mcp.ArgStrSlice(args, "components")
+	deployment, _, err := d.client.Apps.Restart(ctx, id, &godo.AppRestartRequest{
+		Components: components,
+	})
+	if err != nil {
+		return errResult(err)
+	}
+	return mcp.JSONResult(deployment)
+}
+
+func listAppDeployments(ctx context.Context, d *integration, args map[string]any) (*mcp.ToolResult, error) {
+	id, err := mcp.ArgStr(args, "app_id")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	deployments, _, err := d.client.Apps.ListDeployments(ctx, id, listOpts(args))
+	if err != nil {
+		return errResult(err)
+	}
+	return mcp.JSONResult(deployments)
+}
+
+func getAppDeployment(ctx context.Context, d *integration, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	appID := r.Str("app_id")
+	deploymentID := r.Str("deployment_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	deployment, _, err := d.client.Apps.GetDeployment(ctx, appID, deploymentID)
+	if err != nil {
+		return errResult(err)
+	}
+	return mcp.JSONResult(deployment)
+}
+
+func createAppDeployment(ctx context.Context, d *integration, args map[string]any) (*mcp.ToolResult, error) {
+	id, err := mcp.ArgStr(args, "app_id")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	forceBuild, _ := mcp.ArgBool(args, "force_build")
+	var deployment *godo.Deployment
+	if forceBuild {
+		deployment, _, err = d.client.Apps.CreateDeployment(ctx, id, &godo.DeploymentCreateRequest{ForceBuild: true})
+	} else {
+		deployment, _, err = d.client.Apps.CreateDeployment(ctx, id)
+	}
+	if err != nil {
+		return errResult(err)
+	}
+	return mcp.JSONResult(deployment)
+}
+
+func getAppLogs(ctx context.Context, d *integration, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	appID := r.Str("app_id")
+	logType := r.Str("log_type")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	deploymentID, _ := mcp.ArgStr(args, "deployment_id")
+	component, _ := mcp.ArgStr(args, "component")
+	tailLines := mcp.OptInt(args, "tail_lines", 100)
+	logs, _, err := d.client.Apps.GetLogs(ctx, appID, deploymentID, component, godo.AppLogType(logType), false, tailLines)
+	if err != nil {
+		return errResult(err)
+	}
+	return mcp.JSONResult(logs)
+}
+
+func getAppHealth(ctx context.Context, d *integration, args map[string]any) (*mcp.ToolResult, error) {
+	id, err := mcp.ArgStr(args, "app_id")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	health, _, err := d.client.Apps.GetAppHealth(ctx, id)
+	if err != nil {
+		return errResult(err)
+	}
+	return mcp.JSONResult(health)
+}
+
+func listAppAlerts(ctx context.Context, d *integration, args map[string]any) (*mcp.ToolResult, error) {
+	id, err := mcp.ArgStr(args, "app_id")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	alerts, _, err := d.client.Apps.ListAlerts(ctx, id)
+	if err != nil {
+		return errResult(err)
+	}
+	return mcp.JSONResult(alerts)
+}

--- a/integrations/digitalocean/digitalocean.go
+++ b/integrations/digitalocean/digitalocean.go
@@ -132,8 +132,16 @@ var dispatch = map[string]handlerFunc{
 	"digitalocean_get_volume":   getVolume,
 
 	// Apps
-	"digitalocean_list_apps": listApps,
-	"digitalocean_get_app":   getApp,
+	"digitalocean_list_apps":             listApps,
+	"digitalocean_get_app":               getApp,
+	"digitalocean_delete_app":            deleteApp,
+	"digitalocean_restart_app":           restartApp,
+	"digitalocean_list_app_deployments":  listAppDeployments,
+	"digitalocean_get_app_deployment":    getAppDeployment,
+	"digitalocean_create_app_deployment": createAppDeployment,
+	"digitalocean_get_app_logs":          getAppLogs,
+	"digitalocean_get_app_health":        getAppHealth,
+	"digitalocean_list_app_alerts":       listAppAlerts,
 
 	// Extras
 	"digitalocean_list_regions":       listRegions,

--- a/integrations/digitalocean/extras.go
+++ b/integrations/digitalocean/extras.go
@@ -16,26 +16,6 @@ func getAccount(ctx context.Context, d *integration, _ map[string]any) (*mcp.Too
 	return mcp.JSONResult(acct)
 }
 
-func listApps(ctx context.Context, d *integration, args map[string]any) (*mcp.ToolResult, error) {
-	apps, _, err := d.client.Apps.List(ctx, listOpts(args))
-	if err != nil {
-		return errResult(err)
-	}
-	return mcp.JSONResult(apps)
-}
-
-func getApp(ctx context.Context, d *integration, args map[string]any) (*mcp.ToolResult, error) {
-	id, err := mcp.ArgStr(args, "app_id")
-	if err != nil {
-		return mcp.ErrResult(err)
-	}
-	app, _, err := d.client.Apps.Get(ctx, id)
-	if err != nil {
-		return errResult(err)
-	}
-	return mcp.JSONResult(app)
-}
-
 func listRegions(ctx context.Context, d *integration, _ map[string]any) (*mcp.ToolResult, error) {
 	regions, _, err := d.client.Regions.List(ctx, &godo.ListOptions{PerPage: 200})
 	if err != nil {

--- a/integrations/digitalocean/tools.go
+++ b/integrations/digitalocean/tools.go
@@ -178,7 +178,7 @@ var tools = []mcp.ToolDefinition{
 	},
 	{
 		Name: "digitalocean_get_app_logs", Description: "Get logs for an App Platform app. Use log_type BUILD for build logs, DEPLOY for deploy logs, or RUN for runtime logs",
-		Parameters: map[string]string{"app_id": "App UUID", "deployment_id": "Deployment UUID (omit for active deployment)", "component": "Component name (omit for all components)", "log_type": "Log type: BUILD, DEPLOY, RUN, or RUN_RESTARTED", "tail_lines": "Number of log lines to return (default 100)"},
+		Parameters: map[string]string{"app_id": "App UUID", "deployment_id": "Deployment UUID (omit for active deployment)", "component": "Component name (omit for all components)", "log_type": "Log type: BUILD, DEPLOY, RUN, RUN_RESTARTED, or AUTOSCALE_EVENT", "tail_lines": "Number of log lines to return (default 100)"},
 		Required:   []string{"app_id", "log_type"},
 	},
 	{

--- a/integrations/digitalocean/tools.go
+++ b/integrations/digitalocean/tools.go
@@ -147,7 +147,47 @@ var tools = []mcp.ToolDefinition{
 		Parameters: map[string]string{"page": "Page number", "per_page": "Results per page"},
 	},
 	{
-		Name: "digitalocean_get_app", Description: "Get details of an App Platform app",
+		Name: "digitalocean_get_app", Description: "Get details of an App Platform app including its spec and active deployment",
+		Parameters: map[string]string{"app_id": "App UUID"},
+		Required:   []string{"app_id"},
+	},
+	{
+		Name: "digitalocean_delete_app", Description: "Delete an App Platform app",
+		Parameters: map[string]string{"app_id": "App UUID"},
+		Required:   []string{"app_id"},
+	},
+	{
+		Name: "digitalocean_restart_app", Description: "Restart an App Platform app, optionally targeting specific components",
+		Parameters: map[string]string{"app_id": "App UUID", "components": "Comma-separated component names to restart (omit to restart all)"},
+		Required:   []string{"app_id"},
+	},
+	{
+		Name: "digitalocean_list_app_deployments", Description: "List deployments for an App Platform app",
+		Parameters: map[string]string{"app_id": "App UUID", "page": "Page number", "per_page": "Results per page"},
+		Required:   []string{"app_id"},
+	},
+	{
+		Name: "digitalocean_get_app_deployment", Description: "Get details of a specific App Platform deployment",
+		Parameters: map[string]string{"app_id": "App UUID", "deployment_id": "Deployment UUID"},
+		Required:   []string{"app_id", "deployment_id"},
+	},
+	{
+		Name: "digitalocean_create_app_deployment", Description: "Trigger a new deployment for an App Platform app",
+		Parameters: map[string]string{"app_id": "App UUID", "force_build": "Force rebuild even if no source changes (true/false)"},
+		Required:   []string{"app_id"},
+	},
+	{
+		Name: "digitalocean_get_app_logs", Description: "Get logs for an App Platform app. Use log_type BUILD for build logs, DEPLOY for deploy logs, or RUN for runtime logs",
+		Parameters: map[string]string{"app_id": "App UUID", "deployment_id": "Deployment UUID (omit for active deployment)", "component": "Component name (omit for all components)", "log_type": "Log type: BUILD, DEPLOY, RUN, or RUN_RESTARTED", "tail_lines": "Number of log lines to return (default 100)"},
+		Required:   []string{"app_id", "log_type"},
+	},
+	{
+		Name: "digitalocean_get_app_health", Description: "Get health status of all components in an App Platform app",
+		Parameters: map[string]string{"app_id": "App UUID"},
+		Required:   []string{"app_id"},
+	},
+	{
+		Name: "digitalocean_list_app_alerts", Description: "List alerts configured for an App Platform app",
 		Parameters: map[string]string{"app_id": "App UUID"},
 		Required:   []string{"app_id"},
 	},


### PR DESCRIPTION
## Summary
- Add 8 new App Platform tools to the DigitalOcean integration: `delete_app`, `restart_app`, `list_app_deployments`, `get_app_deployment`, `create_app_deployment`, `get_app_logs`, `get_app_health`, `list_app_alerts`
- Move existing `list_apps` and `get_app` handlers from `extras.go` into a dedicated `apps.go` handler file
- Total DigitalOcean tools: 45 → 53

## Test plan
- [x] `go build` passes
- [x] `go vet` passes
- [x] `golangci-lint` passes (0 issues)
- [x] All 16 DigitalOcean tests pass including dispatch map parity, tool name validation, and no-duplicate checks
- [x] `gofmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)