### PR TITLE
feat: ollama integration

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/daltoniam/switchboard/integrations/metabase"
 	nomadInt "github.com/daltoniam/switchboard/integrations/nomad"
 	notionInt "github.com/daltoniam/switchboard/integrations/notion"
+	"github.com/daltoniam/switchboard/integrations/ollama"
 	"github.com/daltoniam/switchboard/integrations/pganalyze"
 	"github.com/daltoniam/switchboard/integrations/postgres"
 	"github.com/daltoniam/switchboard/integrations/posthog"
@@ -221,6 +222,7 @@ func runServer(stdioMode bool, port int, discoverAll bool) {
 		jira.New(),
 		confluence.New(),
 		notionInt.New(),
+		ollama.New(),
 		gcpInt.New(),
 		suno.New(),
 		salesforce.New(),

--- a/config/config.go
+++ b/config/config.go
@@ -84,6 +84,10 @@ var envMapping = map[string]map[string]string{
 		"username": "ELASTICSEARCH_USERNAME",
 		"password": "ELASTICSEARCH_PASSWORD",
 	},
+	"ollama": {
+		"base_url": "OLLAMA_HOST",
+		"api_key":  "OLLAMA_API_KEY",
+	},
 	"salesforce": {
 		"access_token": "SALESFORCE_ACCESS_TOKEN",
 		"instance_url": "SALESFORCE_INSTANCE_URL",
@@ -229,6 +233,10 @@ func defaultConfig() *mcp.Config {
 			"notion": {
 				Enabled:     false,
 				Credentials: mcp.Credentials{"token_v2": ""},
+			},
+			"ollama": {
+				Enabled:     false,
+				Credentials: mcp.Credentials{"base_url": "", "api_key": ""},
 			},
 			"ynab": {
 				Enabled:     false,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -32,8 +32,8 @@ func TestLoad_CreatesDefaultWhenMissing(t *testing.T) {
 	_, err = os.Stat(path)
 	assert.NoError(t, err)
 
-	assert.Len(t, m.cfg.Integrations, 33)
-	for _, name := range []string{"github", "datadog", "linear", "sentry", "slack", "metabase", "aws", "posthog", "postgres", "clickhouse", "elasticsearch", "pganalyze", "rwx", "gmail", "notion", "ynab", "gcp", "suno", "amazon", "jira", "confluence", "salesforce", "cloudflare", "digitalocean", "fly", "snowflake", "acp", "web", "botidentity", "x", "signoz", "nomad", "switchboard"} {
+	assert.Len(t, m.cfg.Integrations, 34)
+	for _, name := range []string{"github", "datadog", "linear", "sentry", "slack", "metabase", "aws", "posthog", "postgres", "clickhouse", "elasticsearch", "pganalyze", "rwx", "gmail", "notion", "ollama", "ynab", "gcp", "suno", "amazon", "jira", "confluence", "salesforce", "cloudflare", "digitalocean", "fly", "snowflake", "acp", "web", "botidentity", "x", "signoz", "nomad", "switchboard"} {
 		ic, ok := m.cfg.Integrations[name]
 		assert.True(t, ok, "missing default integration: %s", name)
 		assert.False(t, ic.Enabled)
@@ -134,7 +134,7 @@ func TestSave(t *testing.T) {
 
 	var cfg mcp.Config
 	require.NoError(t, json.Unmarshal(data, &cfg))
-	assert.Len(t, cfg.Integrations, 33)
+	assert.Len(t, cfg.Integrations, 34)
 }
 
 func TestGet(t *testing.T) {
@@ -143,7 +143,7 @@ func TestGet(t *testing.T) {
 
 	cfg := m.Get()
 	assert.NotNil(t, cfg)
-	assert.Len(t, cfg.Integrations, 33)
+	assert.Len(t, cfg.Integrations, 34)
 }
 
 func TestUpdate(t *testing.T) {
@@ -253,7 +253,7 @@ func TestEnabledIntegrations_Multiple(t *testing.T) {
 func TestDefaultConfig(t *testing.T) {
 	cfg := defaultConfig()
 	require.NotNil(t, cfg)
-	assert.Len(t, cfg.Integrations, 33)
+	assert.Len(t, cfg.Integrations, 34)
 
 	expected := map[string][]string{
 		"github":        {"token", "client_id", "token_source"},
@@ -270,6 +270,7 @@ func TestDefaultConfig(t *testing.T) {
 		"rwx":           {"access_token", "org"},
 		"gmail":         {"access_token", "refresh_token", "client_id", "client_secret", "base_url", "token_source"},
 		"notion":        {"token_v2"},
+		"ollama":        {"base_url", "api_key"},
 		"ynab":          {"api_key"},
 		"gcp":           {"project_id", "credentials_json"},
 		"confluence":    {"email", "api_token", "domain"},
@@ -487,6 +488,8 @@ func TestEnvMapping_ReturnsMapping(t *testing.T) {
 	assert.Equal(t, "RWX_ACCESS_TOKEN", m["rwx"]["access_token"])
 	assert.Equal(t, "RWX_ORG", m["rwx"]["org"])
 	assert.Equal(t, "RWX_CLI_PATH", m["rwx"]["cli_path"])
+	assert.Equal(t, "OLLAMA_HOST", m["ollama"]["base_url"])
+	assert.Equal(t, "OLLAMA_API_KEY", m["ollama"]["api_key"])
 	assert.Equal(t, "JIRA_EMAIL", m["jira"]["email"])
 	assert.Equal(t, "JIRA_API_TOKEN", m["jira"]["api_token"])
 	assert.Equal(t, "JIRA_DOMAIN", m["jira"]["domain"])
@@ -500,7 +503,7 @@ func TestEnvMapping_ReturnsMapping(t *testing.T) {
 	assert.Equal(t, "SIGNOZ_API_KEY", m["signoz"]["api_key"])
 	assert.Equal(t, "NOMAD_ADDR", m["nomad"]["address"])
 	assert.Equal(t, "NOMAD_TOKEN", m["nomad"]["token"])
-	assert.Len(t, m, 23)
+	assert.Len(t, m, 24)
 }
 
 func TestToolGlobs_PersistThroughSaveLoad(t *testing.T) {

--- a/integrations/ollama/compact_specs.go
+++ b/integrations/ollama/compact_specs.go
@@ -1,0 +1,43 @@
+package ollama
+
+import (
+	"fmt"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+var rawFieldCompactionSpecs = map[mcp.ToolName][]string{
+	// Lists
+	"ollama_list_models": {
+		"models[].name", "models[].size", "models[].modified_at",
+		"models[].details.parameter_size", "models[].details.quantization_level", "models[].details.family",
+	},
+	"ollama_list_running": {
+		"models[].name", "models[].size", "models[].size_vram",
+		"models[].context_length", "models[].expires_at", "models[].details.parameter_size",
+	},
+	// Inference — strip timing stats, keep content
+	"ollama_chat": {
+		"model", "message", "done_reason",
+	},
+	"ollama_generate": {
+		"model", "response", "thinking", "done_reason",
+	},
+	"ollama_embed": {
+		"model", "embeddings",
+	},
+}
+
+var fieldCompactionSpecs = mustBuildFieldCompactionSpecs(rawFieldCompactionSpecs)
+
+func mustBuildFieldCompactionSpecs(raw map[mcp.ToolName][]string) map[mcp.ToolName][]mcp.CompactField {
+	parsed := make(map[mcp.ToolName][]mcp.CompactField, len(raw))
+	for tool, specs := range raw {
+		fields, err := mcp.ParseCompactSpecs(specs)
+		if err != nil {
+			panic(fmt.Sprintf("ollama: invalid field compaction spec for %q: %v", tool, err))
+		}
+		parsed[tool] = fields
+	}
+	return parsed
+}

--- a/integrations/ollama/compact_specs_test.go
+++ b/integrations/ollama/compact_specs_test.go
@@ -35,7 +35,10 @@ func TestFieldCompactionSpecs_OnlyReadTools(t *testing.T) {
 }
 
 func TestFieldCompactionSpecs_ExpectedTools(t *testing.T) {
-	expected := []mcp.ToolName{"ollama_list_models", "ollama_list_running"}
+	expected := []mcp.ToolName{
+		"ollama_list_models", "ollama_list_running",
+		"ollama_chat", "ollama_generate", "ollama_embed",
+	}
 	for _, name := range expected {
 		_, ok := fieldCompactionSpecs[name]
 		assert.True(t, ok, "expected compaction spec for %s", name)

--- a/integrations/ollama/compact_specs_test.go
+++ b/integrations/ollama/compact_specs_test.go
@@ -1,0 +1,43 @@
+package ollama
+
+import (
+	"testing"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFieldCompactionSpecs_AllParse(t *testing.T) {
+	require.NotEmpty(t, fieldCompactionSpecs, "fieldCompactionSpecs should not be empty")
+}
+
+func TestFieldCompactionSpecs_NoDuplicateTools(t *testing.T) {
+	assert.Equal(t, len(rawFieldCompactionSpecs), len(fieldCompactionSpecs))
+}
+
+func TestFieldCompactionSpecs_NoOrphanSpecs(t *testing.T) {
+	for toolName := range fieldCompactionSpecs {
+		_, ok := dispatch[toolName]
+		assert.True(t, ok, "field compaction spec for %q has no dispatch handler", toolName)
+	}
+}
+
+func TestFieldCompactionSpecs_OnlyReadTools(t *testing.T) {
+	mutationPrefixes := []string{"create", "update", "delete", "pull", "push", "copy"}
+	for toolName := range fieldCompactionSpecs {
+		name := string(toolName)
+		for _, prefix := range mutationPrefixes {
+			assert.NotContains(t, name, "_"+prefix+"_",
+				"mutation tool %q should not have compaction specs", toolName)
+		}
+	}
+}
+
+func TestFieldCompactionSpecs_ExpectedTools(t *testing.T) {
+	expected := []mcp.ToolName{"ollama_list_models", "ollama_list_running"}
+	for _, name := range expected {
+		_, ok := fieldCompactionSpecs[name]
+		assert.True(t, ok, "expected compaction spec for %s", name)
+	}
+}

--- a/integrations/ollama/inference.go
+++ b/integrations/ollama/inference.go
@@ -1,0 +1,174 @@
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+func chat(ctx context.Context, o *ollama, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	model := r.Str("model")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	rawMsgs, ok := args["messages"]
+	if !ok {
+		return mcp.ErrResult(fmt.Errorf("missing required argument: messages"))
+	}
+	msgsJSON, err := json.Marshal(rawMsgs)
+	if err != nil {
+		return mcp.ErrResult(fmt.Errorf("invalid messages: %w", err))
+	}
+	var messages []chatMessage
+	if err := json.Unmarshal(msgsJSON, &messages); err != nil {
+		return mcp.ErrResult(fmt.Errorf("invalid messages: %w", err))
+	}
+
+	req := chatRequest{
+		Model:    ModelName(model),
+		Messages: messages,
+		Stream:   false,
+	}
+	if v, ok := args["tools"]; ok {
+		if b, err := json.Marshal(v); err == nil {
+			req.Tools = b
+		}
+	}
+	if v, ok := args["format"]; ok {
+		if b, err := json.Marshal(v); err == nil {
+			req.Format = b
+		}
+	}
+	if v, ok := args["options"]; ok {
+		if m, ok := v.(map[string]any); ok {
+			req.Options = m
+		}
+	}
+	if v, ok := args["think"]; ok {
+		if b, err := json.Marshal(v); err == nil {
+			req.Think = b
+		}
+	}
+	if v, ok := args["keep_alive"]; ok {
+		if b, err := json.Marshal(v); err == nil {
+			req.KeepAlive = b
+		}
+	}
+
+	data, err := o.post(ctx, "/api/chat", req)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func generate(ctx context.Context, o *ollama, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	model := r.Str("model")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	req := generateRequest{
+		Model:  ModelName(model),
+		Stream: false,
+	}
+	if v, _ := mcp.ArgStr(args, "prompt"); v != "" {
+		req.Prompt = v
+	}
+	if v, _ := mcp.ArgStr(args, "suffix"); v != "" {
+		req.Suffix = v
+	}
+	if v, _ := mcp.ArgStr(args, "system"); v != "" {
+		req.System = v
+	}
+	if v, ok := args["images"]; ok {
+		if b, err := json.Marshal(v); err == nil {
+			var imgs []string
+			if err := json.Unmarshal(b, &imgs); err == nil {
+				req.Images = imgs
+			}
+		}
+	}
+	if v, ok := args["format"]; ok {
+		if b, err := json.Marshal(v); err == nil {
+			req.Format = b
+		}
+	}
+	if v, ok := args["options"]; ok {
+		if m, ok := v.(map[string]any); ok {
+			req.Options = m
+		}
+	}
+	if v, ok := args["think"]; ok {
+		if b, err := json.Marshal(v); err == nil {
+			req.Think = b
+		}
+	}
+	if v, ok := args["keep_alive"]; ok {
+		if b, err := json.Marshal(v); err == nil {
+			req.KeepAlive = b
+		}
+	}
+	if v, ok := args["raw"]; ok {
+		if b, ok := v.(bool); ok {
+			req.Raw = b
+		}
+	}
+
+	data, err := o.post(ctx, "/api/generate", req)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func embed(ctx context.Context, o *ollama, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	model := r.Str("model")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	input, ok := args["input"]
+	if !ok {
+		return mcp.ErrResult(fmt.Errorf("missing required argument: input"))
+	}
+
+	req := embedRequest{
+		Model:  ModelName(model),
+		Input:  input,
+		Stream: false,
+	}
+	if v, ok := args["truncate"]; ok {
+		if b, ok := v.(bool); ok {
+			req.Truncate = &b
+		}
+	}
+	if v, ok := args["dimensions"]; ok {
+		if f, ok := v.(float64); ok {
+			d := int(f)
+			req.Dimensions = &d
+		}
+	}
+	if v, ok := args["options"]; ok {
+		if m, ok := v.(map[string]any); ok {
+			req.Options = m
+		}
+	}
+	if v, ok := args["keep_alive"]; ok {
+		if b, err := json.Marshal(v); err == nil {
+			req.KeepAlive = b
+		}
+	}
+
+	data, err := o.post(ctx, "/api/embed", req)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}

--- a/integrations/ollama/inference.go
+++ b/integrations/ollama/inference.go
@@ -140,9 +140,8 @@ func embed(ctx context.Context, o *ollama, args map[string]any) (*mcp.ToolResult
 	}
 
 	req := embedRequest{
-		Model:  ModelName(model),
-		Input:  input,
-		Stream: false,
+		Model: ModelName(model),
+		Input: input,
 	}
 	if v, ok := args["truncate"]; ok {
 		if b, ok := v.(bool); ok {

--- a/integrations/ollama/inference_test.go
+++ b/integrations/ollama/inference_test.go
@@ -1,0 +1,171 @@
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChat(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/chat", r.URL.Path)
+		var req chatRequest
+		json.NewDecoder(r.Body).Decode(&req)
+		assert.Equal(t, ModelName("gemma4:e2b"), req.Model)
+		assert.False(t, req.Stream)
+		assert.Len(t, req.Messages, 1)
+		assert.Equal(t, ChatRole("user"), req.Messages[0].Role)
+
+		w.Write([]byte(`{"model":"gemma4:e2b","message":{"role":"assistant","content":"Hello!","thinking":"I should greet the user."},"done":true,"done_reason":"stop","total_duration":5000000,"eval_count":3}`))
+	}))
+	defer srv.Close()
+
+	o := New().(*ollama)
+	_ = o.Configure(context.Background(), mcp.Credentials{"base_url": srv.URL})
+	result, err := chat(context.Background(), o, map[string]any{
+		"model": "gemma4:e2b",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Hi"},
+		},
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	var resp chatResponse
+	require.NoError(t, json.Unmarshal([]byte(result.Data), &resp))
+	assert.Equal(t, "Hello!", resp.Message.Content)
+	assert.Equal(t, "I should greet the user.", resp.Message.Thinking)
+	assert.Equal(t, DoneReason("stop"), resp.DoneReason)
+	assert.Equal(t, Nanoseconds(5000000), resp.TotalDuration)
+}
+
+func TestChat_MissingModel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(400)
+		w.Write([]byte(`{"error":"model is required"}`))
+	}))
+	defer srv.Close()
+
+	o := New().(*ollama)
+	_ = o.Configure(context.Background(), mcp.Credentials{"base_url": srv.URL})
+	result, err := chat(context.Background(), o, map[string]any{
+		"messages": []any{map[string]any{"role": "user", "content": "hi"}},
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "model")
+}
+
+func TestChat_MissingMessages(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("should not reach server when messages is missing")
+	}))
+	defer srv.Close()
+
+	o := New().(*ollama)
+	_ = o.Configure(context.Background(), mcp.Credentials{"base_url": srv.URL})
+	result, err := chat(context.Background(), o, map[string]any{
+		"model": "gemma4:e2b",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "messages")
+}
+
+func TestGenerate(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/generate", r.URL.Path)
+		var req generateRequest
+		json.NewDecoder(r.Body).Decode(&req)
+		assert.Equal(t, ModelName("gemma4:e2b"), req.Model)
+		assert.Equal(t, "Say hello", req.Prompt)
+		assert.False(t, req.Stream)
+
+		w.Write([]byte(`{"model":"gemma4:e2b","response":"Hello!","done":true,"done_reason":"stop","total_duration":300000000,"eval_count":3}`))
+	}))
+	defer srv.Close()
+
+	o := New().(*ollama)
+	_ = o.Configure(context.Background(), mcp.Credentials{"base_url": srv.URL})
+	result, err := generate(context.Background(), o, map[string]any{
+		"model":  "gemma4:e2b",
+		"prompt": "Say hello",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	var resp generateResponse
+	require.NoError(t, json.Unmarshal([]byte(result.Data), &resp))
+	assert.Equal(t, "Hello!", resp.Response)
+	assert.Equal(t, DoneReason("stop"), resp.DoneReason)
+	assert.Equal(t, Nanoseconds(300000000), resp.TotalDuration)
+}
+
+func TestEmbed_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/embed", r.URL.Path)
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body)
+		assert.Equal(t, "nomic-embed-text", body["model"])
+		assert.Equal(t, false, body["stream"])
+
+		w.Write([]byte(`{"model":"nomic-embed-text","embeddings":[[0.1,0.2,0.3]],"total_duration":1000000,"load_duration":500000,"prompt_eval_count":5}`))
+	}))
+	defer srv.Close()
+
+	o := New().(*ollama)
+	_ = o.Configure(context.Background(), mcp.Credentials{"base_url": srv.URL})
+	result, err := embed(context.Background(), o, map[string]any{
+		"model": "nomic-embed-text",
+		"input": "hello world",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	var resp embedResponse
+	require.NoError(t, json.Unmarshal([]byte(result.Data), &resp))
+	assert.Equal(t, ModelName("nomic-embed-text"), resp.Model)
+	require.Len(t, resp.Embeddings, 1)
+	assert.Equal(t, Embedding{0.1, 0.2, 0.3}, resp.Embeddings[0])
+	assert.Equal(t, Nanoseconds(1000000), resp.TotalDuration)
+}
+
+func TestEmbed_UnsupportedModel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(400)
+		w.Write([]byte(`{"error":"this model does not support embeddings"}`))
+	}))
+	defer srv.Close()
+
+	o := New().(*ollama)
+	_ = o.Configure(context.Background(), mcp.Credentials{"base_url": srv.URL})
+	result, err := embed(context.Background(), o, map[string]any{
+		"model": "gemma4:e2b",
+		"input": "hello",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "does not support embeddings")
+}
+
+func TestEmbed_MissingInput(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("should not reach server when input is missing")
+	}))
+	defer srv.Close()
+
+	o := New().(*ollama)
+	_ = o.Configure(context.Background(), mcp.Credentials{"base_url": srv.URL})
+	result, err := embed(context.Background(), o, map[string]any{
+		"model": "nomic-embed-text",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "input")
+}

--- a/integrations/ollama/inference_test.go
+++ b/integrations/ollama/inference_test.go
@@ -113,7 +113,7 @@ func TestEmbed_Success(t *testing.T) {
 		var body map[string]any
 		json.NewDecoder(r.Body).Decode(&body)
 		assert.Equal(t, "nomic-embed-text", body["model"])
-		assert.Equal(t, false, body["stream"])
+		assert.Nil(t, body["stream"], "embed should not send stream field")
 
 		w.Write([]byte(`{"model":"nomic-embed-text","embeddings":[[0.1,0.2,0.3]],"total_duration":1000000,"load_duration":500000,"prompt_eval_count":5}`))
 	}))

--- a/integrations/ollama/markdown.go
+++ b/integrations/ollama/markdown.go
@@ -1,0 +1,106 @@
+package ollama
+
+import (
+	"encoding/json"
+	"strings"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/daltoniam/switchboard/markdown"
+)
+
+var markdownRenderers = map[mcp.ToolName]func([]byte) (markdown.Markdown, bool){
+	"ollama_show_model": renderShowModelMD,
+}
+
+// renderedModel is the semantic type for RenderMarkdown's show_model output.
+type renderedModel struct {
+	Name          ModelName
+	Family        ModelFamily
+	ParameterSize ParameterSize
+	Quantization  QuantizationLevel
+	Format        ModelFormat
+	Capabilities  []Capability
+	Parameters    string
+	Template      string
+	LicenseLine   string
+	ModifiedAt    string
+}
+
+func parseShowResponse(data []byte) (renderedModel, error) {
+	var raw showResponse
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return renderedModel{}, err
+	}
+	name := raw.Model
+	if name == "" {
+		name = raw.Details.ParentModel
+	}
+	return renderedModel{
+		Name:          name,
+		Family:        raw.Details.Family,
+		ParameterSize: raw.Details.ParameterSize,
+		Quantization:  raw.Details.QuantizationLevel,
+		Format:        raw.Details.Format,
+		Capabilities:  raw.Capabilities,
+		Parameters:    raw.Parameters,
+		Template:      raw.Template,
+		LicenseLine:   firstNonEmptyLine(raw.License),
+		ModifiedAt:    raw.ModifiedAt,
+	}, nil
+}
+
+func renderShowModelMD(data []byte) (markdown.Markdown, bool) {
+	m, err := parseShowResponse(data)
+	if err != nil {
+		return "", false
+	}
+
+	b := markdown.NewBuilder()
+	b.Metadata("ollama", "model", string(m.Name))
+	b.Heading(1, string(m.Name))
+
+	b.Attribution(
+		"Family: "+string(m.Family),
+		"Parameters: "+string(m.ParameterSize),
+		"Quantization: "+string(m.Quantization),
+		"Format: "+string(m.Format),
+	)
+
+	if len(m.Capabilities) > 0 {
+		caps := make([]string, len(m.Capabilities))
+		for i, c := range m.Capabilities {
+			caps[i] = string(c)
+		}
+		b.Attribution("Capabilities: " + strings.Join(caps, ", "))
+	}
+
+	if m.Parameters != "" {
+		b.BlankLine()
+		b.Heading(2, "Parameters")
+		b.Raw(m.Parameters + "\n")
+	}
+
+	if m.Template != "" {
+		b.BlankLine()
+		b.Heading(2, "Template")
+		b.Raw(m.Template + "\n")
+	}
+
+	if m.LicenseLine != "" {
+		b.BlankLine()
+		b.Heading(2, "License")
+		b.Raw(m.LicenseLine + "\n")
+	}
+
+	return b.Build(), true
+}
+
+func firstNonEmptyLine(s string) string {
+	for _, line := range strings.Split(s, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}

--- a/integrations/ollama/markdown_test.go
+++ b/integrations/ollama/markdown_test.go
@@ -1,0 +1,100 @@
+package ollama
+
+import (
+	"testing"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRenderMarkdown_ToolsCovered(t *testing.T) {
+	for name := range markdownRenderers {
+		_, ok := dispatch[name]
+		assert.True(t, ok, "markdown renderer %s has no dispatch handler", name)
+	}
+}
+
+func TestRenderMarkdown_ShowModel(t *testing.T) {
+	data := []byte(`{
+		"model":"gemma4:e2b",
+		"details":{"family":"gemma4","parameter_size":"5.1B","quantization_level":"Q8_0","format":"gguf","parent_model":"gemma4:e2b-it-q8_0"},
+		"capabilities":["completion","vision","tools"],
+		"parameters":"temperature 1\ntop_k 64",
+		"template":"{{ .Prompt }}",
+		"license":"                                Apache License\n                           Version 2.0, January 2004",
+		"modified_at":"2026-04-11"
+	}`)
+
+	o := New().(*ollama)
+	md, ok := o.RenderMarkdown("ollama_show_model", data)
+	assert.True(t, ok)
+	s := string(md)
+	assert.Contains(t, s, "<!-- ollama:model=gemma4:e2b -->")
+	assert.Contains(t, s, "# gemma4:e2b")
+	assert.Contains(t, s, "Family: gemma4")
+	assert.Contains(t, s, "Parameters: 5.1B")
+	assert.Contains(t, s, "Quantization: Q8_0")
+	assert.Contains(t, s, "Format: gguf")
+	assert.Contains(t, s, "completion, vision, tools")
+	assert.Contains(t, s, "temperature 1")
+	assert.Contains(t, s, "top_k 64")
+	assert.Contains(t, s, "{{ .Prompt }}")
+	assert.Contains(t, s, "Apache License")
+	assert.NotContains(t, s, "Version 2.0, January 2004", "should only include first non-empty line of license")
+}
+
+func TestRenderMarkdown_ShowModel_MinimalFields(t *testing.T) {
+	data := []byte(`{
+		"details":{"family":"llama","parameter_size":"7B","quantization_level":"Q4_0","format":"gguf"},
+		"capabilities":[],
+		"parameters":"",
+		"template":"",
+		"license":"",
+		"modified_at":""
+	}`)
+
+	o := New().(*ollama)
+	md, ok := o.RenderMarkdown("ollama_show_model", data)
+	assert.True(t, ok)
+	s := string(md)
+	assert.Contains(t, s, "Family: llama")
+	assert.NotContains(t, s, "## Parameters", "empty parameters should be omitted")
+	assert.NotContains(t, s, "## Template", "empty template should be omitted")
+	assert.NotContains(t, s, "## License", "empty license should be omitted")
+}
+
+func TestRenderMarkdown_UnknownTool(t *testing.T) {
+	o := New().(*ollama)
+	_, ok := o.RenderMarkdown("ollama_list_models", nil)
+	assert.False(t, ok)
+}
+
+func TestRenderMarkdown_InvalidJSON(t *testing.T) {
+	o := New().(*ollama)
+	_, ok := o.RenderMarkdown("ollama_show_model", []byte(`{invalid`))
+	assert.False(t, ok)
+}
+
+func TestRenderMarkdown_InterfaceCompliance(t *testing.T) {
+	var _ mcp.MarkdownIntegration = New().(*ollama)
+}
+
+func TestFirstNonEmptyLine(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"normal", "Apache License\nVersion 2.0", "Apache License"},
+		{"leading whitespace", "   \n   Apache License", "Apache License"},
+		{"leading blank lines", "\n\n\nMIT License", "MIT License"},
+		{"only whitespace", "   \n   \n   ", ""},
+		{"empty", "", ""},
+		{"indented first line", "                                Apache License", "Apache License"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, firstNonEmptyLine(tt.input))
+		})
+	}
+}

--- a/integrations/ollama/models.go
+++ b/integrations/ollama/models.go
@@ -1,0 +1,127 @@
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+func listModels(ctx context.Context, o *ollama, args map[string]any) (*mcp.ToolResult, error) {
+	data, err := o.get(ctx, "/api/tags")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func showModel(ctx context.Context, o *ollama, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	model := r.Str("model")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := o.post(ctx, "/api/show", map[string]any{"model": model})
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	// Inject model name — the API response doesn't include it as a top-level field,
+	// but RenderMarkdown needs it for the heading.
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err == nil {
+		if nameJSON, err := json.Marshal(model); err == nil {
+			obj["model"] = nameJSON
+			if patched, err := json.Marshal(obj); err == nil {
+				data = patched
+			}
+		}
+	}
+	return mcp.RawResult(data)
+}
+
+func pullModel(ctx context.Context, o *ollama, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	model := r.Str("model")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := o.post(ctx, "/api/pull", map[string]any{"model": model, "stream": false})
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func deleteModel(ctx context.Context, o *ollama, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	model := r.Str("model")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := o.del(ctx, "/api/delete", map[string]any{"model": model})
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func copyModel(ctx context.Context, o *ollama, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	source := r.Str("source")
+	destination := r.Str("destination")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := o.post(ctx, "/api/copy", copyRequest{
+		Source:      ModelName(source),
+		Destination: ModelName(destination),
+	})
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func createModel(ctx context.Context, o *ollama, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	model := r.Str("model")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	req := map[string]any{"model": model, "stream": false}
+	if v, _ := mcp.ArgStr(args, "from"); v != "" {
+		req["from"] = v
+	}
+	if v, _ := mcp.ArgStr(args, "system"); v != "" {
+		req["system"] = v
+	}
+	if v, _ := mcp.ArgStr(args, "template"); v != "" {
+		req["template"] = v
+	}
+	if v, _ := mcp.ArgStr(args, "quantize"); v != "" {
+		req["quantize"] = v
+	}
+
+	data, err := o.post(ctx, "/api/create", req)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func listRunning(ctx context.Context, o *ollama, args map[string]any) (*mcp.ToolResult, error) {
+	data, err := o.get(ctx, "/api/ps")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func getVersion(ctx context.Context, o *ollama, args map[string]any) (*mcp.ToolResult, error) {
+	data, err := o.get(ctx, "/api/version")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}

--- a/integrations/ollama/models_test.go
+++ b/integrations/ollama/models_test.go
@@ -1,0 +1,195 @@
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListModels(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/tags", r.URL.Path)
+		assert.Equal(t, "GET", r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"models":[{"name":"gemma4:e2b","model":"gemma4:e2b","size":8140152828,"details":{"family":"gemma4","parameter_size":"5.1B","quantization_level":"Q8_0"}}]}`))
+	}))
+	defer srv.Close()
+
+	o := New().(*ollama)
+	_ = o.Configure(context.Background(), mcp.Credentials{"base_url": srv.URL})
+	result, err := listModels(context.Background(), o, nil)
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	var resp tagsResponse
+	require.NoError(t, json.Unmarshal([]byte(result.Data), &resp))
+	require.Len(t, resp.Models, 1)
+	assert.Equal(t, ModelName("gemma4:e2b"), resp.Models[0].Name)
+	assert.Equal(t, ModelFamily("gemma4"), resp.Models[0].Details.Family)
+}
+
+func TestShowModel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/show", r.URL.Path)
+		assert.Equal(t, "POST", r.Method)
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body)
+		assert.Equal(t, "gemma4:e2b", body["model"])
+		w.Write([]byte(`{"details":{"family":"gemma4","parameter_size":"5.1B","quantization_level":"Q8_0","format":"gguf"},"capabilities":["completion","vision"],"parameters":"temperature 1\ntop_k 64","template":"{{ .Prompt }}","license":"Apache License 2.0","modified_at":"2026-04-11"}`))
+	}))
+	defer srv.Close()
+
+	o := New().(*ollama)
+	_ = o.Configure(context.Background(), mcp.Credentials{"base_url": srv.URL})
+	result, err := showModel(context.Background(), o, map[string]any{"model": "gemma4:e2b"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	var resp showResponse
+	require.NoError(t, json.Unmarshal([]byte(result.Data), &resp))
+	assert.Equal(t, ModelFamily("gemma4"), resp.Details.Family)
+	assert.Equal(t, []Capability{"completion", "vision"}, resp.Capabilities)
+}
+
+func TestShowModel_MissingModel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(400)
+		w.Write([]byte(`{"error":"model is required"}`))
+	}))
+	defer srv.Close()
+
+	o := New().(*ollama)
+	_ = o.Configure(context.Background(), mcp.Credentials{"base_url": srv.URL})
+	result, err := showModel(context.Background(), o, map[string]any{})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "model")
+}
+
+func TestPullModel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/pull", r.URL.Path)
+		assert.Equal(t, "POST", r.Method)
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body)
+		assert.Equal(t, "llama3.2", body["model"])
+		assert.Equal(t, false, body["stream"])
+		w.Write([]byte(`{"status":"success"}`))
+	}))
+	defer srv.Close()
+
+	o := New().(*ollama)
+	_ = o.Configure(context.Background(), mcp.Credentials{"base_url": srv.URL})
+	result, err := pullModel(context.Background(), o, map[string]any{"model": "llama3.2"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "success")
+}
+
+func TestDeleteModel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/delete", r.URL.Path)
+		assert.Equal(t, "DELETE", r.Method)
+		w.WriteHeader(204)
+	}))
+	defer srv.Close()
+
+	o := New().(*ollama)
+	_ = o.Configure(context.Background(), mcp.Credentials{"base_url": srv.URL})
+	result, err := deleteModel(context.Background(), o, map[string]any{"model": "old-model"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "success")
+}
+
+func TestCopyModel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/copy", r.URL.Path)
+		assert.Equal(t, "POST", r.Method)
+		var body copyRequest
+		json.NewDecoder(r.Body).Decode(&body)
+		assert.Equal(t, ModelName("gemma4:e2b"), body.Source)
+		assert.Equal(t, ModelName("gemma4-backup"), body.Destination)
+		w.WriteHeader(200)
+		w.Write([]byte(`{"status":"success"}`))
+	}))
+	defer srv.Close()
+
+	o := New().(*ollama)
+	_ = o.Configure(context.Background(), mcp.Credentials{"base_url": srv.URL})
+	result, err := copyModel(context.Background(), o, map[string]any{"source": "gemma4:e2b", "destination": "gemma4-backup"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+}
+
+func TestCreateModel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/create", r.URL.Path)
+		assert.Equal(t, "POST", r.Method)
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body)
+		assert.Equal(t, "my-model", body["model"])
+		assert.Equal(t, false, body["stream"])
+		assert.Equal(t, "gemma3", body["from"])
+		assert.Equal(t, "You are a helpful assistant.", body["system"])
+		w.Write([]byte(`{"status":"success"}`))
+	}))
+	defer srv.Close()
+
+	o := New().(*ollama)
+	_ = o.Configure(context.Background(), mcp.Credentials{"base_url": srv.URL})
+	result, err := createModel(context.Background(), o, map[string]any{
+		"model":  "my-model",
+		"from":   "gemma3",
+		"system": "You are a helpful assistant.",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "success")
+}
+
+func TestListRunning(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/ps", r.URL.Path)
+		assert.Equal(t, "GET", r.Method)
+		w.Write([]byte(`{"models":[{"name":"gemma4:e2b","size":8140152828,"size_vram":8140152828,"context_length":131072,"expires_at":"2026-04-12T07:00:00Z","details":{"family":"gemma4","parameter_size":"5.1B"}}]}`))
+	}))
+	defer srv.Close()
+
+	o := New().(*ollama)
+	_ = o.Configure(context.Background(), mcp.Credentials{"base_url": srv.URL})
+	result, err := listRunning(context.Background(), o, nil)
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	var resp psResponse
+	require.NoError(t, json.Unmarshal([]byte(result.Data), &resp))
+	require.Len(t, resp.Models, 1)
+	assert.Equal(t, ModelName("gemma4:e2b"), resp.Models[0].Name)
+	assert.Equal(t, 131072, resp.Models[0].ContextLength)
+}
+
+func TestGetVersion(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/version", r.URL.Path)
+		assert.Equal(t, "GET", r.Method)
+		w.Write([]byte(`{"version":"0.20.5"}`))
+	}))
+	defer srv.Close()
+
+	o := New().(*ollama)
+	_ = o.Configure(context.Background(), mcp.Credentials{"base_url": srv.URL})
+	result, err := getVersion(context.Background(), o, nil)
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	var resp versionResponse
+	require.NoError(t, json.Unmarshal([]byte(result.Data), &resp))
+	assert.Equal(t, "0.20.5", resp.Version)
+}

--- a/integrations/ollama/ollama.go
+++ b/integrations/ollama/ollama.go
@@ -1,0 +1,164 @@
+package ollama
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/daltoniam/switchboard/markdown"
+)
+
+var (
+	_ mcp.Integration                = (*ollama)(nil)
+	_ mcp.FieldCompactionIntegration = (*ollama)(nil)
+	_ mcp.MarkdownIntegration        = (*ollama)(nil)
+	_ mcp.PlainTextCredentials       = (*ollama)(nil)
+	_ mcp.OptionalCredentials        = (*ollama)(nil)
+)
+
+const defaultBaseURL = "http://localhost:11434"
+
+type ollama struct {
+	baseURL string
+	apiKey  string
+	client  *http.Client
+}
+
+const maxResponseSize = 10 * 1024 * 1024 // 10 MB
+
+func New() mcp.Integration {
+	return &ollama{
+		client: &http.Client{Timeout: 120 * time.Second},
+	}
+}
+
+func (o *ollama) Name() string { return "ollama" }
+
+func (o *ollama) PlainTextKeys() []string { return []string{"base_url"} }
+func (o *ollama) OptionalKeys() []string  { return []string{"api_key"} }
+
+func (o *ollama) Configure(_ context.Context, creds mcp.Credentials) error {
+	o.baseURL = creds["base_url"]
+	if o.baseURL == "" {
+		o.baseURL = defaultBaseURL
+	}
+	o.baseURL = strings.TrimRight(o.baseURL, "/")
+	o.apiKey = creds["api_key"]
+	return nil
+}
+
+func (o *ollama) Healthy(ctx context.Context) bool {
+	if o.baseURL == "" {
+		return false
+	}
+	_, err := o.get(ctx, "/api/version")
+	return err == nil
+}
+
+func (o *ollama) Tools() []mcp.ToolDefinition {
+	return tools
+}
+
+func (o *ollama) Execute(ctx context.Context, toolName mcp.ToolName, args map[string]any) (*mcp.ToolResult, error) {
+	fn, ok := dispatch[toolName]
+	if !ok {
+		return &mcp.ToolResult{Data: fmt.Sprintf("unknown tool: %s", toolName), IsError: true}, nil
+	}
+	return fn(ctx, o, args)
+}
+
+func (o *ollama) CompactSpec(toolName mcp.ToolName) ([]mcp.CompactField, bool) {
+	fields, ok := fieldCompactionSpecs[toolName]
+	return fields, ok
+}
+
+func (o *ollama) RenderMarkdown(toolName mcp.ToolName, data []byte) (markdown.Markdown, bool) {
+	fn, ok := markdownRenderers[toolName]
+	if !ok {
+		return "", false
+	}
+	return fn(data)
+}
+
+type handlerFunc func(ctx context.Context, o *ollama, args map[string]any) (*mcp.ToolResult, error)
+
+var dispatch = map[mcp.ToolName]handlerFunc{
+	// Model management
+	"ollama_list_models":  listModels,
+	"ollama_show_model":   showModel,
+	"ollama_pull_model":   pullModel,
+	"ollama_delete_model": deleteModel,
+	"ollama_copy_model":   copyModel,
+	"ollama_create_model": createModel,
+	"ollama_list_running": listRunning,
+	"ollama_get_version":  getVersion,
+	// Inference
+	"ollama_chat":     chat,
+	"ollama_generate": generate,
+	"ollama_embed":    embed,
+}
+
+// --- HTTP helpers ---
+
+func (o *ollama) doRequest(ctx context.Context, method, path string, body any) (json.RawMessage, error) {
+	var bodyReader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return nil, err
+		}
+		bodyReader = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, o.baseURL+path, bodyReader)
+	if err != nil {
+		return nil, err
+	}
+	if o.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+o.apiKey)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := o.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == 429 || resp.StatusCode >= 500 {
+		re := &mcp.RetryableError{StatusCode: resp.StatusCode, Err: fmt.Errorf("ollama API error (%d): %s", resp.StatusCode, string(data))}
+		re.RetryAfter = mcp.ParseRetryAfter(resp.Header.Get("Retry-After"))
+		return nil, re
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("ollama API error (%d): %s", resp.StatusCode, string(data))
+	}
+	if resp.StatusCode == 204 || len(data) == 0 {
+		return json.RawMessage(`{"status":"success"}`), nil
+	}
+	return json.RawMessage(data), nil
+}
+
+func (o *ollama) get(ctx context.Context, path string) (json.RawMessage, error) {
+	return o.doRequest(ctx, "GET", path, nil)
+}
+
+func (o *ollama) post(ctx context.Context, path string, body any) (json.RawMessage, error) {
+	return o.doRequest(ctx, "POST", path, body)
+}
+
+func (o *ollama) del(ctx context.Context, path string, body any) (json.RawMessage, error) {
+	return o.doRequest(ctx, "DELETE", path, body)
+}

--- a/integrations/ollama/ollama_test.go
+++ b/integrations/ollama/ollama_test.go
@@ -1,0 +1,264 @@
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Constructor + Name ---
+
+func TestNew(t *testing.T) {
+	i := New()
+	assert.NotNil(t, i)
+	assert.Equal(t, "ollama", i.Name())
+}
+
+// --- Configure ---
+
+func TestConfigure_DefaultBaseURL(t *testing.T) {
+	o := New().(*ollama)
+	err := o.Configure(context.Background(), mcp.Credentials{})
+	require.NoError(t, err)
+	assert.Equal(t, defaultBaseURL, o.baseURL)
+	assert.Empty(t, o.apiKey)
+}
+
+func TestConfigure_CustomBaseURL(t *testing.T) {
+	o := New().(*ollama)
+	err := o.Configure(context.Background(), mcp.Credentials{
+		"base_url": "http://myhost:8080/",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "http://myhost:8080", o.baseURL, "trailing slash should be trimmed")
+}
+
+func TestConfigure_WithAPIKey(t *testing.T) {
+	o := New().(*ollama)
+	err := o.Configure(context.Background(), mcp.Credentials{
+		"api_key": "sk-test-123",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "sk-test-123", o.apiKey)
+}
+
+// --- PlainTextKeys / OptionalKeys ---
+
+func TestPlainTextKeys(t *testing.T) {
+	o := New().(*ollama)
+	assert.Equal(t, []string{"base_url"}, o.PlainTextKeys())
+}
+
+func TestOptionalKeys(t *testing.T) {
+	o := New().(*ollama)
+	assert.Equal(t, []string{"api_key"}, o.OptionalKeys())
+}
+
+// --- Tools metadata ---
+
+func TestTools_AllHavePrefix(t *testing.T) {
+	i := New()
+	for _, tool := range i.Tools() {
+		assert.True(t, strings.HasPrefix(string(tool.Name), "ollama_"),
+			"tool %s does not have ollama_ prefix", tool.Name)
+	}
+}
+
+func TestTools_AllHaveDescriptions(t *testing.T) {
+	i := New()
+	for _, tool := range i.Tools() {
+		assert.NotEmpty(t, tool.Description, "tool %s has no description", tool.Name)
+	}
+}
+
+func TestTools_NoDuplicateNames(t *testing.T) {
+	i := New()
+	seen := make(map[mcp.ToolName]bool)
+	for _, tool := range i.Tools() {
+		assert.False(t, seen[tool.Name], "duplicate tool name: %s", tool.Name)
+		seen[tool.Name] = true
+	}
+}
+
+func TestTools_EntryPointHasStartHere(t *testing.T) {
+	i := New()
+	for _, tool := range i.Tools() {
+		if tool.Name == "ollama_list_models" {
+			assert.Contains(t, tool.Description, "Start here")
+			return
+		}
+	}
+	t.Fatal("ollama_list_models not found in tools")
+}
+
+// --- Dispatch parity ---
+
+func TestDispatchMap_AllToolsCovered(t *testing.T) {
+	i := New()
+	for _, tool := range i.Tools() {
+		_, ok := dispatch[tool.Name]
+		assert.True(t, ok, "tool %s has no dispatch handler", tool.Name)
+	}
+}
+
+func TestDispatchMap_NoOrphanHandlers(t *testing.T) {
+	i := New()
+	toolNames := make(map[mcp.ToolName]bool)
+	for _, tool := range i.Tools() {
+		toolNames[tool.Name] = true
+	}
+	for name := range dispatch {
+		assert.True(t, toolNames[name], "dispatch handler %s has no tool definition", name)
+	}
+}
+
+// --- Execute unknown tool ---
+
+func TestExecute_UnknownTool(t *testing.T) {
+	o := New().(*ollama)
+	_ = o.Configure(context.Background(), mcp.Credentials{})
+	result, err := o.Execute(context.Background(), "ollama_nonexistent", nil)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "unknown tool")
+}
+
+// --- Healthy ---
+
+func TestHealthy_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/version" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(versionResponse{Version: "0.20.5"})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	o := New().(*ollama)
+	_ = o.Configure(context.Background(), mcp.Credentials{"base_url": srv.URL})
+	assert.True(t, o.Healthy(context.Background()))
+}
+
+func TestHealthy_Unconfigured(t *testing.T) {
+	o := &ollama{}
+	assert.False(t, o.Healthy(context.Background()))
+}
+
+func TestHealthy_ServerDown(t *testing.T) {
+	o := New().(*ollama)
+	_ = o.Configure(context.Background(), mcp.Credentials{"base_url": "http://localhost:1"})
+	assert.False(t, o.Healthy(context.Background()))
+}
+
+// --- HTTP helpers ---
+
+func TestHTTP_AuthHeaderPresent(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"version":"test"}`))
+	}))
+	defer srv.Close()
+
+	o := New().(*ollama)
+	_ = o.Configure(context.Background(), mcp.Credentials{"base_url": srv.URL, "api_key": "sk-test"})
+	_, _ = o.get(context.Background(), "/api/version")
+	assert.Equal(t, "Bearer sk-test", gotAuth)
+}
+
+func TestHTTP_NoAuthHeaderWhenNoKey(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"version":"test"}`))
+	}))
+	defer srv.Close()
+
+	o := New().(*ollama)
+	_ = o.Configure(context.Background(), mcp.Credentials{"base_url": srv.URL})
+	_, _ = o.get(context.Background(), "/api/version")
+	assert.Empty(t, gotAuth)
+}
+
+func TestHTTP_400Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(400)
+		w.Write([]byte(`{"error":"model not found"}`))
+	}))
+	defer srv.Close()
+
+	o := New().(*ollama)
+	_ = o.Configure(context.Background(), mcp.Credentials{"base_url": srv.URL})
+	_, err := o.get(context.Background(), "/api/show")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "model not found")
+	assert.False(t, mcp.IsRetryable(err))
+}
+
+func TestHTTP_404Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(404)
+		w.Write([]byte(`{"error":"model 'nonexistent' not found"}`))
+	}))
+	defer srv.Close()
+
+	o := New().(*ollama)
+	_ = o.Configure(context.Background(), mcp.Credentials{"base_url": srv.URL})
+	_, err := o.post(context.Background(), "/api/show", map[string]any{"model": "nonexistent"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+	assert.False(t, mcp.IsRetryable(err))
+}
+
+func TestHTTP_429Retryable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "5")
+		w.WriteHeader(429)
+		w.Write([]byte(`{"error":"rate limited"}`))
+	}))
+	defer srv.Close()
+
+	o := New().(*ollama)
+	_ = o.Configure(context.Background(), mcp.Credentials{"base_url": srv.URL})
+	_, err := o.get(context.Background(), "/api/tags")
+	assert.Error(t, err)
+	assert.True(t, mcp.IsRetryable(err))
+}
+
+func TestHTTP_500Retryable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		w.Write([]byte(`internal error`))
+	}))
+	defer srv.Close()
+
+	o := New().(*ollama)
+	_ = o.Configure(context.Background(), mcp.Credentials{"base_url": srv.URL})
+	_, err := o.get(context.Background(), "/api/tags")
+	assert.Error(t, err)
+	assert.True(t, mcp.IsRetryable(err))
+}
+
+func TestHTTP_204EmptyBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(204)
+	}))
+	defer srv.Close()
+
+	o := New().(*ollama)
+	_ = o.Configure(context.Background(), mcp.Credentials{"base_url": srv.URL})
+	data, err := o.del(context.Background(), "/api/delete", map[string]any{"model": "test"})
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "success")
+}

--- a/integrations/ollama/tools.go
+++ b/integrations/ollama/tools.go
@@ -1,0 +1,113 @@
+package ollama
+
+import mcp "github.com/daltoniam/switchboard"
+
+var tools = []mcp.ToolDefinition{
+	// ── Model Management ────────────────────────────────────────────
+	{
+		Name:        "ollama_list_models",
+		Description: "List all locally installed Ollama AI models with sizes, families, parameter counts, and quantization levels. Start here to discover available models before running chat, generate, or embed.",
+		Parameters:  map[string]string{},
+	},
+	{
+		Name:        "ollama_show_model",
+		Description: "Show details of a specific Ollama model including parameters, prompt template, capabilities (vision, tools, thinking), and license. Returns rendered markdown. Use after list_models to inspect a model before using it.",
+		Parameters: map[string]string{
+			"model": "Model name (e.g. 'gemma3', 'llama3.2:7b'). Use list_models to discover available names.",
+		},
+		Required: []string{"model"},
+	},
+	{
+		Name:        "ollama_pull_model",
+		Description: "Download and install an AI model from the Ollama model registry. May take minutes for large models — do not retry on timeout. Use model names like 'gemma3', 'llama3.2', 'qwen3'. Use list_models after to confirm the download completed.",
+		Parameters: map[string]string{
+			"model": "Model name to download from registry (e.g. 'gemma3', 'llama3.2:7b', 'qwen3:14b')",
+		},
+		Required: []string{"model"},
+	},
+	{
+		Name:        "ollama_delete_model",
+		Description: "Permanently delete a locally installed Ollama model. This is irreversible — the model must be re-downloaded with pull_model to restore it. Use list_models first to verify the exact model name.",
+		Parameters: map[string]string{
+			"model": "Exact model name to delete. Must match a name from list_models.",
+		},
+		Required: []string{"model"},
+	},
+	{
+		Name:        "ollama_copy_model",
+		Description: "Create a copy of an existing local Ollama model with a new name. Use before create_model to preserve the original when customizing.",
+		Parameters: map[string]string{
+			"source":      "Existing model name to copy from (must be installed locally)",
+			"destination": "New model name to create",
+		},
+		Required: []string{"source", "destination"},
+	},
+	{
+		Name:        "ollama_create_model",
+		Description: "Create a custom Ollama model from an existing base model. Embed a system prompt, override the prompt template, or change quantization. May take minutes for re-quantization — do not retry on timeout. Use show_model after to verify the result.",
+		Parameters: map[string]string{
+			"model":    "Name for the new custom model",
+			"from":     "Base model to derive from (e.g. 'gemma3'). Must be installed locally.",
+			"system":   "System prompt to embed permanently in the model",
+			"template": "Go template string for prompt formatting",
+			"quantize": "Quantization level to apply (e.g. 'q4_K_M', 'q8_0'). Re-quantizes the model weights.",
+		},
+		Required: []string{"model"},
+	},
+	{
+		Name:        "ollama_list_running",
+		Description: "List currently loaded and running Ollama models with VRAM usage, context window size, and automatic unload time. Use to check GPU memory pressure before loading additional models.",
+		Parameters:  map[string]string{},
+	},
+	{
+		Name:        "ollama_get_version",
+		Description: "Get the Ollama server version. Use to verify the server is reachable and check compatibility.",
+		Parameters:  map[string]string{},
+	},
+
+	// ── Inference ───────────────────────────────────────────────────
+	{
+		Name:        "ollama_chat",
+		Description: "Send a multi-turn chat conversation to a local Ollama model and get a complete response. Preferred over generate for conversations — maintains message history with roles. Supports tool calling, structured JSON output, vision (images in messages), and thinking/reasoning mode. Returns the full response in one call (non-streaming).",
+		Parameters: map[string]string{
+			"model":      "Model name (e.g. 'gemma3', 'llama3.2'). Must be installed — use list_models to check.",
+			"messages":   "Array of message objects. Each has 'role' ('system', 'user', 'assistant') and 'content' (string). For vision: add 'images' array with base64-encoded strings.",
+			"tools":      "Array of tool/function definitions the model may call (OpenAI function-calling format)",
+			"format":     "Constrain output format: 'json' for freeform JSON, or a JSON schema object for structured output",
+			"options":    "Model parameters object: temperature (0-2), top_k, top_p, seed, num_ctx (context window), num_predict (max tokens), etc.",
+			"think":      "Enable chain-of-thought reasoning: true, false, 'high', 'medium', or 'low'. Response includes a 'thinking' field when enabled.",
+			"keep_alive": "Duration to keep model in memory after request: '5m', '1h', or 0 to unload immediately. Default: 5 minutes.",
+		},
+		Required: []string{"model", "messages"},
+	},
+	{
+		Name:        "ollama_generate",
+		Description: "Generate text completion from a single prompt using a local Ollama model. Use for one-shot generation without conversation history — prefer chat for multi-turn dialogue. Supports vision (base64 images), fill-in-the-middle (prompt + suffix), structured JSON output, and thinking mode. Returns the full response in one call (non-streaming).",
+		Parameters: map[string]string{
+			"model":      "Model name (e.g. 'gemma3', 'llama3.2'). Must be installed — use list_models to check.",
+			"prompt":     "Text prompt for generation",
+			"suffix":     "Text after the insertion point for fill-in-the-middle completion. Model generates text between prompt and suffix.",
+			"images":     "Array of base64-encoded images for multimodal/vision models (e.g. llava, gemma4)",
+			"format":     "Constrain output format: 'json' for freeform JSON, or a JSON schema object for structured output",
+			"system":     "System prompt to prepend. Overrides any system prompt embedded in the model.",
+			"options":    "Model parameters object: temperature (0-2), top_k, top_p, seed, num_ctx (context window), num_predict (max tokens), etc.",
+			"think":      "Enable chain-of-thought reasoning: true, false, 'high', 'medium', or 'low'. Response includes a 'thinking' field when enabled.",
+			"raw":        "If true, prompt is sent directly without applying the model's chat template. Use for pre-formatted prompts only.",
+			"keep_alive": "Duration to keep model in memory after request: '5m', '1h', or 0 to unload immediately. Default: 5 minutes.",
+		},
+		Required: []string{"model"},
+	},
+	{
+		Name:        "ollama_embed",
+		Description: "Generate vector embeddings for text using a local Ollama embedding model. For semantic search, similarity matching, and RAG pipelines. Supports single string or batch (array of strings) input. Not all models support embeddings — use an embedding model like 'all-minilm' or 'nomic-embed-text'. Returns 400 error if the model lacks embedding support.",
+		Parameters: map[string]string{
+			"model":      "Embedding model name (e.g. 'all-minilm', 'nomic-embed-text'). Must support embeddings — general chat models will return an error.",
+			"input":      "Text to embed: a single string, or an array of strings for batch embedding",
+			"truncate":   "Truncate input exceeding context window (default true). Set false to return an error instead of silently truncating.",
+			"dimensions": "Custom output vector dimensions. Only supported by some models.",
+			"keep_alive": "Duration to keep model in memory: '5m', '1h', or 0 to unload immediately",
+			"options":    "Model parameters: seed, num_ctx, etc.",
+		},
+		Required: []string{"model", "input"},
+	},
+}

--- a/integrations/ollama/types.go
+++ b/integrations/ollama/types.go
@@ -178,7 +178,6 @@ type generateResponse struct {
 type embedRequest struct {
 	Model      ModelName       `json:"model"`
 	Input      any             `json:"input"`
-	Stream     bool            `json:"stream"`
 	Truncate   *bool           `json:"truncate,omitempty"`
 	Dimensions *int            `json:"dimensions,omitempty"`
 	KeepAlive  json.RawMessage `json:"keep_alive,omitempty"`

--- a/integrations/ollama/types.go
+++ b/integrations/ollama/types.go
@@ -1,0 +1,201 @@
+package ollama
+
+import "encoding/json"
+
+// --- Semantic primitives — prevent mixing distinct string domains ---
+
+// ModelName identifies a model (e.g., "gemma4:e2b", "llama3.2:7b").
+type ModelName string
+
+// ModelDigest is a SHA256 content digest identifying a specific model version.
+type ModelDigest string
+
+// ModelFamily identifies the architecture family (e.g., "gemma4", "qwen2", "llama").
+type ModelFamily string
+
+// ParameterSize is a human-readable size string (e.g., "5.1B", "7.6B").
+type ParameterSize string
+
+// QuantizationLevel describes the quantization method (e.g., "Q4_K_M", "Q8_0").
+type QuantizationLevel string
+
+// ModelFormat is the serialization format (e.g., "gguf").
+type ModelFormat string
+
+// Capability is a model capability flag (e.g., "completion", "vision", "tools", "thinking").
+type Capability string
+
+// ChatRole identifies a message participant ("system", "user", "assistant", "tool").
+type ChatRole string
+
+// DoneReason explains why generation stopped ("stop", "length", "load").
+type DoneReason string
+
+// Embedding is a single embedding vector.
+type Embedding []float64
+
+// Nanoseconds represents a duration in nanoseconds (all Ollama timing fields).
+type Nanoseconds int64
+
+// --- Shared sub-types ---
+
+// modelDetails appears in /api/tags, /api/show, and /api/ps responses.
+type modelDetails struct {
+	ParentModel       ModelName         `json:"parent_model"`
+	Format            ModelFormat       `json:"format"`
+	Family            ModelFamily       `json:"family"`
+	Families          []ModelFamily     `json:"families"`
+	ParameterSize     ParameterSize     `json:"parameter_size"`
+	QuantizationLevel QuantizationLevel `json:"quantization_level"`
+}
+
+// timingStats are common timing fields across chat, generate, and embed responses.
+type timingStats struct {
+	TotalDuration      Nanoseconds `json:"total_duration"`
+	LoadDuration       Nanoseconds `json:"load_duration"`
+	PromptEvalCount    int         `json:"prompt_eval_count"`
+	PromptEvalDuration Nanoseconds `json:"prompt_eval_duration"`
+	EvalCount          int         `json:"eval_count"`
+	EvalDuration       Nanoseconds `json:"eval_duration"`
+}
+
+// --- /api/tags ---
+
+type tagsResponse struct {
+	Models []modelEntry `json:"models"`
+}
+
+type modelEntry struct {
+	Name       ModelName    `json:"name"`
+	Model      ModelName    `json:"model"`
+	ModifiedAt string       `json:"modified_at"`
+	Size       int64        `json:"size"`
+	Digest     ModelDigest  `json:"digest"`
+	Details    modelDetails `json:"details"`
+}
+
+// --- /api/show ---
+
+type showResponse struct {
+	Model        ModelName    `json:"model"` // injected by handler (not in upstream API response)
+	License      string       `json:"license"`
+	Modelfile    string       `json:"modelfile"`
+	Parameters   string       `json:"parameters"`
+	Template     string       `json:"template"`
+	Details      modelDetails `json:"details"`
+	Capabilities []Capability `json:"capabilities"`
+	ModifiedAt   string       `json:"modified_at"`
+	// model_info (55+ keys) and tensors (2000+ entries) intentionally omitted.
+}
+
+// --- /api/ps ---
+
+type psResponse struct {
+	Models []runningModel `json:"models"`
+}
+
+type runningModel struct {
+	Name          ModelName    `json:"name"`
+	Model         ModelName    `json:"model"`
+	Size          int64        `json:"size"`
+	Digest        ModelDigest  `json:"digest"`
+	Details       modelDetails `json:"details"`
+	ExpiresAt     string       `json:"expires_at"`
+	SizeVRAM      int64        `json:"size_vram"`
+	ContextLength int          `json:"context_length"`
+}
+
+// --- /api/version ---
+
+type versionResponse struct {
+	Version string `json:"version"`
+}
+
+// --- /api/chat ---
+
+type chatRequest struct {
+	Model     ModelName       `json:"model"`
+	Messages  []chatMessage   `json:"messages"`
+	Stream    bool            `json:"stream"`
+	Tools     json.RawMessage `json:"tools,omitempty"`
+	Format    json.RawMessage `json:"format,omitempty"`
+	Options   map[string]any  `json:"options,omitempty"`
+	Think     json.RawMessage `json:"think,omitempty"`
+	KeepAlive json.RawMessage `json:"keep_alive,omitempty"`
+}
+
+type chatMessage struct {
+	Role    ChatRole `json:"role"`
+	Content string   `json:"content"`
+	Images  []string `json:"images,omitempty"`
+}
+
+type chatResponse struct {
+	Model      ModelName  `json:"model"`
+	CreatedAt  string     `json:"created_at"`
+	Message    chatReply  `json:"message"`
+	Done       bool       `json:"done"`
+	DoneReason DoneReason `json:"done_reason"`
+	timingStats
+}
+
+type chatReply struct {
+	Role      ChatRole        `json:"role"`
+	Content   string          `json:"content"`
+	Thinking  string          `json:"thinking,omitempty"`
+	ToolCalls json.RawMessage `json:"tool_calls,omitempty"`
+}
+
+// --- /api/generate ---
+
+type generateRequest struct {
+	Model     ModelName       `json:"model"`
+	Prompt    string          `json:"prompt"`
+	Stream    bool            `json:"stream"`
+	Suffix    string          `json:"suffix,omitempty"`
+	Images    []string        `json:"images,omitempty"`
+	Format    json.RawMessage `json:"format,omitempty"`
+	System    string          `json:"system,omitempty"`
+	Think     json.RawMessage `json:"think,omitempty"`
+	Raw       bool            `json:"raw,omitempty"`
+	KeepAlive json.RawMessage `json:"keep_alive,omitempty"`
+	Options   map[string]any  `json:"options,omitempty"`
+}
+
+type generateResponse struct {
+	Model      ModelName  `json:"model"`
+	CreatedAt  string     `json:"created_at"`
+	Response   string     `json:"response"`
+	Thinking   string     `json:"thinking,omitempty"`
+	Done       bool       `json:"done"`
+	DoneReason DoneReason `json:"done_reason"`
+	// context (token ID array) intentionally omitted.
+	timingStats
+}
+
+// --- /api/embed ---
+
+type embedRequest struct {
+	Model      ModelName       `json:"model"`
+	Input      any             `json:"input"`
+	Stream     bool            `json:"stream"`
+	Truncate   *bool           `json:"truncate,omitempty"`
+	Dimensions *int            `json:"dimensions,omitempty"`
+	KeepAlive  json.RawMessage `json:"keep_alive,omitempty"`
+	Options    map[string]any  `json:"options,omitempty"`
+}
+
+type embedResponse struct {
+	Model           ModelName   `json:"model"`
+	Embeddings      []Embedding `json:"embeddings"`
+	TotalDuration   Nanoseconds `json:"total_duration"`
+	LoadDuration    Nanoseconds `json:"load_duration"`
+	PromptEvalCount int         `json:"prompt_eval_count"`
+}
+
+// --- /api/copy ---
+
+type copyRequest struct {
+	Source      ModelName `json:"source"`
+	Destination ModelName `json:"destination"`
+}

--- a/script/engine.go
+++ b/script/engine.go
@@ -23,6 +23,15 @@ type Executor interface {
 	Execute(ctx context.Context, toolName mcp.ToolName, args map[string]any) (*mcp.ToolResult, error)
 }
 
+// RenderedExecutor is an optional interface that extends Executor with a
+// rendered path. ExecuteRendered applies the same markdown/compaction/columnarization
+// pipeline as the execute meta-tool, returning LLM-readable output instead of raw JSON.
+// If the executor does not implement this, api.callRendered() falls back to api.call().
+type RenderedExecutor interface {
+	Executor
+	ExecuteRendered(ctx context.Context, toolName mcp.ToolName, args map[string]any) (*mcp.ToolResult, error)
+}
+
 // Engine runs JavaScript scripts with access to integration tools via api.call().
 type Engine struct {
 	executor Executor
@@ -171,7 +180,7 @@ func (e *Engine) Run(ctx context.Context, source string) (*mcp.ToolResult, error
 		}
 		callCount++
 		if callCount > e.maxCalls {
-			panic(vm.NewGoError(fmt.Errorf("exceeded maximum of %d api.call() invocations", e.maxCalls)))
+			panic(vm.NewGoError(fmt.Errorf("exceeded maximum of %d api calls per script", e.maxCalls)))
 		}
 	}
 
@@ -210,7 +219,7 @@ func (e *Engine) Run(ctx context.Context, source string) (*mcp.ToolResult, error
 		// so partial results from earlier calls are preserved.
 		callCount++
 		if callCount > e.maxCalls {
-			return vm.ToValue(map[string]any{"ok": false, "error": fmt.Sprintf("exceeded maximum of %d api.call() invocations", e.maxCalls)})
+			return vm.ToValue(map[string]any{"ok": false, "error": fmt.Sprintf("exceeded maximum of %d api calls per script", e.maxCalls)})
 		}
 
 		toolName, args, opts := parseCallArgs(call)
@@ -240,6 +249,65 @@ func (e *Engine) Run(ctx context.Context, source string) (*mcp.ToolResult, error
 		return vm.ToValue(map[string]any{"ok": true, "data": parsed})
 	}); err != nil {
 		return nil, fmt.Errorf("failed to set api.tryCall: %w", err)
+	}
+
+	// executeRenderedOrFallback calls ExecuteRendered if the executor supports it,
+	// otherwise falls back to Execute.
+	executeRenderedOrFallback := func(ctx context.Context, toolName mcp.ToolName, args map[string]any) (*mcp.ToolResult, error) {
+		if re, ok := e.executor.(RenderedExecutor); ok {
+			return re.ExecuteRendered(ctx, toolName, args)
+		}
+		return e.executor.Execute(ctx, toolName, args)
+	}
+
+	if err := apiObj.Set("callRendered", func(call goja.FunctionCall) goja.Value {
+		checkCallLimit()
+
+		toolName, args, _ := parseCallArgs(call)
+		if toolName == "" || toolName == "undefined" {
+			panic(vm.NewGoError(fmt.Errorf("api.callRendered() requires a tool name as the first argument")))
+		}
+
+		result, err := executeRenderedOrFallback(ctx, mcp.ToolName(toolName), args)
+		if err != nil {
+			panic(vm.NewGoError(fmt.Errorf("api.callRendered(%q) failed: %w", toolName, err)))
+		}
+		if result.IsError {
+			panic(vm.NewGoError(fmt.Errorf("api.callRendered(%q) returned error: %s", toolName, result.Data)))
+		}
+
+		// Return as string — rendered output is LLM-readable text, not JSON to parse.
+		return vm.ToValue(result.Data)
+	}); err != nil {
+		return nil, fmt.Errorf("failed to set api.callRendered: %w", err)
+	}
+
+	if err := apiObj.Set("tryCallRendered", func(call goja.FunctionCall) goja.Value {
+		if err := ctx.Err(); err != nil {
+			panic(vm.NewGoError(fmt.Errorf("script cancelled: %w", err)))
+		}
+		callCount++
+		if callCount > e.maxCalls {
+			return vm.ToValue(map[string]any{"ok": false, "error": fmt.Sprintf("exceeded maximum of %d api calls per script", e.maxCalls)})
+		}
+
+		toolName, args, _ := parseCallArgs(call)
+		if toolName == "" || toolName == "undefined" {
+			return vm.ToValue(map[string]any{"ok": false, "error": "api.tryCallRendered() requires a tool name"})
+		}
+
+		result, err := executeRenderedOrFallback(ctx, mcp.ToolName(toolName), args)
+		if err != nil {
+			return vm.ToValue(map[string]any{"ok": false, "error": err.Error()})
+		}
+		if result.IsError {
+			return vm.ToValue(map[string]any{"ok": false, "error": result.Data})
+		}
+
+		// Return as string — no JSON parsing, rendered output is text.
+		return vm.ToValue(map[string]any{"ok": true, "data": result.Data})
+	}); err != nil {
+		return nil, fmt.Errorf("failed to set api.tryCallRendered: %w", err)
 	}
 
 	if err := vm.Set("api", apiObj); err != nil {

--- a/script/engine_test.go
+++ b/script/engine_test.go
@@ -35,6 +35,27 @@ func (m *mockExecutor) Execute(_ context.Context, toolName mcp.ToolName, args ma
 	return &mcp.ToolResult{Data: `{"ok":true}`, IsError: false}, nil
 }
 
+// mockRenderedExecutor implements both Executor and RenderedExecutor.
+type mockRenderedExecutor struct {
+	mockExecutor
+	renderedResults map[string]*mcp.ToolResult
+}
+
+func (m *mockRenderedExecutor) ExecuteRendered(_ context.Context, toolName mcp.ToolName, args map[string]any) (*mcp.ToolResult, error) {
+	m.calls = append(m.calls, executorCall{ToolName: string(toolName) + ":rendered", Args: args})
+	if m.err != nil {
+		return nil, m.err
+	}
+	if r, ok := m.renderedResults[string(toolName)]; ok {
+		return r, nil
+	}
+	// Fall through to raw results (simulates tools without rendered output)
+	if r, ok := m.results[string(toolName)]; ok {
+		return r, nil
+	}
+	return &mcp.ToolResult{Data: "rendered fallback"}, nil
+}
+
 func TestEngine_SimpleScript(t *testing.T) {
 	exec := &mockExecutor{results: map[string]*mcp.ToolResult{}}
 	engine := New(exec)
@@ -515,4 +536,134 @@ func TestEngine_FieldProjection(t *testing.T) {
 			}
 		})
 	}
+}
+
+// --- api.callRendered() tests ---
+
+func TestEngine_CallRendered_ReturnsString(t *testing.T) {
+	exec := &mockRenderedExecutor{
+		mockExecutor: mockExecutor{results: map[string]*mcp.ToolResult{}},
+		renderedResults: map[string]*mcp.ToolResult{
+			"notion_get_page_content": {Data: "# Welcome to Notion\n*Last edited*\n"},
+		},
+	}
+	engine := New(exec)
+
+	// callRendered returns a JS string — usable with + concatenation inside scripts.
+	// Wrap in an object to verify the string value without JSON double-encoding.
+	result, err := engine.Run(context.Background(), `({text: api.callRendered('notion_get_page_content', {page_id: 'abc'})})`)
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.Data), &parsed))
+	assert.Equal(t, "# Welcome to Notion\n*Last edited*\n", parsed["text"])
+}
+
+func TestEngine_CallRendered_UsableInConcatenation(t *testing.T) {
+	exec := &mockRenderedExecutor{
+		mockExecutor: mockExecutor{results: map[string]*mcp.ToolResult{}},
+		renderedResults: map[string]*mcp.ToolResult{
+			"notion_get_page_content": {Data: "# Page Title"},
+		},
+	}
+	engine := New(exec)
+
+	// The real use case: concatenate rendered output with other strings
+	result, err := engine.Run(context.Background(), `({prompt: 'Summarize:\n' + api.callRendered('notion_get_page_content', {page_id: 'abc'})})`)
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.Data), &parsed))
+	assert.Equal(t, "Summarize:\n# Page Title", parsed["prompt"])
+}
+
+func TestEngine_CallRendered_FallsBackToRawWhenNotImplemented(t *testing.T) {
+	// Plain mockExecutor does NOT implement RenderedExecutor
+	exec := &mockExecutor{
+		results: map[string]*mcp.ToolResult{
+			"some_tool": {Data: `{"raw":"json"}`},
+		},
+	}
+	engine := New(exec)
+
+	// Falls back to raw Execute — but callRendered still returns result.Data as a string
+	result, err := engine.Run(context.Background(), `({text: api.callRendered('some_tool', {})})`)
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.Data), &parsed))
+	// Fallback returns the raw JSON string (not parsed)
+	assert.Equal(t, `{"raw":"json"}`, parsed["text"])
+}
+
+func TestEngine_CallRendered_PropagatesError(t *testing.T) {
+	exec := &mockRenderedExecutor{
+		mockExecutor:    mockExecutor{results: map[string]*mcp.ToolResult{}, err: fmt.Errorf("connection refused")},
+		renderedResults: map[string]*mcp.ToolResult{},
+	}
+	engine := New(exec)
+
+	result, err := engine.Run(context.Background(), `api.callRendered('bad_tool', {})`)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "connection refused")
+}
+
+func TestEngine_TryCallRendered_ReturnsString(t *testing.T) {
+	exec := &mockRenderedExecutor{
+		mockExecutor: mockExecutor{results: map[string]*mcp.ToolResult{}},
+		renderedResults: map[string]*mcp.ToolResult{
+			"jira_get_issue": {Data: "<!-- jira:key=PROJ-1 -->\n# PROJ-1: Fix bug\n"},
+		},
+	}
+	engine := New(exec)
+
+	result, err := engine.Run(context.Background(), `api.tryCallRendered('jira_get_issue', {issue_key: 'PROJ-1'})`)
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.Data), &parsed))
+	assert.Equal(t, true, parsed["ok"])
+	assert.Equal(t, "<!-- jira:key=PROJ-1 -->\n# PROJ-1: Fix bug\n", parsed["data"])
+}
+
+func TestEngine_TryCallRendered_ErrorEnvelope(t *testing.T) {
+	exec := &mockRenderedExecutor{
+		mockExecutor: mockExecutor{results: map[string]*mcp.ToolResult{}},
+		renderedResults: map[string]*mcp.ToolResult{
+			"bad_tool": {Data: "not found", IsError: true},
+		},
+	}
+	engine := New(exec)
+
+	result, err := engine.Run(context.Background(), `api.tryCallRendered('bad_tool', {})`)
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.Data), &parsed))
+	assert.Equal(t, false, parsed["ok"])
+	assert.Contains(t, parsed["error"], "not found")
+}
+
+func TestEngine_CallRendered_CountsAgainstCallLimit(t *testing.T) {
+	exec := &mockRenderedExecutor{
+		mockExecutor:    mockExecutor{results: map[string]*mcp.ToolResult{}},
+		renderedResults: map[string]*mcp.ToolResult{},
+	}
+	engine := New(exec, WithMaxCalls(2))
+
+	// 2 callRendered calls should succeed, 3rd should fail
+	result, err := engine.Run(context.Background(), `
+		api.callRendered('tool1', {});
+		api.callRendered('tool2', {});
+		api.callRendered('tool3', {});
+	`)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "exceeded maximum")
 }

--- a/server/server.go
+++ b/server/server.go
@@ -189,12 +189,22 @@ Mode 2 — Single tool (provide tool_name + arguments):
   {"tool_name": "github_list_issues", "arguments": {"owner": "golang", "repo": "go"}}
 
 Script API:
-  api.call(toolName, args[, opts]) — call any integration tool, returns parsed JSON. Throws on error (kills script).
-    Optional opts object with fields key applies server-side field projection: {fields: ["id", "title", "user.login"]}.
-    Uses dot-notation: {fields: ["id", "title", "user.login", "labels[].name"]}. Only specified fields are kept.
-  api.tryCall(toolName, args[, opts]) — like call, but returns {ok: true, data: ...} or {ok: false, error: "..."}.
-    Also supports the optional opts with field projection. Prefer tryCall for cross-integration scripts where partial results are useful.
+  api.call(toolName, args[, opts]) — returns parsed JSON object. Use for data you need to read fields from (issues, PRs, metrics).
+    Optional opts: {fields: ["id", "title", "user.login"]} for server-side field projection. Dot-notation and brackets supported.
+    Throws on error (kills script). For partial-failure resilience, use tryCall.
+  api.tryCall(toolName, args[, opts]) — non-throwing call. Returns {ok: true, data: ...} or {ok: false, error: "..."}.
+    Also supports field projection. Prefer for cross-integration scripts where partial results are useful.
+  api.callRendered(toolName, args) — returns LLM-readable STRING (markdown or compacted JSON) instead of a JSON object.
+    The return value is a STRING, not an object — use string concatenation (+), not .field access.
+    Use for document content you need as readable text (pages, emails, issues). Do NOT use when you need field access.
+    No field projection. Throws on error.
+  api.tryCallRendered(toolName, args) — non-throwing callRendered. Returns {ok: true, data: "rendered string"} or {ok: false, error: "..."}.
+    The data value is a STRING. Do not JSON.parse() it — it is already the final readable text.
   console.log(...) — debug logging (included in output on error)
+
+When to use call vs callRendered:
+  Need .field access (data.id, result.items[0])? → api.call()
+  Need readable text to pass to another tool or return to user? → api.callRendered()
 
 Scripts can call integration tools — chain GitHub, Linear, Sentry, Datadog, Slack, etc. in one script.
 Scripts CANNOT call the search or execute meta-tools. Use search before writing a script to discover tool names.
@@ -219,7 +229,10 @@ Cross-integration correlation with tryCall and field projection:
   {"script": "var pr = api.call('github_get_pull', {owner: 'o', repo: 'r', pull_number: 42}, {fields: ['title', 'state']}); var linear = api.tryCall('linear_search_issues', {query: pr.title}, {fields: ['issues.nodes[].identifier', 'issues.nodes[].title']}); ({pr: pr, linear: linear.ok ? linear.data : {error: linear.error}});"}
 
 List issues with server-side projection (only id, title, labels — no manual .map() needed):
-  {"script": "api.call('github_list_issues', {owner: 'o', repo: 'r', state: 'open'}, {fields: ['number', 'title', 'labels[].name']});"}`,
+  {"script": "api.call('github_list_issues', {owner: 'o', repo: 'r', state: 'open'}, {fields: ['number', 'title', 'labels[].name']});"}
+
+Pipe rendered document content between tools (callRendered returns readable text, not raw JSON):
+  {"script": "var page = api.callRendered('notion_get_page_content', {page_id: 'abc'}); var summary = api.call('ollama_chat', {model: 'gemma3', messages: [{role: 'user', content: 'Summarize:\\n' + page}]}); ({summary: summary.message.content});"}`,
 		InputSchema: objectSchema(map[string]any{
 			"tool_name": map[string]any{
 				"type":        "string",
@@ -1092,7 +1105,8 @@ type toolExecutor struct {
 	server *Server
 }
 
-func (te *toolExecutor) Execute(ctx context.Context, toolName mcp.ToolName, args map[string]any) (*mcp.ToolResult, error) {
+// checkMetaTool rejects meta-tools from script calls.
+func (te *toolExecutor) checkMetaTool(toolName mcp.ToolName) *mcp.ToolResult {
 	if toolName == "search" || toolName == "execute" || toolName == "session" || toolName == "history" || toolName == "pin" {
 		return &mcp.ToolResult{
 			Data: fmt.Sprintf(
@@ -1100,12 +1114,37 @@ func (te *toolExecutor) Execute(ctx context.Context, toolName mcp.ToolName, args
 					"Use the search MCP tool before writing a script to discover tool names.",
 				toolName),
 			IsError: true,
-		}, nil
+		}
+	}
+	return nil
+}
+
+func (te *toolExecutor) Execute(ctx context.Context, toolName mcp.ToolName, args map[string]any) (*mcp.ToolResult, error) {
+	if r := te.checkMetaTool(toolName); r != nil {
+		return r, nil
 	}
 	// Integration is discarded: script-path calls intentionally skip per-tool
 	// compaction so scripts can access all fields by name before projecting.
 	_, result, err := te.server.executeTool(ctx, toolName, args)
 	return result, err
+}
+
+// ExecuteRendered applies the same markdown/compaction/columnarization pipeline
+// as the execute meta-tool, returning LLM-readable output. Used by api.callRendered().
+func (te *toolExecutor) ExecuteRendered(ctx context.Context, toolName mcp.ToolName, args map[string]any) (*mcp.ToolResult, error) {
+	if r := te.checkMetaTool(toolName); r != nil {
+		return r, nil
+	}
+	integration, result, err := te.server.executeTool(ctx, toolName, args)
+	if err != nil {
+		return nil, err
+	}
+	if result.IsError || integration == nil {
+		return result, nil
+	}
+	rp := buildResultProcessor(integration)
+	result.Data = processResult(rp, toolName, result.Data, te.server.services.Metrics)
+	return result, nil
 }
 
 // Handler returns an http.Handler that serves MCP over streamable HTTP transport.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2918,3 +2918,156 @@ func TestExecute_UnconfiguredTool_ReturnsConfigurationError(t *testing.T) {
 	assert.Contains(t, tc.Text, "linear",
 		"error should name the unconfigured integration")
 }
+
+// --- ExecuteRendered (script api.callRendered) ---
+
+func TestToolExecutor_ExecuteRendered_AppliesMarkdown(t *testing.T) {
+	mi := &mockMarkdownIntegration{
+		mockIntegration: mockIntegration{
+			name:    "testint",
+			healthy: true,
+			tools: []mcp.ToolDefinition{
+				{Name: mcp.ToolName("testint_get_page"), Description: "Get page"},
+			},
+			execFn: func(_ context.Context, _ mcp.ToolName, _ map[string]any) (*mcp.ToolResult, error) {
+				return &mcp.ToolResult{Data: `{"title":"Hello","body":"World"}`}, nil
+			},
+		},
+		renderFn: func(_ mcp.ToolName, _ []byte) (mcp.Markdown, bool) {
+			return "# Hello\nWorld\n", true
+		},
+	}
+
+	s := setupTestServer(&mi.mockIntegration)
+	s.services.Registry.(*mockRegistry).integrations["testint"] = mi
+
+	te := &toolExecutor{server: s}
+	result, err := te.ExecuteRendered(context.Background(), "testint_get_page", nil)
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Equal(t, "# Hello\nWorld\n", result.Data, "ExecuteRendered should return markdown")
+}
+
+func TestToolExecutor_ExecuteRendered_FallsBackToCompaction(t *testing.T) {
+	// Integration without MarkdownIntegration — should still compact
+	mi := &mockFieldCompactionIntegration{
+		mockIntegration: mockIntegration{
+			name:    "testint",
+			healthy: true,
+			tools: []mcp.ToolDefinition{
+				{Name: mcp.ToolName("testint_list_items"), Description: "List items"},
+			},
+			execFn: func(_ context.Context, _ mcp.ToolName, _ map[string]any) (*mcp.ToolResult, error) {
+				return &mcp.ToolResult{Data: `{"id":1,"name":"kept","secret":"dropped"}`}, nil
+			},
+		},
+		specs: map[mcp.ToolName][]mcp.CompactField{
+			"testint_list_items": mustParseSpecs([]string{"id", "name"}),
+		},
+	}
+
+	s := setupTestServer(&mi.mockIntegration)
+	s.services.Registry.(*mockRegistry).integrations["testint"] = mi
+
+	te := &toolExecutor{server: s}
+	result, err := te.ExecuteRendered(context.Background(), "testint_list_items", nil)
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "kept")
+	assert.NotContains(t, result.Data, "secret", "compaction should strip unspecified fields")
+}
+
+func TestToolExecutor_ExecuteRendered_SkipsProcessResultOnError(t *testing.T) {
+	mi := &mockMarkdownIntegration{
+		mockIntegration: mockIntegration{
+			name:    "testint",
+			healthy: true,
+			tools: []mcp.ToolDefinition{
+				{Name: mcp.ToolName("testint_get_page"), Description: "Get page"},
+			},
+			execFn: func(_ context.Context, _ mcp.ToolName, _ map[string]any) (*mcp.ToolResult, error) {
+				return &mcp.ToolResult{Data: "page not found", IsError: true}, nil
+			},
+		},
+		renderFn: func(_ mcp.ToolName, _ []byte) (mcp.Markdown, bool) {
+			return "# Should not render", true
+		},
+	}
+
+	s := setupTestServer(&mi.mockIntegration)
+	s.services.Registry.(*mockRegistry).integrations["testint"] = mi
+
+	te := &toolExecutor{server: s}
+	result, err := te.ExecuteRendered(context.Background(), "testint_get_page", nil)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Equal(t, "page not found", result.Data, "error results should not be rendered")
+}
+
+func TestToolExecutor_ExecuteRendered_BlocksMetaTools(t *testing.T) {
+	s := setupTestServer()
+	te := &toolExecutor{server: s}
+
+	result, err := te.ExecuteRendered(context.Background(), "search", nil)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "meta-tool")
+
+	result, err = te.ExecuteRendered(context.Background(), "execute", nil)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "meta-tool")
+}
+
+func TestScript_CallRendered_EndToEnd(t *testing.T) {
+	mi := &mockMarkdownIntegration{
+		mockIntegration: mockIntegration{
+			name:    "testint",
+			healthy: true,
+			tools: []mcp.ToolDefinition{
+				{Name: mcp.ToolName("testint_get_doc"), Description: "Get doc"},
+			},
+			execFn: func(_ context.Context, _ mcp.ToolName, _ map[string]any) (*mcp.ToolResult, error) {
+				return &mcp.ToolResult{Data: `{"raw":"json","noise":"dropped"}`}, nil
+			},
+		},
+		renderFn: func(_ mcp.ToolName, _ []byte) (mcp.Markdown, bool) {
+			return "# Rendered Document\nClean content.\n", true
+		},
+	}
+
+	s := setupTestServer(&mi.mockIntegration)
+	s.services.Registry.(*mockRegistry).integrations["testint"] = mi
+
+	script := `({text: api.callRendered('testint_get_doc', {id: '123'})})`
+	scriptReq := &mcpsdk.CallToolRequest{
+		Params: &mcpsdk.CallToolParamsRaw{
+			Name:      "execute",
+			Arguments: mustMarshal(map[string]any{"script": script}),
+		},
+	}
+	result, err := s.handleExecute(context.Background(), scriptReq)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	tc := result.Content[0].(*mcpsdk.TextContent)
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(tc.Text), &parsed))
+	assert.Equal(t, "# Rendered Document\nClean content.\n", parsed["text"])
+}
+
+func mustParseSpecs(specs []string) []mcp.CompactField {
+	fields, err := mcp.ParseCompactSpecs(specs)
+	if err != nil {
+		panic(err)
+	}
+	return fields
+}
+
+func mustMarshal(v any) json.RawMessage {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}


### PR DESCRIPTION
1. add support for ollama's built in API
2. adds a rendered output option so tools can pass around output rendered from our render pipeline directly to each other during execution scripts.