### PR TITLE
fix(slack): skip Chrome extraction and file persistence when token provided via config

### DIFF
--- a/integrations/slack/slack.go
+++ b/integrations/slack/slack.go
@@ -39,14 +39,15 @@ func (s *slackIntegration) Configure(ctx context.Context, creds mcp.Credentials)
 	s.clients = make(map[string]*slack.Client)
 	s.mu.Unlock()
 
-	if t := creds["token"]; t != "" {
+	configToken := creds["token"]
+	if configToken != "" {
 		teamID := creds["team_id"]
 		if teamID == "" {
 			teamID = "_config"
 		}
 		s.store.setWorkspace(&workspace{
 			TeamID: teamID,
-			Token:  t,
+			Token:  configToken,
 			Cookie: creds["cookie"],
 			Source: "config",
 		})
@@ -55,16 +56,20 @@ func (s *slackIntegration) Configure(ctx context.Context, creds mcp.Credentials)
 		}
 	}
 
-	s.store.loadFromFile()
+	// When a token was provided via config (e.g. OAuth in hosted environments),
+	// skip local file and Chrome extraction — the config token is authoritative.
+	if configToken == "" {
+		s.store.loadFromFile()
 
-	if len(s.store.allWorkspaces()) == 0 {
-		wss, _ := listWorkspacesFromChrome()
-		for _, ws := range wss {
-			s.store.setWorkspace(&workspace{
-				TeamID:   ws.TeamID,
-				TeamName: ws.Name,
-				Source:   "chrome",
-			})
+		if len(s.store.allWorkspaces()) == 0 {
+			wss, _ := listWorkspacesFromChrome()
+			for _, ws := range wss {
+				s.store.setWorkspace(&workspace{
+					TeamID:   ws.TeamID,
+					TeamName: ws.Name,
+					Source:   "chrome",
+				})
+			}
 		}
 	}
 
@@ -79,13 +84,20 @@ func (s *slackIntegration) Configure(ctx context.Context, creds mcp.Credentials)
 		s.store.setDefault(tid)
 	}
 
-	_ = s.store.saveToFile()
+	// Only persist and run background refresh for locally-sourced tokens.
+	// OAuth tokens (xoxp-*, xoxb-*) are long-lived and managed externally.
+	if configToken == "" {
+		_ = s.store.saveToFile()
 
-	if s.stopBg != nil {
+		if s.stopBg != nil {
+			close(s.stopBg)
+		}
+		s.stopBg = make(chan struct{})
+		go s.backgroundRefresh()
+	} else if s.stopBg != nil {
 		close(s.stopBg)
+		s.stopBg = nil
 	}
-	s.stopBg = make(chan struct{})
-	go s.backgroundRefresh()
 
 	return nil
 }

--- a/integrations/slack/slack.go
+++ b/integrations/slack/slack.go
@@ -85,7 +85,7 @@ func (s *slackIntegration) Configure(ctx context.Context, creds mcp.Credentials)
 	}
 
 	// Only persist and run background refresh for locally-sourced tokens.
-	// OAuth tokens (xoxp-*, xoxb-*) are long-lived and managed externally.
+	// Config-provided tokens are managed externally and don't need local refresh.
 	if configToken == "" {
 		_ = s.store.saveToFile()
 

--- a/integrations/slack/slack_test.go
+++ b/integrations/slack/slack_test.go
@@ -347,6 +347,60 @@ func TestGetClientForArgs_UnknownWorkspace(t *testing.T) {
 	assert.Contains(t, err.Error(), "unknown workspace")
 }
 
+// --- Configure token-gating tests ---
+
+func TestConfigure_ConfigTokenSkipsFileAndChrome(t *testing.T) {
+	s := &slackIntegration{}
+	s.Configure(t.Context(), mcp.Credentials{
+		"token":   "xoxb-test-token",
+		"team_id": "T_CONFIG",
+	})
+
+	// Exactly one workspace with Source=="config".
+	all := s.store.allWorkspaces()
+	require.Len(t, all, 1)
+	assert.Equal(t, "config", all[0].Source)
+	assert.Equal(t, "xoxb-test-token", all[0].Token)
+	assert.Equal(t, "T_CONFIG", all[0].TeamID)
+
+	// No background refresh started.
+	assert.Nil(t, s.stopBg)
+}
+
+func TestConfigure_ConfigTokenDefaultTeamID(t *testing.T) {
+	s := &slackIntegration{}
+	s.Configure(t.Context(), mcp.Credentials{
+		"token": "xoxb-test-token",
+	})
+
+	// When no team_id is provided, it defaults to "_config".
+	ws := s.store.getWorkspace("_config")
+	require.NotNil(t, ws)
+	assert.Equal(t, "xoxb-test-token", ws.Token)
+}
+
+func TestConfigure_SwitchToConfigTokenStopsBackgroundRefresh(t *testing.T) {
+	stopCh := make(chan struct{})
+	s := &slackIntegration{
+		stopBg: stopCh,
+	}
+	s.Configure(t.Context(), mcp.Credentials{
+		"token":   "xoxb-test-token",
+		"team_id": "T_CONFIG",
+	})
+
+	// The pre-existing stopBg channel should have been closed.
+	select {
+	case <-stopCh:
+		// ok — channel was closed
+	default:
+		t.Fatal("expected previous stopBg channel to be closed")
+	}
+
+	// And stopBg is now nil (no new refresh goroutine).
+	assert.Nil(t, s.stopBg)
+}
+
 func TestErrResult_NonRetryableProducesToolResult(t *testing.T) {
 	result, err := mcp.ErrResult(fmt.Errorf("no workspace"))
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

- When a Slack token is provided via config credentials (e.g. OAuth in hosted environments), skip local file I/O, Chrome workspace extraction, and background refresh — none of which apply when tokens are externally managed.
- Local-only usage (no config token) follows the original code path unchanged.

## Test plan

- [ ] Verify hosted path: configure with `token` credential, confirm no file reads/writes or Chrome calls
- [ ] Verify local path: configure without `token`, confirm Chrome extraction and file persistence still run
- [ ] Verify re-configure: switch from local to config token, confirm background refresh goroutine is stopped


🐙 Generated with [Crush](https://crush.ai)