### PR TITLE
Add per-integration response size cap override

### DIFF
--- a/integrations/confluence/confluence.go
+++ b/integrations/confluence/confluence.go
@@ -16,10 +16,17 @@ import (
 
 // Compile-time interface assertions.
 var (
-	_ mcp.Integration                = (*confluence)(nil)
-	_ mcp.FieldCompactionIntegration = (*confluence)(nil)
-	_ mcp.PlainTextCredentials       = (*confluence)(nil)
+	_ mcp.Integration                 = (*confluence)(nil)
+	_ mcp.FieldCompactionIntegration  = (*confluence)(nil)
+	_ mcp.PlainTextCredentials        = (*confluence)(nil)
+	_ mcp.MaxResponseBytesIntegration = (*confluence)(nil)
 )
+
+// confluenceMaxResponseBytes raises the response cap for Confluence above the
+// server default. Confluence page bodies (Atlassian Document Format or Storage
+// Format XHTML) routinely exceed 50KB for richly authored pages, and the whole
+// point of tools like confluence_get_page is to return that content to the LLM.
+const confluenceMaxResponseBytes = 256 * 1024 // 256KB
 
 type confluence struct {
 	email    string
@@ -72,6 +79,8 @@ func (c *confluence) CompactSpec(toolName string) ([]mcp.CompactField, bool) {
 	fields, ok := fieldCompactionSpecs[toolName]
 	return fields, ok
 }
+
+func (c *confluence) MaxResponseBytes() int { return confluenceMaxResponseBytes }
 
 func (c *confluence) Execute(ctx context.Context, toolName string, args map[string]any) (*mcp.ToolResult, error) {
 	fn, ok := dispatch[toolName]

--- a/mcp.go
+++ b/mcp.go
@@ -194,6 +194,19 @@ type FieldCompactionIntegration interface {
 	CompactSpec(toolName string) ([]CompactField, bool)
 }
 
+// MaxResponseBytesIntegration is an optional interface that integrations can implement
+// to raise the response size cap above the server's default. Content-heavy integrations
+// (e.g. Confluence pages, Notion documents) can declare a higher cap when a single
+// record legitimately exceeds the default. Integrations that don't implement this
+// interface use the server default and are expected to stay under it via filters,
+// pagination, and field compaction.
+type MaxResponseBytesIntegration interface {
+	// MaxResponseBytes returns the maximum response size in bytes that this
+	// integration's tools are allowed to produce. Values at or below the server
+	// default are ignored (the default applies).
+	MaxResponseBytes() int
+}
+
 // PlainTextCredentials is an optional interface that integrations can implement
 // to declare which credential keys should be rendered as plain text inputs
 // instead of password fields in the web UI.

--- a/server/project_server.go
+++ b/server/project_server.go
@@ -331,13 +331,14 @@ func (pr *ProjectRouter) makeExecuteHandler(def *project.Definition, scopeRule *
 		if !result.IsError {
 			result.Data = processResult(integration, args.ToolName, result.Data, pr.services.Metrics)
 
-			if len(result.Data) > maxResponseBytes {
+			limit := responseLimitFor(integration)
+			if len(result.Data) > limit {
 				if pr.services.Metrics != nil {
 					pr.services.Metrics.RecordTruncation()
 				}
 				return errorResult(fmt.Sprintf(
 					"Response exceeded %dKB (actual: %dKB). Use more specific filters, lower limit/per_page, or fetch individual items.",
-					maxResponseBytes/1024, len(result.Data)/1024,
+					limit/1024, len(result.Data)/1024,
 				)), nil
 			}
 		}

--- a/server/project_server_test.go
+++ b/server/project_server_test.go
@@ -3,8 +3,10 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	mcp "github.com/daltoniam/switchboard"
@@ -44,6 +46,36 @@ func setupProjectRouter(t *testing.T, def *project.Definition, integrations ...*
 		for _, tool := range i.Tools() {
 			tools = append(tools, toolWithIntegration{Integration: i.Name(), Tool: tool})
 		}
+	}
+	idf := computeIDF(tools)
+
+	router := NewProjectRouter(services, store, "switchboard", SearchIndex{IDF: idf, SynMap: sm, AllTools: tools})
+	return router, store
+}
+
+// setupProjectRouterWithIntegration mirrors setupProjectRouter but accepts an
+// arbitrary mcp.Integration so tests can register wrapper types like
+// mockIntegrationWithCap that aren't *mockIntegration directly.
+func setupProjectRouterWithIntegration(t *testing.T, def *project.Definition, i mcp.Integration) (*ProjectRouter, *project.Store) {
+	t.Helper()
+	dir := t.TempDir()
+	store := project.NewStore(dir)
+	require.NoError(t, store.Create(def))
+
+	reg := newMockRegistry()
+	reg.Register(i)
+
+	services := &mcp.Services{
+		Config: newMockConfigService(map[string]*mcp.IntegrationConfig{
+			i.Name(): {Enabled: true, Credentials: mcp.Credentials{"token": "test"}},
+		}),
+		Registry: reg,
+	}
+
+	sm := buildSynonymMap(synonymGroups)
+	var tools []toolWithIntegration
+	for _, tool := range i.Tools() {
+		tools = append(tools, toolWithIntegration{Integration: i.Name(), Tool: tool})
 	}
 	idf := computeIDF(tools)
 
@@ -240,6 +272,64 @@ func TestProjectRouter_ExecuteDenied(t *testing.T) {
 
 	tc := result.Content[0].(*mcpsdk.TextContent)
 	assert.Contains(t, tc.Text, "denied")
+}
+
+func TestProjectRouter_ExecutePerIntegrationCap(t *testing.T) {
+	// The project router's execute handler and server.handleExecute both call
+	// responseLimitFor. These subtests pin the project router path so a future
+	// refactor can't silently regress the per-integration cap behavior there.
+	def := &project.Definition{Version: "1", Name: "cap-test"}
+
+	buildIntegration := func(payload string) *mockIntegrationWithCap {
+		return &mockIntegrationWithCap{
+			mockIntegration: &mockIntegration{
+				name:    "bigint",
+				healthy: true,
+				tools: []mcp.ToolDefinition{
+					{Name: "bigint_get_page", Description: "Returns rich page content"},
+				},
+				execFn: func(_ context.Context, _ string, _ map[string]any) (*mcp.ToolResult, error) {
+					return &mcp.ToolResult{Data: payload}, nil
+				},
+			},
+			maxBytes: 256 * 1024,
+		}
+	}
+
+	executeTool := func(t *testing.T, mi *mockIntegrationWithCap) *mcpsdk.CallToolResult {
+		t.Helper()
+		router, _ := setupProjectRouterWithIntegration(t, def, mi)
+		scopeRule := project.GetEffectiveRule(def, "switchboard", "")
+		handler := router.makeExecuteHandler(def, scopeRule)
+		result, err := handler(context.Background(), projectToolRequest("execute", map[string]any{
+			"tool_name": "bigint_get_page",
+			"arguments": map[string]any{},
+		}))
+		require.NoError(t, err)
+		return result
+	}
+
+	t.Run("honored above default under override", func(t *testing.T) {
+		// 100KB payload is above the 50KB default but under the 256KB override —
+		// a default-capped integration would reject this, the override must allow it.
+		payload := fmt.Sprintf(`{"data":"%s"}`, strings.Repeat("x", 100*1024))
+		result := executeTool(t, buildIntegration(payload))
+
+		assert.False(t, result.IsError, "response within per-integration cap should succeed")
+		tc := result.Content[0].(*mcpsdk.TextContent)
+		assert.Equal(t, payload, tc.Text)
+	})
+
+	t.Run("still enforced above override", func(t *testing.T) {
+		// 300KB payload exceeds even the raised 256KB cap — must still be rejected,
+		// and the error must report the integration's cap, not the default.
+		payload := fmt.Sprintf(`{"data":"%s"}`, strings.Repeat("x", 300*1024))
+		result := executeTool(t, buildIntegration(payload))
+
+		assert.True(t, result.IsError, "response above per-integration cap should be rejected")
+		tc := result.Content[0].(*mcpsdk.TextContent)
+		assert.Contains(t, tc.Text, "256KB", "error should report the integration's own cap")
+	})
 }
 
 func TestProjectRouter_ContextManifest(t *testing.T) {

--- a/server/server.go
+++ b/server/server.go
@@ -20,7 +20,19 @@ import (
 )
 
 const defaultSearchLimit = 20
-const maxResponseBytes = 50 * 1024 // 50KB
+const defaultMaxResponseBytes = 50 * 1024 // 50KB
+
+// responseLimitFor returns the effective response byte cap for an integration.
+// Integrations that implement MaxResponseBytesIntegration may declare a higher
+// cap; values at or below the default are ignored.
+func responseLimitFor(integration mcp.Integration) int {
+	if mri, ok := integration.(mcp.MaxResponseBytesIntegration); ok {
+		if v := mri.MaxResponseBytes(); v > defaultMaxResponseBytes {
+			return v
+		}
+	}
+	return defaultMaxResponseBytes
+}
 
 // searchToolInfo represents a tool in search results.
 type searchToolInfo struct {
@@ -566,13 +578,14 @@ func (s *Server) handleExecute(ctx context.Context, req *mcpsdk.CallToolRequest)
 		}, nil
 	}
 	result.Data = processResult(integration, args.ToolName, result.Data, s.services.Metrics)
-	if len(result.Data) > maxResponseBytes {
+	limit := responseLimitFor(integration)
+	if len(result.Data) > limit {
 		if s.services.Metrics != nil {
 			s.services.Metrics.RecordTruncation()
 		}
 		return errorResult(fmt.Sprintf(
 			"Response exceeded %dKB (actual: %dKB). Use more specific filters, lower limit/per_page, or fetch individual items.",
-			maxResponseBytes/1024,
+			limit/1024,
 			len(result.Data)/1024,
 		)), nil
 	}
@@ -601,13 +614,13 @@ func (s *Server) handleScriptExecute(ctx context.Context, source string) (*mcpsd
 		}, nil
 	}
 	result.Data = columnarizeResult(result.Data)
-	if len(result.Data) > maxResponseBytes {
+	if len(result.Data) > defaultMaxResponseBytes {
 		if s.services.Metrics != nil {
 			s.services.Metrics.RecordTruncation()
 		}
 		return errorResult(fmt.Sprintf(
 			"Script output exceeded %dKB (actual: %dKB). Return only the fields you need from each api.call() result.",
-			maxResponseBytes/1024,
+			defaultMaxResponseBytes/1024,
 			len(result.Data)/1024,
 		)), nil
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1044,7 +1044,7 @@ func TestHandleExecute_ByteCapEnforced(t *testing.T) {
 	assert.True(t, result.IsError, "over-cap response should return error")
 
 	tc := result.Content[0].(*mcpsdk.TextContent)
-	capKB := fmt.Sprintf("%dKB", maxResponseBytes/1024)
+	capKB := fmt.Sprintf("%dKB", defaultMaxResponseBytes/1024)
 	assert.Contains(t, tc.Text, capKB)
 }
 
@@ -1067,8 +1067,86 @@ func TestHandleExecute_ByteCapSkippedOnError(t *testing.T) {
 	assert.True(t, result.IsError)
 
 	tc := result.Content[0].(*mcpsdk.TextContent)
-	capKB := fmt.Sprintf("%dKB", maxResponseBytes/1024)
+	capKB := fmt.Sprintf("%dKB", defaultMaxResponseBytes/1024)
 	assert.NotContains(t, tc.Text, capKB, "error results should skip byte cap")
+}
+
+// mockIntegrationWithCap is a mockIntegration that also implements
+// mcp.MaxResponseBytesIntegration, declaring a higher per-integration cap.
+type mockIntegrationWithCap struct {
+	*mockIntegration
+	maxBytes int
+}
+
+func (m *mockIntegrationWithCap) MaxResponseBytes() int { return m.maxBytes }
+
+// setupTestServerWithIntegration builds a Server around a single arbitrary
+// mcp.Integration — unlike setupTestServer which only accepts *mockIntegration.
+// Needed for tests that register wrapper types like mockIntegrationWithCap.
+func setupTestServerWithIntegration(i mcp.Integration) *Server {
+	reg := newMockRegistry()
+	reg.Register(i)
+	services := &mcp.Services{
+		Config: newMockConfigService(map[string]*mcp.IntegrationConfig{
+			i.Name(): {Enabled: true, Credentials: mcp.Credentials{"token": "test"}},
+		}),
+		Registry: reg,
+	}
+	return New(services)
+}
+
+func TestHandleExecute_PerIntegrationCapHonored(t *testing.T) {
+	// Payload is above the default (50KB) but under the integration's 256KB cap.
+	// A default-capped integration would reject this; the override must allow it.
+	bigData := `{"data":"` + strings.Repeat("x", 100*1024) + `"}`
+	mi := &mockIntegrationWithCap{
+		mockIntegration: &mockIntegration{
+			name:    "bigint",
+			healthy: true,
+			tools: []mcp.ToolDefinition{
+				{Name: "bigint_get_page", Description: "Returns rich page content"},
+			},
+			execFn: func(_ context.Context, _ string, _ map[string]any) (*mcp.ToolResult, error) {
+				return &mcp.ToolResult{Data: bigData}, nil
+			},
+		},
+		maxBytes: 256 * 1024,
+	}
+
+	s := setupTestServerWithIntegration(mi)
+	result, err := s.handleExecute(context.Background(), executeRequest("bigint_get_page", nil))
+	require.NoError(t, err)
+	assert.False(t, result.IsError, "response within per-integration cap should succeed")
+
+	tc := result.Content[0].(*mcpsdk.TextContent)
+	assert.Equal(t, bigData, tc.Text)
+}
+
+func TestHandleExecute_PerIntegrationCapStillEnforced(t *testing.T) {
+	// Payload exceeds even the integration's raised cap — must still be rejected,
+	// and the error must report the integration's cap, not the default.
+	bigData := `{"data":"` + strings.Repeat("x", 300*1024) + `"}`
+	mi := &mockIntegrationWithCap{
+		mockIntegration: &mockIntegration{
+			name:    "bigint",
+			healthy: true,
+			tools: []mcp.ToolDefinition{
+				{Name: "bigint_get_page", Description: "Returns rich page content"},
+			},
+			execFn: func(_ context.Context, _ string, _ map[string]any) (*mcp.ToolResult, error) {
+				return &mcp.ToolResult{Data: bigData}, nil
+			},
+		},
+		maxBytes: 256 * 1024,
+	}
+
+	s := setupTestServerWithIntegration(mi)
+	result, err := s.handleExecute(context.Background(), executeRequest("bigint_get_page", nil))
+	require.NoError(t, err)
+	assert.True(t, result.IsError, "response above per-integration cap should be rejected")
+
+	tc := result.Content[0].(*mcpsdk.TextContent)
+	assert.Contains(t, tc.Text, "256KB", "error should report the integration's own cap")
 }
 
 func TestToolResultJSON(t *testing.T) {
@@ -1646,7 +1724,7 @@ func TestScriptExecution_OutputByteCapEnforced(t *testing.T) {
 	assert.True(t, result.IsError, "over-cap script output should return error")
 
 	tc := result.Content[0].(*mcpsdk.TextContent)
-	capKB := fmt.Sprintf("%dKB", maxResponseBytes/1024)
+	capKB := fmt.Sprintf("%dKB", defaultMaxResponseBytes/1024)
 	assert.Contains(t, tc.Text, capKB)
 	assert.Contains(t, tc.Text, "Script output exceeded")
 }


### PR DESCRIPTION
## Summary
- The 50KB default response cap is too small for content-heavy integrations like Confluence, where a single `confluence_get_page` response legitimately exceeds it and fails
- Instead of bumping the global default (closes #118), introduce an optional `MaxResponseBytesIntegration` interface — mirroring `FieldCompactionIntegration` — that lets specific integrations declare a higher cap without forcing every adapter to share the same ceiling
- Confluence now declares a 256KB cap; all other integrations continue to use the tight 50KB default and remain incentivized to use filters, pagination, and field compaction

## Design

| Path | Cap |
|------|-----|
| Direct tool call (`handleExecute`) | Per-integration override if declared, else 50KB default |
| Project-scoped tool call (`project_server.go`) | Same |
| Script output (`handleScriptExecute`) | 50KB default (scripts assemble across integrations; should project/trim) |

The override only loosens the cap — integrations can't declare a *lower* cap than the default. That's intentional: the default is already the floor for "nothing should exceed this."

## Why not a global bump?
Global ceiling tuning forces every integration to share the same limit. An integration listing 10 lightweight items shouldn't share a cap designed for a 200KB Confluence page — keeping the default tight keeps compaction discipline honest where it matters.

## Why not per-tool?
Too granular. The useful unit is "this integration publishes rich content" (Confluence, Notion, etc.), not "this specific tool call does." Integrations with mixed tool shapes can always split their declaration later if needed.

## Test plan
- [x] `go build` passes
- [x] `go vet` passes
- [x] `golangci-lint` passes (0 issues)
- [x] Existing `TestHandleExecute_ByteCapEnforced` / `ByteCapSkippedOnError` / `TestScriptExecution_OutputByteCapEnforced` still pass against the renamed `defaultMaxResponseBytes`
- [x] New `TestHandleExecute_PerIntegrationCapHonored` — 100KB payload from an integration declaring 256KB succeeds (would fail under default)
- [x] New `TestHandleExecute_PerIntegrationCapStillEnforced` — 300KB payload from the same integration is rejected with the integration's own cap in the error message

## Files
- `mcp.go` — new `MaxResponseBytesIntegration` interface
- `server/server.go` — `responseLimitFor()` helper; applied in `handleExecute`
- `server/project_server.go` — same helper applied to project tool-call path
- `integrations/confluence/confluence.go` — declares 256KB cap
- `server/server_test.go` — 2 new tests + `mockIntegrationWithCap` test helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)