### PR TITLE
fix: tool prompting

### DIFF
--- a/.agents/skills/add-integration/SKILL.md
+++ b/.agents/skills/add-integration/SKILL.md
@@ -85,10 +85,21 @@ for discoverability, not just accuracy.
 - **Don't pad with stop words.** Words like "a", "the", "to", "for" are filtered by the search engine. Every word in the description should carry meaning.
 - **Include both singular and plural forms.** The search engine does exact token matching with NO stemming. "errors" ≠ "error". If users might search for either form, include both: "List errors and exceptions" covers both "sentry errors" and "sentry error". Check the synonym groups in `server/search.go` — common plurals are covered there, but new domain words need explicit plural coverage either in the description or as a synonym group.
 
+**Entry-point guidance (MUST):** Every integration's first/primary tool MUST include "Start here" in its description. This is wayfinding — models use it to orient when browsing an unfamiliar integration. Examples:
+- `"List all schemas in the database. Start here for schema discovery."`
+- `"List all projects in the PostHog organization. Start here to discover projects."`
+
+**Naming deviation callouts:** When the integration uses non-standard verb prefixes (e.g., Notion uses `retrieve_*` where others use `get_*`), add the standard verb in parentheses: `"Retrieve (get) a page's metadata"`. This helps both search scoring and models that skip search.
+
+**Noun synonym awareness:** The search engine has noun synonym groups (table/tables, label/labels/tag/tags, diff/patch/changes, database/databases/db, etc.) in `server/search.go`. When adding tools with domain-specific nouns, check if your nouns are covered. If not, either add a synonym group or include both forms in the description.
+
+**IDF dilution warning:** Avoid creating synonym groups where the union covers too many tools (>60). High-union groups dilute IDF scores and can cause regressions. Verb groups are safe because MAX-per-word scoring means rare synonyms carry the score. Noun groups need more care — test with `/search-benchmark` before and after.
+
 **Anti-patterns:**
 - `"List issues for a project"` — too generic, no domain keywords
 - `"Get a specific message by ID"` — no "email", "mail", or "read"
 - `"List events with optional filters"` — what kind of events? For what purpose?
+- Missing "Start here" on entry-point tool — model has no wayfinding signal
 
 **Verify with benchmark:** After adding tools, run `/search-benchmark` to check
 that your tools surface for natural-language queries users would actually type.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,8 @@ Co-Authored-By: <agent model name> <noreply@anthropic.com>
 - **Shared arg helpers** (MUST): use `mcp.NewArgs(args)` reader or standalone `mcp.ArgStr`/`mcp.ArgInt`/etc. from `args.go` — never define local `argStr`/`argInt` in adapters. All return `(value, error)`. Use `r.OptInt("page", 1)` for pagination defaults. See `args.go` for the full API and [docs/go-anti-patterns.md](docs/go-anti-patterns.md) for extraction pitfalls that cause silent errors.
 - **Args parity test** (MUST): `TestNewArgs_ErrCheckParity` in `args_test.go` walks all adapters verifying every `NewArgs` call has a matching `.Err()` check — new adapters are covered automatically
 - **Parse at boundary, not throughout** (MUST): JSON is unmarshalled once at ingress and marshalled once at egress. Use `CompactAny`/`ColumnarizeAny` for already-parsed data — never re-serialize to `[]byte` just to call `CompactJSON`/`ColumnarizeJSON`. Redundant marshal/unmarshal cycles are the #1 performance regression to guard against in the response pipeline.
+- **Entry-point guidance** (MUST): Every integration's primary tool description must include "Start here" text for wayfinding. See `add-integration` skill for pattern.
+- **Script scope**: `api.call()` in scripts can only call integration tools — the `search` and `execute` meta-tools are not callable from scripts. The `toolExecutor` returns a specific error for this.
 
 ## Reference Docs
 

