### PR TITLE
fix(sdk): coerce string args to bool/int in guest SDK

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/daltoniam/switchboard/browser"
 	"github.com/daltoniam/switchboard/config"
 	"github.com/daltoniam/switchboard/daemon"
+	acpInt "github.com/daltoniam/switchboard/integrations/acp"
 	"github.com/daltoniam/switchboard/integrations/amazon"
 	awsInt "github.com/daltoniam/switchboard/integrations/aws"
 	"github.com/daltoniam/switchboard/integrations/clickhouse"
@@ -226,6 +227,7 @@ func runServer(stdioMode bool, port int, discoverAll bool) {
 		digitalocean.New(),
 		flyInt.New(),
 		snowflakeInt.New(),
+		acpInt.New(),
 	} {
 		if err := reg.Register(i); err != nil {
 			log.Fatalf("Failed to register integration: %v", err)

--- a/config/config.go
+++ b/config/config.go
@@ -112,6 +112,9 @@ var envMapping = map[string]map[string]string{
 		"role":        "SNOWFLAKE_ROLE",
 		"account_url": "SNOWFLAKE_ACCOUNT_URL",
 	},
+	"acp": {
+		"config": "ACP_CONFIG",
+	},
 }
 
 // EnvMapping returns the env var mapping table. Useful for documentation and debugging.
@@ -263,6 +266,10 @@ func defaultConfig() *mcp.Config {
 			"snowflake": {
 				Enabled:     false,
 				Credentials: mcp.Credentials{"account": "", "token": "", "warehouse": "", "database": "", "schema": "", "role": "", "account_url": ""},
+			},
+			"acp": {
+				Enabled:     false,
+				Credentials: mcp.Credentials{"config": ""},
 			},
 		},
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -32,7 +32,7 @@ func TestLoad_CreatesDefaultWhenMissing(t *testing.T) {
 	_, err = os.Stat(path)
 	assert.NoError(t, err)
 
-	assert.Len(t, m.cfg.Integrations, 28)
+	assert.Len(t, m.cfg.Integrations, 29)
 	for _, name := range []string{"github", "datadog", "linear", "sentry", "slack", "metabase", "aws", "posthog", "postgres", "clickhouse", "elasticsearch", "pganalyze", "rwx", "gmail", "homeassistant", "notion", "ynab", "gcp", "suno", "amazon", "jira", "confluence", "readarr", "salesforce", "cloudflare", "digitalocean", "fly", "snowflake"} {
 		ic, ok := m.cfg.Integrations[name]
 		assert.True(t, ok, "missing default integration: %s", name)
@@ -134,7 +134,7 @@ func TestSave(t *testing.T) {
 
 	var cfg mcp.Config
 	require.NoError(t, json.Unmarshal(data, &cfg))
-	assert.Len(t, cfg.Integrations, 28)
+	assert.Len(t, cfg.Integrations, 29)
 }
 
 func TestGet(t *testing.T) {
@@ -143,7 +143,7 @@ func TestGet(t *testing.T) {
 
 	cfg := m.Get()
 	assert.NotNil(t, cfg)
-	assert.Len(t, cfg.Integrations, 28)
+	assert.Len(t, cfg.Integrations, 29)
 }
 
 func TestUpdate(t *testing.T) {
@@ -253,7 +253,7 @@ func TestEnabledIntegrations_Multiple(t *testing.T) {
 func TestDefaultConfig(t *testing.T) {
 	cfg := defaultConfig()
 	require.NotNil(t, cfg)
-	assert.Len(t, cfg.Integrations, 28)
+	assert.Len(t, cfg.Integrations, 29)
 
 	expected := map[string][]string{
 		"github":        {"token", "client_id", "token_source"},
@@ -486,7 +486,7 @@ func TestEnvMapping_ReturnsMapping(t *testing.T) {
 	assert.Equal(t, "RWX_ACCESS_TOKEN", m["rwx"]["access_token"])
 	assert.Equal(t, "RWX_ORG", m["rwx"]["org"])
 	assert.Equal(t, "RWX_CLI_PATH", m["rwx"]["cli_path"])
-	assert.Len(t, m, 19)
+	assert.Len(t, m, 20)
 	assert.Equal(t, "JIRA_EMAIL", m["jira"]["email"])
 	assert.Equal(t, "JIRA_API_TOKEN", m["jira"]["api_token"])
 	assert.Equal(t, "JIRA_DOMAIN", m["jira"]["domain"])

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/daltoniam/switchboard
 
-go 1.26.1
+go 1.26.2
 
 require (
 	cloud.google.com/go/compute v1.38.0

--- a/integrations/acp/acp.go
+++ b/integrations/acp/acp.go
@@ -1,0 +1,349 @@
+package acp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+type acpIntegration struct {
+	clients map[string]*client
+	timeout time.Duration
+}
+
+var _ mcp.PlainTextCredentials = (*acpIntegration)(nil)
+var _ mcp.PlaceholderHints = (*acpIntegration)(nil)
+var _ mcp.OptionalCredentials = (*acpIntegration)(nil)
+
+func New() mcp.Integration {
+	return &acpIntegration{
+		clients: make(map[string]*client),
+		timeout: 120 * time.Second,
+	}
+}
+
+func (a *acpIntegration) Name() string { return "acp" }
+
+// serverEntry represents a single ACP server parsed from the config JSON.
+type serverEntry struct {
+	Name    string            `json:"name"`
+	URL     string            `json:"url"`
+	Headers map[string]string `json:"headers,omitempty"`
+}
+
+func (a *acpIntegration) Configure(_ context.Context, creds mcp.Credentials) error {
+	raw := creds["config"]
+	if raw == "" {
+		return nil
+	}
+
+	var cfg struct {
+		Servers []serverEntry `json:"servers"`
+	}
+	if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
+		return fmt.Errorf("acp: invalid config JSON: %w", err)
+	}
+
+	a.clients = make(map[string]*client, len(cfg.Servers))
+	for _, srv := range cfg.Servers {
+		if srv.URL == "" {
+			return fmt.Errorf("acp: server %q has no url", srv.Name)
+		}
+		name := srv.Name
+		if name == "" {
+			name = srv.URL
+		}
+		a.clients[name] = newClient(name, srv.URL, srv.Headers)
+	}
+	return nil
+}
+
+func (a *acpIntegration) PlainTextKeys() []string { return []string{"config"} }
+func (a *acpIntegration) OptionalKeys() []string  { return []string{"config"} }
+func (a *acpIntegration) Placeholders() map[string]string {
+	return map[string]string{
+		"config": `{"servers":[{"name":"local","url":"http://localhost:8199"}]}`,
+	}
+}
+
+func (a *acpIntegration) Healthy(ctx context.Context) bool {
+	if len(a.clients) == 0 {
+		return true
+	}
+	for _, c := range a.clients {
+		_, err := c.listAgents(ctx)
+		if err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+func (a *acpIntegration) Tools() []mcp.ToolDefinition {
+	return tools
+}
+
+func (a *acpIntegration) Execute(ctx context.Context, toolName string, args map[string]any) (*mcp.ToolResult, error) {
+	fn, ok := dispatch[toolName]
+	if !ok {
+		return &mcp.ToolResult{Data: fmt.Sprintf("unknown tool: %s", toolName), IsError: true}, nil
+	}
+	return fn(ctx, a, args)
+}
+
+type handlerFunc func(ctx context.Context, a *acpIntegration, args map[string]any) (*mcp.ToolResult, error)
+
+var dispatch = map[string]handlerFunc{
+	"acp_list_agents": handleListAgents,
+	"acp_run_agent":   handleRunAgent,
+	"acp_resume_run":  handleResumeRun,
+}
+
+// resolveClient returns a client based on the args. Priority:
+// 1. server_url — create an ephemeral client for the inline URL
+// 2. server — look up a pre-configured client by name
+// 3. first pre-configured client
+func (a *acpIntegration) resolveClient(args map[string]any) (*client, error) {
+	serverURL, _ := mcp.ArgStr(args, "server_url")
+	if serverURL != "" {
+		headers := parseHeaders(args)
+		return newClient(serverURL, serverURL, headers), nil
+	}
+
+	serverName, _ := mcp.ArgStr(args, "server")
+	if serverName != "" {
+		c, ok := a.clients[serverName]
+		if !ok {
+			available := make([]string, 0, len(a.clients))
+			for k := range a.clients {
+				available = append(available, k)
+			}
+			return nil, fmt.Errorf("server %q not found, available: %s", serverName, strings.Join(available, ", "))
+		}
+		return c, nil
+	}
+
+	for _, c := range a.clients {
+		return c, nil
+	}
+	return nil, fmt.Errorf("no ACP server specified: provide server_url or configure servers in credentials")
+}
+
+// parseHeaders extracts optional HTTP headers from the server_headers arg.
+func parseHeaders(args map[string]any) map[string]string {
+	raw, _ := mcp.ArgStr(args, "server_headers")
+	if raw == "" {
+		return nil
+	}
+	var headers map[string]string
+	if json.Unmarshal([]byte(raw), &headers) != nil {
+		return nil
+	}
+	return headers
+}
+
+func handleListAgents(ctx context.Context, a *acpIntegration, args map[string]any) (*mcp.ToolResult, error) {
+	serverURL, _ := mcp.ArgStr(args, "server_url")
+	serverName, _ := mcp.ArgStr(args, "server")
+
+	if serverURL == "" && serverName == "" && len(a.clients) > 0 {
+		var allAgents []map[string]string
+		for name, c := range a.clients {
+			agents, err := c.listAgents(ctx)
+			if err != nil {
+				allAgents = append(allAgents, map[string]string{
+					"server": name,
+					"error":  err.Error(),
+				})
+				continue
+			}
+			for _, agent := range agents {
+				allAgents = append(allAgents, map[string]string{
+					"name":        agent.Name,
+					"description": agent.Description,
+					"server":      name,
+				})
+			}
+		}
+		return mcp.JSONResult(allAgents)
+	}
+
+	c, err := a.resolveClient(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	agents, err := c.listAgents(ctx)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	summaries := make([]map[string]string, len(agents))
+	for i, agent := range agents {
+		summaries[i] = map[string]string{
+			"name":        agent.Name,
+			"description": agent.Description,
+			"server":      c.name,
+		}
+	}
+	return mcp.JSONResult(summaries)
+}
+
+func handleRunAgent(ctx context.Context, a *acpIntegration, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	agentName := r.Str("agent_name")
+	input := r.Str("input")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if agentName == "" {
+		return mcp.ErrResult(fmt.Errorf("agent_name is required"))
+	}
+	if input == "" {
+		return mcp.ErrResult(fmt.Errorf("input is required"))
+	}
+
+	sessionID, _ := mcp.ArgStr(args, "session_id")
+
+	c, err := a.resolveClient(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	messages := []Message{NewUserMessage(input)}
+
+	events, err := c.createRunStream(ctx, agentName, messages, sessionID)
+	if err != nil {
+		return runSync(ctx, c, a.timeout, agentName, messages, sessionID)
+	}
+	return collectStreamResponse(events)
+}
+
+func handleResumeRun(ctx context.Context, a *acpIntegration, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	runID := r.Str("run_id")
+	input := r.Str("input")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if runID == "" {
+		return mcp.ErrResult(fmt.Errorf("run_id is required"))
+	}
+	if input == "" {
+		return mcp.ErrResult(fmt.Errorf("input is required"))
+	}
+
+	c, err := a.resolveClient(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	resume := &AwaitResume{
+		Message: &Message{
+			Role:  "user",
+			Parts: []MessagePart{{ContentType: "text/plain", Content: input}},
+		},
+	}
+
+	events, err := c.resumeRunStream(ctx, runID, resume)
+	if err != nil {
+		run, syncErr := c.resumeRun(ctx, runID, resume)
+		if syncErr != nil {
+			return mcp.ErrResult(syncErr)
+		}
+		return formatRunResponse(run)
+	}
+	return collectStreamResponse(events)
+}
+
+func runSync(ctx context.Context, c *client, timeout time.Duration, agentName string, input []Message, sessionID string) (*mcp.ToolResult, error) {
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	run, err := c.createRunSync(timeoutCtx, agentName, input, sessionID)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return formatRunResponse(run)
+}
+
+func collectStreamResponse(events <-chan Event) (*mcp.ToolResult, error) {
+	var parts []string
+	var lastRun *Run
+
+	for event := range events {
+		switch event.Type {
+		case EventMessagePart:
+			if event.Part != nil && event.Part.Content != "" {
+				parts = append(parts, event.Part.Content)
+			}
+		case EventMessageCompleted:
+			if event.Message != nil {
+				text := TextContent([]Message{*event.Message})
+				if text != "" && len(parts) == 0 {
+					parts = append(parts, text)
+				}
+			}
+		case EventRunCompleted, EventRunFailed, EventRunAwaiting, EventRunCancelled:
+			lastRun = event.Run
+		case EventError:
+			if event.Error != nil {
+				return &mcp.ToolResult{Data: event.Error.Message, IsError: true}, nil
+			}
+		}
+	}
+
+	if lastRun != nil && lastRun.Status == RunStatusAwaiting {
+		return formatRunResponse(lastRun)
+	}
+
+	if lastRun != nil && lastRun.Status == RunStatusFailed {
+		msg := "agent run failed"
+		if lastRun.Error != nil {
+			msg = lastRun.Error.Message
+		}
+		return &mcp.ToolResult{Data: msg, IsError: true}, nil
+	}
+
+	if len(parts) > 0 {
+		return &mcp.ToolResult{Data: strings.Join(parts, "")}, nil
+	}
+
+	if lastRun != nil {
+		return formatRunResponse(lastRun)
+	}
+
+	return &mcp.ToolResult{Data: "no response received from agent", IsError: true}, nil
+}
+
+func formatRunResponse(run *Run) (*mcp.ToolResult, error) {
+	if run.Status == RunStatusAwaiting {
+		awaitMsg := "The agent is waiting for additional input."
+		if run.AwaitRequest != nil && run.AwaitRequest.Message != nil {
+			awaitMsg = TextContent([]Message{*run.AwaitRequest.Message})
+		}
+		result := map[string]any{
+			"status":  "awaiting",
+			"run_id":  run.RunID,
+			"message": awaitMsg,
+		}
+		return mcp.JSONResult(result)
+	}
+
+	if run.Status == RunStatusFailed {
+		msg := "agent run failed"
+		if run.Error != nil {
+			msg = run.Error.Message
+		}
+		return &mcp.ToolResult{Data: msg, IsError: true}, nil
+	}
+
+	text := TextContent(run.Output)
+	if text != "" {
+		return &mcp.ToolResult{Data: text}, nil
+	}
+	return mcp.JSONResult(run)
+}

--- a/integrations/acp/acp_test.go
+++ b/integrations/acp/acp_test.go
@@ -1,0 +1,721 @@
+package acp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestName(t *testing.T) {
+	i := New()
+	assert.Equal(t, "acp", i.Name())
+}
+
+func TestConfigure_Success(t *testing.T) {
+	ts := newMockAgentsServer(t, []AgentManifest{{Name: "echo"}})
+	defer ts.Close()
+
+	i := New()
+	err := i.Configure(context.Background(), mcp.Credentials{
+		"config": fmt.Sprintf(`{"servers":[{"name":"test","url":"%s"}]}`, ts.URL),
+	})
+	assert.NoError(t, err)
+}
+
+func TestConfigure_EmptyConfig(t *testing.T) {
+	i := New()
+	err := i.Configure(context.Background(), mcp.Credentials{})
+	assert.NoError(t, err)
+}
+
+func TestConfigure_InvalidJSON(t *testing.T) {
+	i := New()
+	err := i.Configure(context.Background(), mcp.Credentials{"config": "not json"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid config JSON")
+}
+
+func TestConfigure_EmptyServersArray(t *testing.T) {
+	i := New()
+	err := i.Configure(context.Background(), mcp.Credentials{"config": `{"servers":[]}`})
+	assert.NoError(t, err)
+}
+
+func TestConfigure_ServerMissingURL(t *testing.T) {
+	i := New()
+	err := i.Configure(context.Background(), mcp.Credentials{
+		"config": `{"servers":[{"name":"bad"}]}`,
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no url")
+}
+
+func TestConfigure_MultipleServers(t *testing.T) {
+	ts1 := newMockAgentsServer(t, []AgentManifest{{Name: "a1"}})
+	defer ts1.Close()
+	ts2 := newMockAgentsServer(t, []AgentManifest{{Name: "a2"}})
+	defer ts2.Close()
+
+	i := New()
+	cfg := fmt.Sprintf(`{"servers":[{"name":"s1","url":"%s"},{"name":"s2","url":"%s"}]}`, ts1.URL, ts2.URL)
+	err := i.Configure(context.Background(), mcp.Credentials{"config": cfg})
+	assert.NoError(t, err)
+
+	a := i.(*acpIntegration)
+	assert.Len(t, a.clients, 2)
+}
+
+func TestTools(t *testing.T) {
+	i := New()
+	tl := i.Tools()
+	assert.Len(t, tl, 3)
+	for _, tool := range tl {
+		assert.NotEmpty(t, tool.Name)
+		assert.NotEmpty(t, tool.Description)
+	}
+}
+
+func TestTools_AllHaveACPPrefix(t *testing.T) {
+	i := New()
+	for _, tool := range i.Tools() {
+		assert.Contains(t, tool.Name, "acp_", "tool %s missing acp_ prefix", tool.Name)
+	}
+}
+
+func TestTools_NoDuplicateNames(t *testing.T) {
+	i := New()
+	seen := make(map[string]bool)
+	for _, tool := range i.Tools() {
+		assert.False(t, seen[tool.Name], "duplicate tool name: %s", tool.Name)
+		seen[tool.Name] = true
+	}
+}
+
+func TestTools_AllHaveServerURLParam(t *testing.T) {
+	i := New()
+	for _, tool := range i.Tools() {
+		_, ok := tool.Parameters["server_url"]
+		assert.True(t, ok, "tool %s missing server_url parameter", tool.Name)
+	}
+}
+
+func TestDispatchMap_AllToolsCovered(t *testing.T) {
+	i := New()
+	for _, tool := range i.Tools() {
+		_, ok := dispatch[tool.Name]
+		assert.True(t, ok, "tool %s has no dispatch handler", tool.Name)
+	}
+}
+
+func TestDispatchMap_NoOrphanHandlers(t *testing.T) {
+	i := New()
+	toolNames := make(map[string]bool)
+	for _, tool := range i.Tools() {
+		toolNames[tool.Name] = true
+	}
+	for name := range dispatch {
+		assert.True(t, toolNames[name], "dispatch handler %s has no tool definition", name)
+	}
+}
+
+func TestExecute_UnknownTool(t *testing.T) {
+	a := &acpIntegration{clients: make(map[string]*client)}
+	result, err := a.Execute(context.Background(), "acp_nonexistent", nil)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "unknown tool")
+}
+
+func TestHealthy(t *testing.T) {
+	ts := newMockAgentsServer(t, []AgentManifest{{Name: "echo"}})
+	defer ts.Close()
+
+	a := newTestACP(t, ts.URL)
+	assert.True(t, a.Healthy(context.Background()))
+}
+
+func TestHealthy_NoClients(t *testing.T) {
+	a := &acpIntegration{clients: make(map[string]*client)}
+	assert.True(t, a.Healthy(context.Background()))
+}
+
+func TestHealthy_Failure(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(500)
+	}))
+	defer ts.Close()
+
+	a := newTestACP(t, ts.URL)
+	assert.False(t, a.Healthy(context.Background()))
+}
+
+func TestPlainTextKeys(t *testing.T) {
+	a := New().(*acpIntegration)
+	assert.Equal(t, []string{"config"}, a.PlainTextKeys())
+}
+
+func TestOptionalKeys(t *testing.T) {
+	a := New().(*acpIntegration)
+	assert.Equal(t, []string{"config"}, a.OptionalKeys())
+}
+
+func TestPlaceholders(t *testing.T) {
+	a := New().(*acpIntegration)
+	ph := a.Placeholders()
+	assert.Contains(t, ph["config"], "servers")
+}
+
+// --- Tool handler tests: pre-configured servers ---
+
+func TestListAgents(t *testing.T) {
+	agents := []AgentManifest{
+		{Name: "echo", Description: "Echoes input"},
+		{Name: "summarizer", Description: "Summarizes text"},
+	}
+	ts := newMockAgentsServer(t, agents)
+	defer ts.Close()
+
+	a := newTestACP(t, ts.URL)
+	result, err := a.Execute(context.Background(), "acp_list_agents", map[string]any{})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "echo")
+	assert.Contains(t, result.Data, "summarizer")
+}
+
+func TestListAgents_SpecificServer(t *testing.T) {
+	ts := newMockAgentsServer(t, []AgentManifest{{Name: "echo"}})
+	defer ts.Close()
+
+	a := newTestACP(t, ts.URL)
+	result, err := a.Execute(context.Background(), "acp_list_agents", map[string]any{"server": "test"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "echo")
+}
+
+func TestListAgents_UnknownServer(t *testing.T) {
+	a := newTestACP(t, "http://unused")
+	result, err := a.Execute(context.Background(), "acp_list_agents", map[string]any{"server": "nonexistent"})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "not found")
+}
+
+func TestRunAgent_Sync(t *testing.T) {
+	ts := newEchoServer(t)
+	defer ts.Close()
+
+	a := newTestACP(t, ts.URL)
+	result, err := a.Execute(context.Background(), "acp_run_agent", map[string]any{
+		"agent_name": "echo",
+		"input":      "hello world",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "hello world")
+}
+
+func TestRunAgent_Stream(t *testing.T) {
+	ts := newStreamServer(t)
+	defer ts.Close()
+
+	a := newTestACP(t, ts.URL)
+	result, err := a.Execute(context.Background(), "acp_run_agent", map[string]any{
+		"agent_name": "echo",
+		"input":      "hi",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "Hello World")
+}
+
+func TestRunAgent_MissingParams(t *testing.T) {
+	a := newTestACP(t, "http://unused")
+	result, err := a.Execute(context.Background(), "acp_run_agent", map[string]any{})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+}
+
+func TestRunAgent_NoServersConfigured(t *testing.T) {
+	a := &acpIntegration{clients: make(map[string]*client)}
+	result, err := a.Execute(context.Background(), "acp_run_agent", map[string]any{
+		"agent_name": "echo",
+		"input":      "hi",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "no ACP server specified")
+}
+
+func TestRunAgent_Awaiting(t *testing.T) {
+	ts := newAwaitServer(t)
+	defer ts.Close()
+
+	a := newTestACP(t, ts.URL)
+	result, err := a.Execute(context.Background(), "acp_run_agent", map[string]any{
+		"agent_name": "approval",
+		"input":      "please approve",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "awaiting")
+	assert.Contains(t, result.Data, "run-await-1")
+}
+
+func TestResumeRun(t *testing.T) {
+	ts := newResumeServer(t)
+	defer ts.Close()
+
+	a := newTestACP(t, ts.URL)
+	result, err := a.Execute(context.Background(), "acp_resume_run", map[string]any{
+		"run_id": "run-await-1",
+		"input":  "yes, proceed",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "Approved")
+}
+
+func TestResumeRun_MissingParams(t *testing.T) {
+	a := newTestACP(t, "http://unused")
+	result, err := a.Execute(context.Background(), "acp_resume_run", map[string]any{})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+}
+
+func TestListAgents_MultipleServers(t *testing.T) {
+	ts1 := newMockAgentsServer(t, []AgentManifest{{Name: "agent1", Description: "First"}})
+	defer ts1.Close()
+	ts2 := newMockAgentsServer(t, []AgentManifest{{Name: "agent2", Description: "Second"}})
+	defer ts2.Close()
+
+	a := &acpIntegration{
+		clients: map[string]*client{
+			"server1": newClient("server1", ts1.URL, nil),
+			"server2": newClient("server2", ts2.URL, nil),
+		},
+	}
+
+	result, err := a.Execute(context.Background(), "acp_list_agents", map[string]any{})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "agent1")
+	assert.Contains(t, result.Data, "agent2")
+}
+
+func TestRunAgent_WithSessionID(t *testing.T) {
+	var capturedSessionID string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req RunCreateRequest
+		json.NewDecoder(r.Body).Decode(&req)
+		capturedSessionID = req.SessionID
+
+		if req.Mode == RunModeStream {
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(ACPError{Message: "no stream"})
+			return
+		}
+
+		json.NewEncoder(w).Encode(Run{
+			AgentName: req.AgentName,
+			RunID:     "run-1",
+			Status:    RunStatusCompleted,
+			Output:    []Message{NewAgentMessage("done")},
+		})
+	}))
+	defer ts.Close()
+
+	a := newTestACP(t, ts.URL)
+	_, err := a.Execute(context.Background(), "acp_run_agent", map[string]any{
+		"agent_name": "echo",
+		"input":      "hi",
+		"session_id": "ses-123",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "ses-123", capturedSessionID)
+}
+
+// --- Tool handler tests: inline server_url ---
+
+func TestListAgents_InlineServerURL(t *testing.T) {
+	ts := newMockAgentsServer(t, []AgentManifest{{Name: "remote-agent", Description: "Remote"}})
+	defer ts.Close()
+
+	a := &acpIntegration{clients: make(map[string]*client)}
+	result, err := a.Execute(context.Background(), "acp_list_agents", map[string]any{
+		"server_url": ts.URL,
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "remote-agent")
+}
+
+func TestRunAgent_InlineServerURL(t *testing.T) {
+	ts := newEchoServer(t)
+	defer ts.Close()
+
+	a := &acpIntegration{clients: make(map[string]*client), timeout: 10 * time.Second}
+	result, err := a.Execute(context.Background(), "acp_run_agent", map[string]any{
+		"agent_name": "echo",
+		"input":      "hello via url",
+		"server_url": ts.URL,
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "hello via url")
+}
+
+func TestRunAgent_InlineServerURLStream(t *testing.T) {
+	ts := newStreamServer(t)
+	defer ts.Close()
+
+	a := &acpIntegration{clients: make(map[string]*client), timeout: 10 * time.Second}
+	result, err := a.Execute(context.Background(), "acp_run_agent", map[string]any{
+		"agent_name": "echo",
+		"input":      "hi",
+		"server_url": ts.URL,
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "Hello World")
+}
+
+func TestResumeRun_InlineServerURL(t *testing.T) {
+	ts := newResumeServer(t)
+	defer ts.Close()
+
+	a := &acpIntegration{clients: make(map[string]*client)}
+	result, err := a.Execute(context.Background(), "acp_resume_run", map[string]any{
+		"run_id":     "run-await-1",
+		"input":      "yes",
+		"server_url": ts.URL,
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "Approved")
+}
+
+func TestRunAgent_InlineServerHeaders(t *testing.T) {
+	var capturedAuth string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedAuth = r.Header.Get("Authorization")
+		if r.URL.Path == "/runs" {
+			var req RunCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Mode == RunModeStream {
+				w.WriteHeader(http.StatusBadRequest)
+				json.NewEncoder(w).Encode(ACPError{Message: "no stream"})
+				return
+			}
+			json.NewEncoder(w).Encode(Run{
+				AgentName: req.AgentName,
+				RunID:     "run-1",
+				Status:    RunStatusCompleted,
+				Output:    []Message{NewAgentMessage("done")},
+			})
+		}
+	}))
+	defer ts.Close()
+
+	a := &acpIntegration{clients: make(map[string]*client), timeout: 10 * time.Second}
+	result, err := a.Execute(context.Background(), "acp_run_agent", map[string]any{
+		"agent_name":     "echo",
+		"input":          "hi",
+		"server_url":     ts.URL,
+		"server_headers": `{"Authorization":"Bearer sk-test-123"}`,
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Equal(t, "Bearer sk-test-123", capturedAuth)
+}
+
+func TestRunAgent_InlineServerURLOverridesNamed(t *testing.T) {
+	tsNamed := newMockAgentsServer(t, []AgentManifest{{Name: "named"}})
+	defer tsNamed.Close()
+	tsInline := newEchoServer(t)
+	defer tsInline.Close()
+
+	a := &acpIntegration{
+		clients: map[string]*client{
+			"named": newClient("named", tsNamed.URL, nil),
+		},
+		timeout: 10 * time.Second,
+	}
+	result, err := a.Execute(context.Background(), "acp_run_agent", map[string]any{
+		"agent_name": "echo",
+		"input":      "hi from inline",
+		"server_url": tsInline.URL,
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "hi from inline")
+}
+
+func TestParseHeaders(t *testing.T) {
+	h := parseHeaders(map[string]any{"server_headers": `{"Authorization":"Bearer x","X-Custom":"val"}`})
+	assert.Equal(t, "Bearer x", h["Authorization"])
+	assert.Equal(t, "val", h["X-Custom"])
+}
+
+func TestParseHeaders_Empty(t *testing.T) {
+	h := parseHeaders(map[string]any{})
+	assert.Nil(t, h)
+}
+
+func TestParseHeaders_InvalidJSON(t *testing.T) {
+	h := parseHeaders(map[string]any{"server_headers": "not json"})
+	assert.Nil(t, h)
+}
+
+// --- Client tests ---
+
+func TestClient_ListAgents(t *testing.T) {
+	agents := []AgentManifest{
+		{Name: "echo", Description: "Echoes input"},
+	}
+	ts := newMockAgentsServer(t, agents)
+	defer ts.Close()
+
+	c := newClient("test", ts.URL, nil)
+	result, err := c.listAgents(context.Background())
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, "echo", result[0].Name)
+}
+
+func TestClient_ListAgents_Error(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(500)
+		json.NewEncoder(w).Encode(ACPError{Message: "internal error"})
+	}))
+	defer ts.Close()
+
+	c := newClient("test", ts.URL, nil)
+	_, err := c.listAgents(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "internal error")
+}
+
+func TestClient_CustomHeaders(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+		json.NewEncoder(w).Encode(AgentsListResponse{Agents: []AgentManifest{}})
+	}))
+	defer ts.Close()
+
+	c := newClient("test", ts.URL, map[string]string{"Authorization": "Bearer test-token"})
+	_, err := c.listAgents(context.Background())
+	assert.NoError(t, err)
+}
+
+func TestClient_CreateRunSync(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req RunCreateRequest
+		json.NewDecoder(r.Body).Decode(&req)
+		assert.Equal(t, RunModeSync, req.Mode)
+		json.NewEncoder(w).Encode(Run{
+			AgentName: req.AgentName,
+			RunID:     "run-1",
+			Status:    RunStatusCompleted,
+			Output:    []Message{NewAgentMessage("Echo: " + TextContent(req.Input))},
+		})
+	}))
+	defer ts.Close()
+
+	c := newClient("test", ts.URL, nil)
+	run, err := c.createRunSync(context.Background(), "echo", []Message{NewUserMessage("hello")}, "")
+	require.NoError(t, err)
+	assert.Equal(t, RunStatusCompleted, run.Status)
+	assert.Equal(t, "Echo: hello", TextContent(run.Output))
+}
+
+func TestClient_CreateRunStream(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", ContentTypeNDJSON)
+		w.WriteHeader(http.StatusOK)
+		events := []string{
+			`{"type":"run.in-progress","run":{"agent_name":"echo","run_id":"r1","status":"in-progress","output":[],"created_at":"2025-01-01T00:00:00Z"}}`,
+			`{"type":"message.part","part":{"content_type":"text/plain","content":"Hello"}}`,
+			`{"type":"message.part","part":{"content_type":"text/plain","content":" World"}}`,
+			`{"type":"run.completed","run":{"agent_name":"echo","run_id":"r1","status":"completed","output":[],"created_at":"2025-01-01T00:00:00Z"}}`,
+		}
+		for _, e := range events {
+			fmt.Fprintf(w, "%s\n", e)
+		}
+	}))
+	defer ts.Close()
+
+	c := newClient("test", ts.URL, nil)
+	ch, err := c.createRunStream(context.Background(), "echo", []Message{NewUserMessage("hi")}, "")
+	require.NoError(t, err)
+
+	var collected []Event
+	for e := range ch {
+		collected = append(collected, e)
+	}
+	require.Len(t, collected, 4)
+	assert.Equal(t, EventMessagePart, collected[1].Type)
+	assert.Equal(t, "Hello", collected[1].Part.Content)
+}
+
+func TestClient_ResumeRun(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req RunResumeRequest
+		json.NewDecoder(r.Body).Decode(&req)
+		assert.Equal(t, "run-await-1", req.RunID)
+		json.NewEncoder(w).Encode(Run{
+			RunID:  "run-await-1",
+			Status: RunStatusCompleted,
+			Output: []Message{NewAgentMessage("Approved")},
+		})
+	}))
+	defer ts.Close()
+
+	c := newClient("test", ts.URL, nil)
+	resume := &AwaitResume{Message: &Message{
+		Role:  "user",
+		Parts: []MessagePart{{ContentType: "text/plain", Content: "yes"}},
+	}}
+	run, err := c.resumeRun(context.Background(), "run-await-1", resume)
+	require.NoError(t, err)
+	assert.Equal(t, RunStatusCompleted, run.Status)
+}
+
+// --- Type tests ---
+
+func TestRunStatus_IsTerminal(t *testing.T) {
+	assert.True(t, RunStatusCompleted.IsTerminal())
+	assert.True(t, RunStatusFailed.IsTerminal())
+	assert.True(t, RunStatusCancelled.IsTerminal())
+	assert.False(t, RunStatusCreated.IsTerminal())
+	assert.False(t, RunStatusInProgress.IsTerminal())
+	assert.False(t, RunStatusAwaiting.IsTerminal())
+	assert.False(t, RunStatusCancelling.IsTerminal())
+}
+
+func TestTextContent(t *testing.T) {
+	msgs := []Message{
+		{Role: "agent", Parts: []MessagePart{{ContentType: "text/plain", Content: "Hello"}}},
+		{Role: "agent", Parts: []MessagePart{{ContentType: "text/plain", Content: "World"}}},
+	}
+	assert.Equal(t, "Hello\nWorld", TextContent(msgs))
+}
+
+func TestTextContent_Empty(t *testing.T) {
+	assert.Equal(t, "", TextContent(nil))
+	assert.Equal(t, "", TextContent([]Message{}))
+}
+
+func TestNewUserMessage(t *testing.T) {
+	msg := NewUserMessage("hello")
+	assert.Equal(t, "user", msg.Role)
+	assert.Len(t, msg.Parts, 1)
+	assert.Equal(t, "text/plain", msg.Parts[0].ContentType)
+	assert.Equal(t, "hello", msg.Parts[0].Content)
+}
+
+func TestNewAgentMessage(t *testing.T) {
+	msg := NewAgentMessage("done")
+	assert.Equal(t, "agent", msg.Role)
+	assert.Equal(t, "done", msg.Parts[0].Content)
+}
+
+// --- Test helpers ---
+
+func newTestACP(t *testing.T, serverURL string) *acpIntegration {
+	t.Helper()
+	return &acpIntegration{
+		clients: map[string]*client{
+			"test": newClient("test", serverURL, nil),
+		},
+		timeout: 10 * time.Second,
+	}
+}
+
+func newMockAgentsServer(t *testing.T, agents []AgentManifest) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode(AgentsListResponse{Agents: agents})
+	}))
+}
+
+func newEchoServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/runs" && r.Method == http.MethodPost {
+			var req RunCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+
+			if req.Mode == RunModeStream {
+				w.WriteHeader(http.StatusBadRequest)
+				json.NewEncoder(w).Encode(ACPError{Message: "stream not supported"})
+				return
+			}
+
+			json.NewEncoder(w).Encode(Run{
+				AgentName: req.AgentName,
+				RunID:     "run-echo-1",
+				Status:    RunStatusCompleted,
+				Output:    []Message{NewAgentMessage("Echo: " + TextContent(req.Input))},
+			})
+		}
+	}))
+}
+
+func newStreamServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", ContentTypeNDJSON)
+		w.WriteHeader(http.StatusOK)
+		events := []string{
+			`{"type":"run.in-progress","run":{"agent_name":"echo","run_id":"r1","status":"in-progress","output":[],"created_at":"2025-01-01T00:00:00Z"}}`,
+			`{"type":"message.part","part":{"content_type":"text/plain","content":"Hello"}}`,
+			`{"type":"message.part","part":{"content_type":"text/plain","content":" World"}}`,
+			`{"type":"run.completed","run":{"agent_name":"echo","run_id":"r1","status":"completed","output":[],"created_at":"2025-01-01T00:00:00Z"}}`,
+		}
+		for _, e := range events {
+			fmt.Fprintf(w, "%s\n", e)
+		}
+	}))
+}
+
+func newAwaitServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", ContentTypeNDJSON)
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, `{"type":"run.awaiting","run":{"agent_name":"approval","run_id":"run-await-1","status":"awaiting","output":[],"await_request":{"message":{"role":"agent","parts":[{"content_type":"text/plain","content":"Do you approve?"}]}},"created_at":"2025-01-01T00:00:00Z"}}`+"\n")
+	}))
+}
+
+func newResumeServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			var req RunResumeRequest
+			json.NewDecoder(r.Body).Decode(&req)
+
+			if req.Mode == RunModeStream {
+				w.WriteHeader(http.StatusBadRequest)
+				json.NewEncoder(w).Encode(ACPError{Message: "stream not supported"})
+				return
+			}
+
+			json.NewEncoder(w).Encode(Run{
+				AgentName: "approval",
+				RunID:     req.RunID,
+				Status:    RunStatusCompleted,
+				Output:    []Message{NewAgentMessage("Approved and processed")},
+			})
+		}
+	}))
+}

