### PR TITLE
Add crate-type configuration to Cargo.toml

### DIFF
--- a/wasm/guest-rust/sdk/Cargo.toml
+++ b/wasm/guest-rust/sdk/Cargo.toml
@@ -3,6 +3,9 @@ name = "switchboard-guest-sdk"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
this was needed to generate a `.wasm` file