--- a/docs/tool-search.md
+++ b/docs/tool-search.md
@@ -9,7 +9,11 @@ search({"query": "create ticket"}) → [{name: "linear_create_issue", ...}]
 execute({"tool_name": "linear_create_issue", "arguments": {...}}) → result
 ```
 
-Search scores ~850 tools across integrations using synonym-expanded TF-IDF. The index is built once at startup; queries are zero-allocation beyond the result slice.
+Search scores ~1100+ tools across integrations using synonym-expanded TF-IDF. The index is built once at startup; queries are zero-allocation beyond the result slice.
+
+<!-- @[MODEL LAUNCH]: Review query guidance in search tool description (server.go) —
+     new models may handle long queries differently. Also check if Instructions
+     field is being surfaced by the new model's MCP client. -->
 
 ## How Scoring Works
 
@@ -66,10 +70,11 @@ The list is a closed linguistic class — English doesn't gain new prepositions.
 The search tool's description coaches LLMs on query strategy:
 
 ```
-Query format — use 2-3 keywords, not full sentences:
+Query format — use 1-2 keywords, not full sentences. Fewer words = better results:
 - {"query": "create ticket"} — synonym matching finds linear_create_issue
-- {"query": "slack send message"} — always include the integration name
+- {"query": "slack send"} — integration name + verb is ideal
 - {"integration": "sentry", "query": "errors"} — or use the integration filter
+Avoid 4+ word queries — they return fewer results.
 ```
 
 Keywords beat sentences because:
@@ -78,6 +83,10 @@ Keywords beat sentences because:
 - Synonym expansion compensates for vocabulary mismatches, so exact tool names aren't required
 
 The `integration` parameter pre-filters tools before scoring, useful when the LLM already knows which integration to target.
+
+<!-- @[MODEL LAUNCH]: The "1-2 keywords" guidance was calibrated for the current
+     TF-IDF engine. If search moves to embedding-based or hybrid scoring,
+     revisit — longer queries may perform better with semantic search. -->
 
 ## Tool Description Guidelines
 
@@ -89,6 +98,20 @@ Tool descriptions are the only context an LLM gets for tool selection. The scori
 - **Gotcha prevention**: surface ID/parameter confusion in descriptions and parameter strings
 
 See [field-compaction.md](field-compaction.md) § "Tool Description Design" for the full style guide.
+
+## Known Failure Modes & Counterweights
+
+Measured failure modes in LLM tool discovery, with the prompt-level mitigations applied.
+
+| Failure | Rate | Counterweight | Bidirectional Check |
+|---------|------|---------------|---------------------|
+| **Tool name hallucination** — model guesses `notion_get_page` instead of searching | Observed in multi-model testing | Server Instructions: "do not guess tool names"; execute description: "Use search first" | Don't overcorrect into always searching for single well-known tools (e.g., `github_list_issues`) — the search call adds latency |
+| **Script meta-tool confusion** — model calls `api.call('search')` inside scripts | Observed in user sessions | Execute description: "Scripts CANNOT call search or execute"; `toolExecutor` returns specific error | Don't block legitimate integration tools named similarly — the check is exact-match on "search"/"execute" only |
+| **Long query degradation** — 4+ word queries return 0 results | Consistent in benchmark testing | Search description: "Avoid 4+ word queries"; "1-2 keywords" guidance | Don't make models afraid of 2-3 word queries — those work well. Only 4+ is problematic |
+| **Verb vocabulary mismatch** — "get" vs "retrieve" vs "describe" | Systemic across integrations | Synonym group: `{"get", "retrieve", "fetch", "read", "show", "view", "describe"}` | The MAX-per-word scoring ensures rare synonyms (retrieve, IDF=5.1) boost results without common synonyms (get, IDF=1.5) causing pollution |
+| **Noun IDF dilution** — synonym group union >60 tools degrades ranking | Measured: page/doc/document group (union=90) caused get-page benchmark regression | Dropped page/doc group; kept targeted pairs (table/tables, label/labels) | `TestSynonymGroups_Disjoint` enforces no word in multiple groups; benchmark catches IDF regressions |
+
+**Removal triggers**: Revisit counterweights when search moves to embedding-based scoring (long queries may work), or when MCP clients universally surface Instructions (reducing reliance on tool-description-level guidance).
 
 ## Benchmarking
 

--- a/docs/tool-search.md
+++ b/docs/tool-search.md
@@ -30,10 +30,22 @@ The formula: `IDF(word) = log(totalTools / toolsContainingWord)`. A word appeari
 Synonym groups define equivalence sets of words that match interchangeably. Defined in `server/search.go` as `synonymGroups`:
 
 ```go
