### PR TITLE
Bump max response cap from 50KB to 256KB

### DIFF
--- a/.agents/skills/mcp-benchmark/SKILL.md
+++ b/.agents/skills/mcp-benchmark/SKILL.md
@@ -95,7 +95,7 @@ For any integration not listed, use the first list/search tool found via
 | Columnar format | If 8+ items, verify columnar shape with `columns`+`rows`. Check `constants` for lifted uniform values |
 | Empty object `{}` | **FLAG as compaction shape mismatch (Critical)** |
 | Error | Record error message verbatim |
-| Approximate size | Eyeball response length; flag if approaching 50KB |
+| Approximate size | Eyeball response length; flag if approaching 256KB |
 
 ### Phase 3: Search Discoverability Tests
 
@@ -150,7 +150,7 @@ Calculate metrics from all phases:
 |--------|---------|
 | Script rewrite rate | Scripts rewritten / scripts attempted |
 | Integration error rate | Upstream API errors / total calls |
-| Server error rate | Tool-not-found + 50KB exceeded / total calls |
+| Server error rate | Tool-not-found + 256KB exceeded / total calls |
 | Silent data loss | Responses returning `{}` when data expected |
 | Search miss rate | 0-result queries / total search queries |
 | Search false-negative rate | Expected tool not in results / total queries |

--- a/server/server.go
+++ b/server/server.go
@@ -20,7 +20,7 @@ import (
 )
 
 const defaultSearchLimit = 20
-const maxResponseBytes = 50 * 1024 // 50KB
+const maxResponseBytes = 256 * 1024 // 256KB
 
 // searchToolInfo represents a tool in search results.
 type searchToolInfo struct {
@@ -161,8 +161,8 @@ Scripts can call tools from ANY integration — chain GitHub, Linear, Sentry, Da
 
 List and search responses are automatically compacted to essential fields.
 Use single-item get tools (e.g., github_get_issue) for full detail.
-Responses over 50KB return an error — use filters, lower limit/per_page, or fetch individual items.
-Script output is also capped at 50KB — return only the fields you need, not entire API responses.
+Responses over 256KB return an error — use filters, lower limit/per_page, or fetch individual items.
+Script output is also capped at 256KB — return only the fields you need, not entire API responses.
 
 CRITICAL: Use search first to discover tool names and parameter schemas. Do NOT guess
 tool names — call search with a keyword (e.g., {"query": "list repos"}) to find the exact name.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1025,8 +1025,8 @@ func TestHandleExecute_CompactionSkippedOnErrorResult(t *testing.T) {
 }
 
 func TestHandleExecute_ByteCapEnforced(t *testing.T) {
-	// Generate a response over 50KB.
-	bigData := `{"data":"` + string(make([]byte, 60*1024)) + `"}`
+	// Generate a response over the 256KB cap.
+	bigData := `{"data":"` + string(make([]byte, 300*1024)) + `"}`
 	mi := &mockIntegration{
 		name:    "testint",
 		healthy: true,
@@ -1049,7 +1049,7 @@ func TestHandleExecute_ByteCapEnforced(t *testing.T) {
 }
 
 func TestHandleExecute_ByteCapSkippedOnError(t *testing.T) {
-	bigErr := string(make([]byte, 60*1024))
+	bigErr := string(make([]byte, 300*1024))
 	mi := &mockIntegration{
 		name:    "testint",
 		healthy: true,
@@ -1605,7 +1605,7 @@ func TestScriptExecution_CrossIntegration(t *testing.T) {
 }
 
 func TestScriptExecution_OutputByteCapEnforced(t *testing.T) {
-	chunkData := `{"data":"` + strings.Repeat("x", 20*1024) + `"}`
+	chunkData := `{"data":"` + strings.Repeat("x", 100*1024) + `"}`
 	mi := &mockIntegration{
 		name:    "testint",
 		healthy: true,


### PR DESCRIPTION
## Summary
- Raise `maxResponseBytes` in `server/server.go` from 50KB to 256KB
- The previous cap was too small for content-rich integrations like Confluence, Notion, and Jira, where a single page response regularly exceeds 50KB and fails with `Response exceeded 50KB`
- 256KB (~64K tokens) accommodates these payloads while still leaving roughly two-thirds of a 200K-token context window for the rest of the conversation
- Updated the user-facing description text in the execute tool prompt and benchmark skill docs
- Updated the three byte-cap tests to use payload sizes that exceed the new cap

## Why 256KB?
| Cap | ~Tokens | % of 200K context |
|-----|---------|-------------------|
| 50KB (old) | ~12K | 6% |
| 256KB (new) | ~64K | 32% |

256KB is large enough for rich pages (Confluence/Notion bodies, GitHub issues with comments, Datadog log windows) but small enough that a single response can't dominate a conversation. Field projection and pagination remain available for further reduction.

## Test plan
- [x] `go build` passes
- [x] `go vet` passes
- [x] `golangci-lint` passes (0 issues)
- [x] All server tests pass, including `TestHandleExecute_ByteCapEnforced`, `TestHandleExecute_ByteCapSkippedOnError`, and `TestScriptExecution_OutputByteCapEnforced` updated to use 300KB / 100KB chunks

🤖 Generated with [Claude Code](https://claude.com/claude-code)