--- a/integrations/acp/client.go
+++ b/integrations/acp/client.go
@@ -1,0 +1,236 @@
+package acp
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// client is an HTTP client for the ACP protocol.
+type client struct {
+	name         string
+	baseURL      string
+	httpClient   *http.Client
+	streamClient *http.Client
+	headers      map[string]string
+}
+
+func newClient(name, baseURL string, headers map[string]string) *client {
+	transport := http.DefaultTransport
+	return &client{
+		name:    name,
+		baseURL: strings.TrimRight(baseURL, "/"),
+		httpClient: &http.Client{
+			Timeout:   120 * time.Second,
+			Transport: transport,
+		},
+		streamClient: &http.Client{
+			Timeout:   0,
+			Transport: transport,
+		},
+		headers: headers,
+	}
+}
+
+// listAgents returns agents available on the ACP server.
+func (c *client) listAgents(ctx context.Context) ([]AgentManifest, error) {
+	url := fmt.Sprintf("%s/agents?limit=100&offset=0", c.baseURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	c.setHeaders(req)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("list agents: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.readError(resp)
+	}
+
+	var result AgentsListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return result.Agents, nil
+}
+
+// createRunSync creates a run and blocks until completion.
+func (c *client) createRunSync(ctx context.Context, agentName string, input []Message, sessionID string) (*Run, error) {
+	body := RunCreateRequest{
+		AgentName: agentName,
+		Input:     input,
+		SessionID: sessionID,
+		Mode:      RunModeSync,
+	}
+	return c.createRun(ctx, body)
+}
+
+// createRunStream creates a run and returns a channel of streaming events.
+func (c *client) createRunStream(ctx context.Context, agentName string, input []Message, sessionID string) (<-chan Event, error) {
+	body := RunCreateRequest{
+		AgentName: agentName,
+		Input:     input,
+		SessionID: sessionID,
+		Mode:      RunModeStream,
+	}
+	return c.doStream(ctx, fmt.Sprintf("%s/runs", c.baseURL), body)
+}
+
+// resumeRun resumes an awaiting run with new input (sync mode).
+func (c *client) resumeRun(ctx context.Context, runID string, resume *AwaitResume) (*Run, error) {
+	body := RunResumeRequest{
+		RunID:       runID,
+		AwaitResume: resume,
+		Mode:        RunModeSync,
+	}
+	data, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/runs/%s", c.baseURL, runID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	c.setHeaders(req)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("resume run: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+		return nil, c.readError(resp)
+	}
+
+	var run Run
+	if err := json.NewDecoder(resp.Body).Decode(&run); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return &run, nil
+}
+
+// resumeRunStream resumes an awaiting run and returns a channel of streaming events.
+func (c *client) resumeRunStream(ctx context.Context, runID string, resume *AwaitResume) (<-chan Event, error) {
+	body := RunResumeRequest{
+		RunID:       runID,
+		AwaitResume: resume,
+		Mode:        RunModeStream,
+	}
+	return c.doStream(ctx, fmt.Sprintf("%s/runs/%s", c.baseURL, runID), body)
+}
+
+func (c *client) createRun(ctx context.Context, body RunCreateRequest) (*Run, error) {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/runs", c.baseURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	c.setHeaders(req)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("create run: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+		return nil, c.readError(resp)
+	}
+
+	var run Run
+	if err := json.NewDecoder(resp.Body).Decode(&run); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return &run, nil
+}
+
+func (c *client) doStream(ctx context.Context, url string, body any) (<-chan Event, error) {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", ContentTypeNDJSON)
+	c.setHeaders(req)
+
+	resp, err := c.streamClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("stream request: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		defer func() { _ = resp.Body.Close() }()
+		return nil, c.readError(resp)
+	}
+
+	return parseStream(resp.Body), nil
+}
+
+func (c *client) setHeaders(req *http.Request) {
+	for k, v := range c.headers {
+		req.Header.Set(k, v)
+	}
+}
+
+func (c *client) readError(resp *http.Response) error {
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	var acpErr ACPError
+	if json.Unmarshal(body, &acpErr) == nil && acpErr.Message != "" {
+		return fmt.Errorf("ACP error (HTTP %d): %s", resp.StatusCode, acpErr.Message)
+	}
+	return fmt.Errorf("ACP error (HTTP %d): %s", resp.StatusCode, string(body))
+}
+
+// parseStream reads an NDJSON stream and emits typed events.
+func parseStream(r io.ReadCloser) <-chan Event {
+	ch := make(chan Event, 16)
+	go func() {
+		defer close(ch)
+		defer func() { _ = r.Close() }()
+		scanner := bufio.NewScanner(r)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+		for scanner.Scan() {
+			line := scanner.Text()
+			if line == "" {
+				continue
+			}
+
+			var event Event
+			if err := json.Unmarshal([]byte(line), &event); err != nil {
+				ch <- Event{
+					Type:  EventError,
+					Error: &ACPError{Message: fmt.Sprintf("failed to parse event: %v", err)},
+				}
+				continue
+			}
+			ch <- event
+		}
+	}()
+	return ch
+}

