### PR TITLE
Fix browser service race and move reg.Register after Configure

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -240,7 +240,6 @@ func runServer(stdioMode bool, port int, discoverAll bool) {
 	services := &mcp.Services{
 		Config:   cfgMgr,
 		Registry: reg,
-		Browser:  browserSvc,
 		Metrics:  mcp.NewMetrics(),
 	}
 
@@ -349,10 +348,6 @@ func loadWasmModule(ctx context.Context, rt *wasmmod.Runtime, wc mcp.WasmModuleC
 	if wc.Name != "" {
 		mod.SetName(wc.Name)
 	}
-	if err := reg.Register(mod); err != nil {
-		log.Printf("WARN: failed to register WASM module %q: %v", wc.Path, err)
-		return
-	}
 
 	// Merge credentials: WASM inline creds are the baseline, existing config
 	// creds (e.g. set via the web UI integration page) override them.
@@ -372,6 +367,11 @@ func loadWasmModule(ctx context.Context, rt *wasmmod.Runtime, wc mcp.WasmModuleC
 			log.Printf("WARN: failed to configure WASM module %q: %v", wc.Path, err)
 			return
 		}
+	}
+
+	if err := reg.Register(mod); err != nil {
+		log.Printf("WARN: failed to register WASM module %q: %v", wc.Path, err)
+		return
 	}
 
 	// Always persist the integration config entry so the web UI shows


### PR DESCRIPTION
## Summary

Follow-up to #114 — the review feedback fixes were pushed after the PR was merged.

- **Remove `Browser: browserSvc` from Services struct**: The background goroutine writes to `browserSvc` while the main goroutine reads it to build the struct literal — a data race. Since nothing actually reads `services.Browser` (Amazon uses `SetBrowserService` directly), just drop the field assignment.
- **Move `reg.Register(mod)` after `mod.Configure()`**: Previously a configure failure returned early but left the unconfigured module registered in the registry, making its tools visible in search results with broken execution.

## Test plan

- [x] Build passes
- [x] All tests pass
- [x] Vet + lint clean


💘 Generated with Crush