### PR TITLE
Migrate jira_search_issues to /search/jql endpoint

### DIFF
--- a/integrations/jira/compact_specs.go
+++ b/integrations/jira/compact_specs.go
@@ -12,6 +12,7 @@ var rawFieldCompactionSpecs = map[mcp.ToolName][]string{
 		"issues[].key", "issues[].fields.summary", "issues[].fields.status.name",
 		"issues[].fields.assignee.displayName", "issues[].fields.priority.name",
 		"issues[].fields.issuetype.name", "issues[].fields.created", "issues[].fields.updated",
+		"nextPageToken", "isLast",
 	},
 	mcp.ToolName("jira_get_issue"): {
 		"key", "fields.summary", "fields.status.name", "fields.assignee.displayName",

--- a/integrations/jira/compact_specs_test.go
+++ b/integrations/jira/compact_specs_test.go
@@ -56,7 +56,7 @@ func TestFieldCompactionSpecs_ShapeParity(t *testing.T) {
 	// Representative payloads matching the real Jira API response shapes.
 	handlerOutputs := map[string]string{
 		// Issues
-		"jira_search_issues":    `{"issues":[{"key":"PROJ-1","fields":{"summary":"Fix bug","status":{"name":"Open"},"assignee":{"displayName":"Alice"},"priority":{"name":"High"},"issuetype":{"name":"Bug"},"created":"2024-01-01","updated":"2024-01-02"}}],"total":1}`,
+		"jira_search_issues":    `{"issues":[{"key":"PROJ-1","fields":{"summary":"Fix bug","status":{"name":"Open"},"assignee":{"displayName":"Alice"},"priority":{"name":"High"},"issuetype":{"name":"Bug"},"created":"2024-01-01","updated":"2024-01-02"}}],"isLast":false,"nextPageToken":"eyJhIjoiMTIzIn0="}`,
 		"jira_get_issue":        `{"key":"PROJ-1","fields":{"summary":"Fix bug","status":{"name":"Open"},"assignee":{"displayName":"Alice","accountId":"abc"},"reporter":{"displayName":"Bob"},"priority":{"name":"High"},"issuetype":{"name":"Bug"},"description":{"type":"doc"},"created":"2024-01-01","updated":"2024-01-02","labels":["backend"],"components":[{"name":"API"}],"fixVersions":[{"name":"1.0"}]}}`,
 		"jira_get_transitions":  `{"transitions":[{"id":"1","name":"Done","to":{"name":"Done"}}]}`,
 		"jira_list_comments":    `{"comments":[{"id":"1","body":{"type":"doc"},"author":{"displayName":"Alice"},"created":"2024-01-01","updated":"2024-01-02"}]}`,

--- a/integrations/jira/issues.go
+++ b/integrations/jira/issues.go
@@ -24,19 +24,19 @@ func searchIssues(ctx context.Context, j *jira, args map[string]any) (*mcp.ToolR
 	} else {
 		body["fields"] = []string{"summary", "status", "assignee", "priority", "issuetype"}
 	}
-	if v := r.Int("start_at"); v > 0 {
-		body["startAt"] = v
+	if v := r.Str("next_page_token"); v != "" {
+		body["nextPageToken"] = v
 	}
 	if v := r.Int("max_results"); v > 0 {
 		body["maxResults"] = v
 	} else {
-		body["maxResults"] = 50
+		body["maxResults"] = 200
 	}
 	if err := r.Err(); err != nil {
 		return mcp.ErrResult(err)
 	}
 
-	data, err := j.post(ctx, "/search", body)
+	data, err := j.post(ctx, "/search/jql", body)
 	if err != nil {
 		return mcp.ErrResult(err)
 	}

--- a/integrations/jira/jira_test.go
+++ b/integrations/jira/jira_test.go
@@ -345,14 +345,12 @@ func TestSearchIssues(t *testing.T) {
 		wantPath  string
 		wantToken string
 		wantMax   float64
-		noStartAt bool
 	}{
 		{
-			name:      "basic search hits /search/jql",
-			args:      map[string]any{"jql": "project = PROJ"},
-			wantPath:  "/search/jql",
-			wantMax:   200,
-			noStartAt: true,
+			name:     "basic search hits /search/jql",
+			args:     map[string]any{"jql": "project = PROJ"},
+			wantPath: "/search/jql",
+			wantMax:  200,
 		},
 		{
 			name:      "with next_page_token",
@@ -360,14 +358,12 @@ func TestSearchIssues(t *testing.T) {
 			wantPath:  "/search/jql",
 			wantToken: "abc123",
 			wantMax:   200,
-			noStartAt: true,
 		},
 		{
-			name:      "custom max_results",
-			args:      map[string]any{"jql": "project = PROJ", "max_results": float64(500)},
-			wantPath:  "/search/jql",
-			wantMax:   500,
-			noStartAt: true,
+			name:     "custom max_results",
+			args:     map[string]any{"jql": "project = PROJ", "max_results": float64(500)},
+			wantPath: "/search/jql",
+			wantMax:  500,
 		},
 	}
 
@@ -380,12 +376,14 @@ func TestSearchIssues(t *testing.T) {
 				var body map[string]any
 				require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
 
-				if tt.noStartAt {
-					_, hasStartAt := body["startAt"]
-					assert.False(t, hasStartAt, "request body should not contain startAt")
-				}
+				_, hasStartAt := body["startAt"]
+				assert.False(t, hasStartAt, "request body should not contain startAt")
+
 				if tt.wantToken != "" {
 					assert.Equal(t, tt.wantToken, body["nextPageToken"])
+				} else {
+					_, hasToken := body["nextPageToken"]
+					assert.False(t, hasToken, "nextPageToken should not be sent on first page")
 				}
 				assert.Equal(t, tt.wantMax, body["maxResults"])
 

--- a/integrations/jira/jira_test.go
+++ b/integrations/jira/jira_test.go
@@ -338,6 +338,70 @@ func TestQueryEncode(t *testing.T) {
 	})
 }
 
+func TestSearchIssues(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      map[string]any
+		wantPath  string
+		wantToken string
+		wantMax   float64
+		noStartAt bool
+	}{
+		{
+			name:      "basic search hits /search/jql",
+			args:      map[string]any{"jql": "project = PROJ"},
+			wantPath:  "/search/jql",
+			wantMax:   200,
+			noStartAt: true,
+		},
+		{
+			name:      "with next_page_token",
+			args:      map[string]any{"jql": "project = PROJ", "next_page_token": "abc123"},
+			wantPath:  "/search/jql",
+			wantToken: "abc123",
+			wantMax:   200,
+			noStartAt: true,
+		},
+		{
+			name:      "custom max_results",
+			args:      map[string]any{"jql": "project = PROJ", "max_results": float64(500)},
+			wantPath:  "/search/jql",
+			wantMax:   500,
+			noStartAt: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, tt.wantPath, r.URL.Path)
+				assert.Equal(t, "POST", r.Method)
+
+				var body map[string]any
+				require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+
+				if tt.noStartAt {
+					_, hasStartAt := body["startAt"]
+					assert.False(t, hasStartAt, "request body should not contain startAt")
+				}
+				if tt.wantToken != "" {
+					assert.Equal(t, tt.wantToken, body["nextPageToken"])
+				}
+				assert.Equal(t, tt.wantMax, body["maxResults"])
+
+				w.Header().Set("Content-Type", "application/json")
+				w.Write([]byte(`{"issues":[],"isLast":true}`))
+			}))
+			defer ts.Close()
+
+			j := &jira{email: "u@test.com", apiToken: "tok", client: ts.Client(), baseURL: ts.URL, agileURL: ts.URL}
+			result, err := searchIssues(context.Background(), j, tt.args)
+			require.NoError(t, err)
+			assert.False(t, result.IsError)
+		})
+	}
+}
+
 func TestTextToADF(t *testing.T) {
 	adf := textToADF("Hello\nWorld")
 	assert.Equal(t, "doc", adf["type"])

--- a/integrations/jira/tools.go
+++ b/integrations/jira/tools.go
@@ -6,7 +6,7 @@ var tools = []mcp.ToolDefinition{
 	// ── Issues ───────────────────────────────────────────────────────
 	{
 		Name: mcp.ToolName("jira_search_issues"), Description: "Search issues using JQL (Jira Query Language). Start here for most issue workflows. Returns paginated results; pass nextPageToken from response to fetch next page",
-		Parameters: map[string]string{"jql": "JQL query (e.g., 'project = PROJ AND status = Open')", "fields": "Comma-separated fields to return (default: summary,status,assignee,priority,issuetype)", "next_page_token": "Cursor for next page (from previous response's nextPageToken field)", "max_results": "Max results per page (default 200, max 5000)"},
+		Parameters: map[string]string{"jql": "JQL query (e.g., 'project = PROJ AND status = Open')", "fields": "Comma-separated fields to return (default: summary,status,assignee,priority,issuetype)", "next_page_token": "Cursor for next page (from previous response's nextPageToken field)", "max_results": "Max results per page (default 200, server may cap)"},
 		Required:   []string{"jql"},
 	},
 	{

--- a/integrations/jira/tools.go
+++ b/integrations/jira/tools.go
@@ -5,8 +5,8 @@ import mcp "github.com/daltoniam/switchboard"
 var tools = []mcp.ToolDefinition{
 	// ── Issues ───────────────────────────────────────────────────────
 	{
-		Name: mcp.ToolName("jira_search_issues"), Description: "Search issues using JQL (Jira Query Language). Start here for most issue workflows. Returns paginated results",
-		Parameters: map[string]string{"jql": "JQL query (e.g., 'project = PROJ AND status = Open')", "fields": "Comma-separated fields to return (default: summary,status,assignee,priority,issuetype)", "start_at": "Pagination offset (0-based)", "max_results": "Max results per page (default 50, max 100)"},
+		Name: mcp.ToolName("jira_search_issues"), Description: "Search issues using JQL (Jira Query Language). Start here for most issue workflows. Returns paginated results; pass nextPageToken from response to fetch next page",
+		Parameters: map[string]string{"jql": "JQL query (e.g., 'project = PROJ AND status = Open')", "fields": "Comma-separated fields to return (default: summary,status,assignee,priority,issuetype)", "next_page_token": "Cursor for next page (from previous response's nextPageToken field)", "max_results": "Max results per page (default 200, max 5000)"},
 		Required:   []string{"jql"},
 	},
 	{


### PR DESCRIPTION
## Summary
- Migrates `jira_search_issues` from deprecated `POST /rest/api/3/search` to `POST /rest/api/3/search/jql` ([Atlassian deprecation notice](https://developer.atlassian.com/changelog/#CHANGE-2046))
- Replaces offset-based pagination (`start_at` / `startAt`) with cursor-based pagination (`next_page_token` / `nextPageToken`)
- Bumps default `maxResults` from 50 to 200 (new endpoint supports up to 5000)
- Adds `nextPageToken` and `isLast` to compaction spec so pagination fields survive response compaction

## Test plan
- [x] Added `TestSearchIssues` table-driven test verifying new endpoint path, cursor parameter, and default max
- [x] Updated compact spec shape parity test payload to match new response format
- [x] All existing tests pass (`go test ./integrations/jira/`)
- [ ] Live smoke test against a Jira Cloud instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)