--- a/integrations/acp/tools.go
+++ b/integrations/acp/tools.go
@@ -1,0 +1,40 @@
+package acp
+
+import mcp "github.com/daltoniam/switchboard"
+
+var tools = []mcp.ToolDefinition{
+	{
+		Name:        "acp_list_agents",
+		Description: "List available remote agents on ACP servers. Discover AI agents, bots, and autonomous workers before invoking them. Returns agent names, descriptions, and capabilities",
+		Parameters: map[string]string{
+			"server":         "Name of a pre-configured ACP server to query. Uses the first configured server if omitted",
+			"server_url":     "URL of an ACP server to query directly (e.g. http://localhost:8199). Overrides server name lookup",
+			"server_headers": "Optional JSON object of HTTP headers to send with the request (e.g. {\"Authorization\":\"Bearer sk-xxx\"})",
+		},
+	},
+	{
+		Name:        "acp_run_agent",
+		Description: "Invoke a remote ACP agent with a message and get its response. Send a text prompt to an AI agent on a remote server. Use acp_list_agents first to discover available agents. If the agent enters an awaiting state (needs more input), the response includes a run_id — use acp_resume_run to continue",
+		Parameters: map[string]string{
+			"agent_name":     "Name of the remote agent to invoke",
+			"input":          "Text message to send to the agent",
+			"server":         "Name of a pre-configured ACP server. Uses the first configured server if omitted",
+			"server_url":     "URL of an ACP server to connect to directly (e.g. http://localhost:8199). Overrides server name lookup",
+			"server_headers": "Optional JSON object of HTTP headers to send with the request (e.g. {\"Authorization\":\"Bearer sk-xxx\"})",
+			"session_id":     "Session ID for multi-turn conversations with the same agent",
+		},
+		Required: []string{"agent_name", "input"},
+	},
+	{
+		Name:        "acp_resume_run",
+		Description: "Resume an ACP agent run that is waiting for additional input. When acp_run_agent returns a response indicating the agent is awaiting input, use this tool to provide the requested information and continue the run",
+		Parameters: map[string]string{
+			"run_id":         "The run_id returned by acp_run_agent when the agent entered awaiting state",
+			"input":          "Text response to provide to the awaiting agent",
+			"server":         "Name of a pre-configured ACP server. Uses the first configured server if omitted",
+			"server_url":     "URL of an ACP server to connect to directly (e.g. http://localhost:8199). Overrides server name lookup",
+			"server_headers": "Optional JSON object of HTTP headers to send with the request (e.g. {\"Authorization\":\"Bearer sk-xxx\"})",
+		},
+		Required: []string{"run_id", "input"},
+	},
+}