+// Nouns
 {"ticket", "issue", "issues", "task", "bug"},
+{"table", "tables"},
+{"label", "labels", "tag", "tags"},
+{"diff", "patch", "changes"},
+{"database", "databases", "db"},
+// ... and more (see server/search.go for full list)
+
+// Verbs
 {"create", "add", "new", "make", "generate"},
+{"get", "retrieve", "fetch", "read", "show", "view", "describe"},
+{"list", "ls", "enumerate"},
 {"deploy", "deploys", "deployment", "deployments", "release", "releases", "rollout", "ship"},
 ```
+
+**IDF dilution warning**: Noun synonym groups where the union covers >60 tools can degrade search quality. The MAX-per-word scoring makes verb synonyms inherently safe (rare variants like "retrieve" carry the score), but noun groups with many common words dilute the IDF signal. Test with the search benchmark before adding high-union noun groups.
 
 At startup, `buildSynonymMap` expands these into a bidirectional lookup map where each word maps to its full group (including itself). Groups must be disjoint — no word in multiple groups.
 

--- a/integrations/acp/tools.go
+++ b/integrations/acp/tools.go
@@ -5,7 +5,7 @@ import mcp "github.com/daltoniam/switchboard"
 var tools = []mcp.ToolDefinition{
 	{
 		Name:        "acp_list_agents",
-		Description: "List available remote agents on ACP servers. Discover AI agents, bots, and autonomous workers before invoking them. Returns agent names, descriptions, and capabilities",
+		Description: "List available remote agents on ACP servers. Start here to discover AI agents, bots, and autonomous workers before invoking them. Returns agent names, descriptions, and capabilities",
 		Parameters: map[string]string{
 			"server":         "Name of a pre-configured ACP server to query. Uses the first configured server if omitted",
 			"server_url":     "URL of an ACP server to query directly (e.g. http://localhost:8199). Overrides server name lookup",

--- a/integrations/clickhouse/tools.go
+++ b/integrations/clickhouse/tools.go
@@ -26,7 +26,7 @@ var tools = []mcp.ToolDefinition{
 	// --- Databases ---
 	{
 		Name:        "clickhouse_list_databases",
-		Description: "List all databases in the ClickHouse server",
+		Description: "List all databases in the ClickHouse server. Start here for schema discovery.",
 		Parameters:  map[string]string{},
 	},
 	{

--- a/integrations/digitalocean/tools.go
+++ b/integrations/digitalocean/tools.go
@@ -5,7 +5,7 @@ import mcp "github.com/daltoniam/switchboard"
 var tools = []mcp.ToolDefinition{
 	// ── Account ─────────────────────────────────────────────────────
 	{
-		Name: "digitalocean_get_account", Description: "Get current account information including email, droplet limit, and status",
+		Name: "digitalocean_get_account", Description: "Get current account information including email, droplet limit, and status. Start here to verify access.",
 		Parameters: map[string]string{},
 	},
 

--- a/integrations/gcp/tools.go
+++ b/integrations/gcp/tools.go
@@ -5,7 +5,7 @@ import mcp "github.com/daltoniam/switchboard"
 var tools = []mcp.ToolDefinition{
 	// ── Resource Manager ─────────────────────────────────────────────
 	{
-		Name: "gcp_get_project", Description: "Get details about the configured GCP project",
+		Name: "gcp_get_project", Description: "Get details about the configured GCP project. Start here to verify project access.",
 		Parameters: map[string]string{},
 	},
 	{

--- a/integrations/gmail/tools.go
+++ b/integrations/gmail/tools.go
@@ -5,7 +5,7 @@ import mcp "github.com/daltoniam/switchboard"
 var tools = []mcp.ToolDefinition{
 	// ── Profile ─────────────────────────────────────────────────────
 	{
-		Name: "gmail_get_profile", Description: "Get the current user's Gmail profile (email, messages total, threads total, history ID)",
+		Name: "gmail_get_profile", Description: "Get the current user's Gmail profile (email, messages total, threads total, history ID). Start here to verify access.",
 		Parameters: map[string]string{"user_id": "User ID (defaults to 'me' for authenticated user)"},
 	},
 

--- a/integrations/homeassistant/tools.go
+++ b/integrations/homeassistant/tools.go
@@ -5,7 +5,7 @@ import mcp "github.com/daltoniam/switchboard"
 var tools = []mcp.ToolDefinition{
 	// ── States / Entities ───────────────────────────────────────────
 	{
-		Name: "homeassistant_list_states", Description: "List all smart home device and entity states in Home Assistant. Returns sensors, lights, switches, and other IoT device states.",
+		Name: "homeassistant_list_states", Description: "List all smart home device and entity states in Home Assistant. Start here to discover devices. Returns sensors, lights, switches, and other IoT device states.",
 		Parameters: map[string]string{},
 	},
 	{

--- a/integrations/pganalyze/tools.go
+++ b/integrations/pganalyze/tools.go
@@ -6,7 +6,7 @@ var tools = []mcp.ToolDefinition{
 	// --- Servers ---
 	{
 		Name:        "pganalyze_get_servers",
-		Description: "List all monitored PostgreSQL servers and their databases from pganalyze",
+		Description: "List all monitored PostgreSQL servers and their databases from pganalyze. Start here to discover monitored servers.",
 		Parameters: map[string]string{
 			"organization_slug": "Organization slug to filter servers (e.g. 'my-org')",
 		},

--- a/integrations/postgres/tools.go
+++ b/integrations/postgres/tools.go
@@ -6,7 +6,7 @@ var tools = []mcp.ToolDefinition{
 	// --- Schema Discovery ---
 	{
 		Name:        "postgres_list_schemas",
-		Description: "List all schemas in the database",
+		Description: "List all schemas in the database. Start here for schema discovery.",
 		Parameters:  map[string]string{},
 	},
 	{

--- a/integrations/posthog/tools.go
+++ b/integrations/posthog/tools.go
@@ -5,7 +5,7 @@ import mcp "github.com/daltoniam/switchboard"
 var tools = []mcp.ToolDefinition{
 	// ── Projects ────────────────────────────────────────────────────
 	{
-		Name: "posthog_list_projects", Description: "List all projects in the PostHog organization",
+		Name: "posthog_list_projects", Description: "List all projects in the PostHog organization. Start here to discover projects.",
 		Parameters: map[string]string{"limit": "Max results", "offset": "Pagination offset"},
 	},
 	{

--- a/integrations/rwx/tools.go
+++ b/integrations/rwx/tools.go
@@ -6,7 +6,7 @@ var tools = []mcp.ToolDefinition{
 	// ── Runs ────────────────────────────────────────────────────────
 	{
 		Name:        "rwx_launch_ci_run",
-		Description: "Launch a CI/CD pipeline run using the rwx CLI. Executes continuous integration tests and builds from .rwx/ci.yml by default.",
+		Description: "Launch a CI/CD pipeline run using the rwx CLI. Start here to run CI. Executes continuous integration tests and builds from .rwx/ci.yml by default.",
 		Parameters: map[string]string{
 			"targets": "JSON array of specific task keys to target (optional)",
 			"wait":    "Wait for the run to complete before returning (true/false, default: false)",

--- a/integrations/salesforce/tools.go
+++ b/integrations/salesforce/tools.go
@@ -5,7 +5,7 @@ import mcp "github.com/daltoniam/switchboard"
 var tools = []mcp.ToolDefinition{
 	// ── SObject Describe ────────────────────────────────────────────
 	{
-		Name: "salesforce_describe_global", Description: "List all SObjects available in the org with metadata (name, label, keyPrefix, queryable, createable, etc.)",
+		Name: "salesforce_describe_global", Description: "List all SObjects available in the org with metadata (name, label, keyPrefix, queryable, createable, etc.). Start here for schema discovery.",
 		Parameters: map[string]string{},
 	},
 	{

--- a/integrations/snowflake/tools.go
+++ b/integrations/snowflake/tools.go
@@ -38,7 +38,7 @@ var tools = []mcp.ToolDefinition{
 	// --- Schema Discovery ---
 	{
 		Name:        "snowflake_list_databases",
-		Description: "List all databases accessible in the Snowflake account",
+		Description: "List all databases accessible in the Snowflake account. Start here for schema discovery.",
 		Parameters: map[string]string{
 			"role": "Role to use (overrides configured default)",
 		},

--- a/server/project_server.go
+++ b/server/project_server.go
@@ -108,7 +108,7 @@ func (pr *ProjectRouter) buildServer(def *project.Definition) *projectMCPServer 
 		},
 		&mcpsdk.ServerOptions{
 			Instructions: fmt.Sprintf(
-				"Project-scoped MCP server for %q. Use the search tool to discover available operations and project_context to retrieve project context.",
+				"Project-scoped MCP server for %q. Use the search tool to discover available operations — do not guess tool names. Use project_context to retrieve project context.",
 				def.Name,
 			),
 			Logger: slog.Default(),

--- a/server/search.go
+++ b/server/search.go
@@ -129,7 +129,7 @@ var synonymGroups = [][]string{
 	{"channel", "conversation", "room"},
 	{"state", "status"},
 	{"cycle", "sprint", "iteration"},
-	{"dashboard", "dashboards", "board", "view"},
+	{"dashboard", "dashboards", "board"},
 	{"credential", "secret", "key", "token"},
 	{"member", "user", "participant"},
 	{"email", "mail", "gmail"},
@@ -144,6 +144,8 @@ var synonymGroups = [][]string{
 	{"find", "search", "query", "queries", "lookup", "discover", "filter"},
 	{"send", "post", "publish"},
 	{"execute", "run", "invoke", "trigger"},
+	{"get", "retrieve", "fetch", "read", "show", "view", "describe"},
+	{"list", "ls", "enumerate"},
 }
 
 // buildSynonymMap expands synonym groups into a self-inclusive lookup map.

--- a/server/search.go
+++ b/server/search.go
@@ -135,6 +135,14 @@ var synonymGroups = [][]string{
 	{"email", "mail", "gmail"},
 	{"break", "fail", "crash", "down"},
 	{"metric", "metrics"},
+	{"table", "tables"},
+	{"label", "labels", "tag", "tags"},
+	{"diff", "patch", "changes"},
+	{"column", "columns", "field", "fields"},
+	{"schema", "schemas"},
+	{"database", "databases", "db"},
+	{"branch", "branches"},
+	{"comment", "comments"},
 
 	// Verbs — action synonyms
 	{"create", "add", "new", "make", "generate"},

--- a/server/search_benchmark_test.go
+++ b/server/search_benchmark_test.go
@@ -87,6 +87,8 @@ var singleToolCases = []searchBenchmarkCase{
 	{Name: "synonym/remove-ref", Query: "remove branch", ExpectedTools: []string{"github_delete_ref"}, K: 5},
 	{Name: "synonym/edit-issue", Query: "edit issue", ExpectedTools: []string{"linear_update_issue"}, K: 5},
 	{Name: "synonym/lookup-user", Query: "lookup user", ExpectedTools: []string{"github_get_user"}, K: 5},
+	{Name: "synonym/get-page", Query: "get page", ExpectedTools: []string{"notion_retrieve_page", "notion_get_page_content"}, K: 5},
+	{Name: "synonym/describe-table", Query: "describe table", ExpectedTools: []string{"postgres_describe_table"}, K: 5},
 	{Name: "synonym/post-notification", Query: "post notification", ExpectedTools: []string{"slack_send_message"}, K: 5},
 	{Name: "synonym/search-logs", Query: "find logs", ExpectedTools: []string{"datadog_search_logs"}, K: 5},
 	{Name: "synonym/query-database", Query: "query database", ExpectedTools: []string{"postgres_execute_query", "clickhouse_execute_query"}, K: 5},

--- a/server/search_test.go
+++ b/server/search_test.go
@@ -289,6 +289,18 @@ func TestPreComputedTokens(t *testing.T) {
 	})
 }
 
+func TestSynonymGroups_Disjoint(t *testing.T) {
+	seen := make(map[string][]string)
+	for _, group := range synonymGroups {
+		for _, word := range group {
+			if prev, ok := seen[word]; ok {
+				t.Errorf("word %q in two groups: %v and %v", word, prev, group)
+			}
+			seen[word] = group
+		}
+	}
+}
+
 func TestBuildSynonymMap_IncludesSelf(t *testing.T) {
 	synMap := buildSynonymMap([][]string{
 		{"ticket", "issue", "bug"},

--- a/server/server.go
+++ b/server/server.go
@@ -549,6 +549,11 @@ func (s *Server) handleExecute(ctx context.Context, req *mcpsdk.CallToolRequest)
 	if args.ToolName == "" {
 		return errorResult("either tool_name or script is required"), nil
 	}
+	if args.ToolName == "search" || args.ToolName == "execute" {
+		return errorResult(fmt.Sprintf(
+			"tool %q is a meta-tool — use it directly as an MCP tool call, not through execute",
+			args.ToolName)), nil
+	}
 	if args.Arguments == nil {
 		args.Arguments = map[string]any{}
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -77,7 +77,13 @@ func New(services *mcp.Services, opts ...Option) *Server {
 			Name:    "switchboard",
 			Version: "0.2.0",
 		},
-		nil,
+		&mcpsdk.ServerOptions{
+			Instructions: "Switchboard aggregates tools from multiple integrations " +
+				"behind two meta-tools: search and execute. " +
+				"Always search before calling execute — do not guess tool names. " +
+				"Search uses synonym matching, so short keyword queries work best " +
+				"(e.g., {\"query\": \"get page\"} finds notion_retrieve_page).",
+		},
 	)
 
 	s := &Server{
@@ -150,14 +156,15 @@ Mode 2 — Single tool (provide tool_name + arguments):
   {"tool_name": "github_list_issues", "arguments": {"owner": "golang", "repo": "go"}}
 
 Script API:
-  api.call(toolName, args[, opts]) — call any tool, returns parsed JSON. Throws on error (kills script).
+  api.call(toolName, args[, opts]) — call any integration tool, returns parsed JSON. Throws on error (kills script).
     Optional opts object with fields key applies server-side field projection: {fields: ["id", "title", "user.login"]}.
     Uses dot-notation: {fields: ["id", "title", "user.login", "labels[].name"]}. Only specified fields are kept.
   api.tryCall(toolName, args[, opts]) — like call, but returns {ok: true, data: ...} or {ok: false, error: "..."}.
     Also supports the optional opts with field projection. Prefer tryCall for cross-integration scripts where partial results are useful.
   console.log(...) — debug logging (included in output on error)
 
-Scripts can call tools from ANY integration — chain GitHub, Linear, Sentry, Datadog, Slack, etc. in one script.
+Scripts can call integration tools — chain GitHub, Linear, Sentry, Datadog, Slack, etc. in one script.
+Scripts CANNOT call the search or execute meta-tools. Use search before writing a script to discover tool names.
 
 List and search responses are automatically compacted to essential fields.
 Use single-item get tools (e.g., github_get_issue) for full detail.
@@ -913,6 +920,15 @@ type toolExecutor struct {
 }
 
 func (te *toolExecutor) Execute(ctx context.Context, toolName string, args map[string]any) (*mcp.ToolResult, error) {
+	if toolName == "search" || toolName == "execute" {
+		return &mcp.ToolResult{
+			Data: fmt.Sprintf(
+				"tool %q is a meta-tool and cannot be called from scripts. "+
+					"Use the search MCP tool before writing a script to discover tool names.",
+				toolName),
+			IsError: true,
+		}, nil
+	}
 	// Integration is discarded: script-path calls intentionally skip per-tool
 	// compaction so scripts can access all fields by name before projecting.
 	_, result, err := te.server.executeTool(ctx, toolName, args)

--- a/server/server.go
+++ b/server/server.go
@@ -172,9 +172,6 @@ Use single-item get tools (e.g., github_get_issue) for full detail.
 Responses over 50KB return an error — use filters, lower limit/per_page, or fetch individual items.
 Script output is also capped at 50KB — return only the fields you need, not entire API responses.
 
-CRITICAL: Use search first to discover tool names and parameter schemas. Do NOT guess
-tool names — call search with a keyword (e.g., {"query": "list repos"}) to find the exact name.
-
 Script examples:
 
 Fetch a GitHub PR with field projection (only title, state, and branch refs returned):

--- a/server/server.go
+++ b/server/server.go
@@ -113,10 +113,11 @@ func (s *Server) registerTools() {
 
 IMPORTANT: Always search before calling execute. Do NOT guess tool names.
 
-Query format — use 2-3 keywords, not full sentences:
+Query format — use 1-2 keywords, not full sentences. Fewer words = better results:
 - {"query": "create ticket"} — synonym matching finds linear_create_issue
-- {"query": "slack send message"} — always include the integration name
-- {"integration": "sentry", "query": "errors"} — or use the integration filter`,
+- {"query": "slack send"} — integration name + verb is ideal
+- {"integration": "sentry", "query": "errors"} — or use the integration filter
+Avoid 4+ word queries — they return fewer results. Search twice with short queries instead of once with a long query.`,
 		InputSchema: objectSchema(map[string]any{
 			"query": map[string]any{
 				"type":        "string",

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1208,6 +1208,21 @@ func TestScriptExecution_ToolNotFound(t *testing.T) {
 	assert.Contains(t, result.Data, "not found")
 }
 
+func TestScriptExecution_MetaToolReturnsSpecificError(t *testing.T) {
+	s := setupTestServer()
+	for _, toolName := range []string{"search", "execute"} {
+		t.Run(toolName, func(t *testing.T) {
+			result, err := s.scriptEngine.Run(context.Background(),
+				`api.call("`+toolName+`", {});`,
+			)
+			require.NoError(t, err)
+			assert.True(t, result.IsError)
+			assert.Contains(t, result.Data, "meta-tool")
+			assert.Contains(t, result.Data, "cannot")
+		})
+	}
+}
+
 func TestHandleExecute_EmptyArgs(t *testing.T) {
 	s := setupTestServer()
 	_, result, err := s.executeTool(context.Background(), "", map[string]any{})


### PR DESCRIPTION
Attacking this at a couple levels:
1. create a `search` and `execute` meta prompting, so that if an LLM tries to execute `search` or `execute` they get a useful error explaining that they are doing it wrong.
2. adjust synonyms to improve tf-idf scoring.
3. Add "start here" guidance for integrations missing it to give LLMs usage hints.