--- a/integrations/acp/types.go
+++ b/integrations/acp/types.go
@@ -1,0 +1,165 @@
+package acp
+
+import "time"
+
+// RunStatus represents the state of an ACP run.
+type RunStatus string
+
+const (
+	RunStatusCreated    RunStatus = "created"
+	RunStatusInProgress RunStatus = "in-progress"
+	RunStatusAwaiting   RunStatus = "awaiting"
+	RunStatusCompleted  RunStatus = "completed"
+	RunStatusFailed     RunStatus = "failed"
+	RunStatusCancelling RunStatus = "cancelling"
+	RunStatusCancelled  RunStatus = "cancelled"
+)
+
+// IsTerminal returns true if the run status is a terminal state.
+func (s RunStatus) IsTerminal() bool {
+	switch s {
+	case RunStatusCompleted, RunStatusFailed, RunStatusCancelled:
+		return true
+	}
+	return false
+}
+
+// RunMode determines how a run is executed.
+type RunMode string
+
+const (
+	RunModeSync   RunMode = "sync"
+	RunModeAsync  RunMode = "async"
+	RunModeStream RunMode = "stream"
+)
+
+// AgentManifest describes a remote ACP agent.
+type AgentManifest struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+// Message is the core communication unit in ACP.
+type Message struct {
+	Role  string        `json:"role"`
+	Parts []MessagePart `json:"parts"`
+}
+
+// MessagePart is a single typed content unit within a message.
+type MessagePart struct {
+	ContentType string `json:"content_type"`
+	Content     string `json:"content,omitempty"`
+}
+
+// Run represents an ACP agent run.
+type Run struct {
+	AgentName    string        `json:"agent_name"`
+	RunID        string        `json:"run_id"`
+	SessionID    string        `json:"session_id,omitempty"`
+	Status       RunStatus     `json:"status"`
+	Output       []Message     `json:"output"`
+	AwaitRequest *AwaitRequest `json:"await_request,omitempty"`
+	Error        *ACPError     `json:"error,omitempty"`
+	CreatedAt    time.Time     `json:"created_at"`
+	FinishedAt   *time.Time    `json:"finished_at,omitempty"`
+}
+
+// AwaitRequest represents an agent's request for external input.
+type AwaitRequest struct {
+	Message *Message `json:"message,omitempty"`
+}
+
+// AwaitResume provides input to resume an awaiting run.
+type AwaitResume struct {
+	Message *Message `json:"message,omitempty"`
+}
+
+// ACPError represents an error returned by the ACP server.
+type ACPError struct {
+	Code    int    `json:"code,omitempty"`
+	Message string `json:"message"`
+}
+
+// RunCreateRequest is the body for POST /runs.
+type RunCreateRequest struct {
+	AgentName string    `json:"agent_name"`
+	Input     []Message `json:"input"`
+	SessionID string    `json:"session_id,omitempty"`
+	Mode      RunMode   `json:"mode,omitempty"`
+}
+
+// RunResumeRequest is the body for POST /runs/{run_id}.
+type RunResumeRequest struct {
+	RunID       string       `json:"run_id"`
+	AwaitResume *AwaitResume `json:"await_resume"`
+	Mode        RunMode      `json:"mode,omitempty"`
+}
+
+// AgentsListResponse is the response from GET /agents.
+type AgentsListResponse struct {
+	Agents []AgentManifest `json:"agents"`
+}
+
+// EventType identifies the kind of streaming event.
+type EventType string
+
+const (
+	EventRunCreated       EventType = "run.created"
+	EventRunInProgress    EventType = "run.in-progress"
+	EventRunAwaiting      EventType = "run.awaiting"
+	EventRunCompleted     EventType = "run.completed"
+	EventRunFailed        EventType = "run.failed"
+	EventRunCancelled     EventType = "run.cancelled"
+	EventMessageCreated   EventType = "message.created"
+	EventMessagePart      EventType = "message.part"
+	EventMessageCompleted EventType = "message.completed"
+	EventError            EventType = "error"
+)
+
+// Event is a discriminated union of all streaming event types.
+type Event struct {
+	Type    EventType    `json:"type"`
+	Run     *Run         `json:"run,omitempty"`
+	Message *Message     `json:"message,omitempty"`
+	Part    *MessagePart `json:"part,omitempty"`
+	Error   *ACPError    `json:"error,omitempty"`
+}
+
+// ContentTypeNDJSON is the MIME type for newline-delimited JSON streams.
+const ContentTypeNDJSON = "application/x-ndjson"
+
+// TextContent extracts all text/plain content from a slice of messages.
+func TextContent(messages []Message) string {
+	var result string
+	for _, msg := range messages {
+		for _, part := range msg.Parts {
+			if part.ContentType == "text/plain" || part.ContentType == "" {
+				if result != "" {
+					result += "\n"
+				}
+				result += part.Content
+			}
+		}
+	}
+	return result
+}
+
+// NewUserMessage creates a simple text message with the "user" role.
+func NewUserMessage(text string) Message {
+	return Message{
+		Role: "user",
+		Parts: []MessagePart{
+			{ContentType: "text/plain", Content: text},
+		},
+	}
+}
+
+// NewAgentMessage creates a simple text message with the "agent" role.
+func NewAgentMessage(text string) Message {
+	return Message{
+		Role: "agent",
+		Parts: []MessagePart{
+			{ContentType: "text/plain", Content: text},
+		},
+	}
+}

--- a/wasm/guest-rust/sdk/src/lib.rs
+++ b/wasm/guest-rust/sdk/src/lib.rs
@@ -115,11 +115,19 @@ pub fn arg_str_slice(args: &HashMap<String, serde_json::Value>, key: &str) -> Ve
 }
 
 pub fn arg_int(args: &HashMap<String, serde_json::Value>, key: &str) -> Option<i64> {
-    args.get(key).and_then(|v| v.as_i64())
+    args.get(key).and_then(|v| {
+        v.as_i64().or_else(|| v.as_str().and_then(|s| s.parse::<i64>().ok()))
+    })
 }
 
 pub fn arg_bool(args: &HashMap<String, serde_json::Value>, key: &str) -> Option<bool> {
-    args.get(key).and_then(|v| v.as_bool())
+    args.get(key).and_then(|v| {
+        v.as_bool().or_else(|| v.as_str().and_then(|s| match s {
+            "true" | "1" | "yes" => Some(true),
+            "false" | "0" | "no" => Some(false),
+            _ => None,
+        }))
+    })
 }
 
 pub fn arg_map(


### PR DESCRIPTION

## Summary

- Switchboard passes all tool arguments as JSON strings, but `arg_bool` and `arg_int` only accepted native JSON booleans/integers. This caused `enabled` and `timeout_minutes` to silently be ignored when set via `mcp_switchboard_execute`.
- `arg_int` now falls back to parsing the string representation, and `arg_bool` accepts `"true"`/`"false"`/`"1"`/`"0"`/`"yes"`/`"no"`.

## Test plan

- [ ] Verify `arg_bool` returns `Some(true)` for `Value::Bool(true)` and `Value::String("true")`
- [ ] Verify `arg_int` returns `Some(120)` for `Value::Number(120)` and `Value::String("120")`
- [ ] Verify `arg_bool` returns `None` for `Value::String("maybe")`
- [ ] Test with overmind flow create/update using `enabled=true` and `timeout_minutes=120` via switchboard


🐨 Generated with Crush