### PR TITLE
fix: remove hardcoded .rwx/ci.yml filter from RWX integration

### DIFF
--- a/integrations/rwx/compact_specs.go
+++ b/integrations/rwx/compact_specs.go
@@ -8,8 +8,8 @@ import (
 
 var rawFieldCompactionSpecs = map[mcp.ToolName][]string{
 	// ── Runs ────────────────────────────────────────────────────────
-	// Handler: jsonResult(map{ref, count, runs: [{run_id, status, commit_sha, title, url}]})
-	mcp.ToolName("rwx_get_recent_runs"): {"ref", "count", "runs[].run_id", "runs[].status", "runs[].commit_sha", "runs[].title", "runs[].url"},
+	// Handler: jsonResult(map{ref, count, runs: [{run_id, status, commit_sha, title, definition_path, url}]})
+	mcp.ToolName("rwx_get_recent_runs"): {"ref", "count", "runs[].run_id", "runs[].status", "runs[].commit_sha", "runs[].title", "runs[].definition_path", "runs[].url"},
 	// Handler: jsonResult(map{run_id, url, status, execution, duration_seconds, summary, failed_tasks, tasks: [{key, status, duration_seconds, cache_hit}]})
 	mcp.ToolName("rwx_get_run_results"): {"run_id", "url", "status", "duration_seconds", "summary", "failed_tasks", "tasks[].key", "tasks[].status", "tasks[].duration_seconds", "tasks[].cache_hit"},
 }

--- a/integrations/rwx/extras.go
+++ b/integrations/rwx/extras.go
@@ -21,7 +21,7 @@ func getArtifacts(_ context.Context, r *rwx, args map[string]any) (*mcp.ToolResu
 	}
 
 	id := extractRunID(runIDRaw)
-	runURL := fmt.Sprintf("%s/mint/%s/runs/%s", rwxAPIBase, r.org, id)
+	runURL := fmt.Sprintf("%s/mint/%s/runs/%s", r.baseURL, r.org, id)
 
 	cmdArgs := []string{"artifacts", id, "--output", "json"}
 	if !download {

--- a/integrations/rwx/runs.go
+++ b/integrations/rwx/runs.go
@@ -13,7 +13,14 @@ import (
 )
 
 func launchCIRun(_ context.Context, r *rwx, args map[string]any) (*mcp.ToolResult, error) {
-	cmdArgs := []string{"run", ".rwx/ci.yml", "--output", "json"}
+	workflow, err := mcp.ArgStr(args, "workflow")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	if workflow == "" {
+		workflow = ".rwx/ci.yml"
+	}
+	cmdArgs := []string{"run", workflow, "--output", "json"}
 
 	wait, err := mcp.ArgBool(args, "wait")
 	if err != nil {
@@ -53,7 +60,7 @@ func launchCIRun(_ context.Context, r *rwx, args map[string]any) (*mcp.ToolResul
 
 	runURL := parsed.RunURL
 	if runURL == "" {
-		runURL = fmt.Sprintf("%s/mint/%s/runs/%s", rwxAPIBase, r.org, parsed.RunID)
+		runURL = fmt.Sprintf("%s/mint/%s/runs/%s", r.baseURL, r.org, parsed.RunID)
 	}
 
 	if wait {
@@ -95,7 +102,7 @@ func waitForCIRun(ctx context.Context, r *rwx, args map[string]any) (*mcp.ToolRe
 	}
 
 	id := extractRunID(runIDRaw)
-	runURL := fmt.Sprintf("%s/mint/%s/runs/%s", rwxAPIBase, r.org, id)
+	runURL := fmt.Sprintf("%s/mint/%s/runs/%s", r.baseURL, r.org, id)
 
 	if timeoutSec <= 0 {
 		timeoutSec = 1800
@@ -153,6 +160,7 @@ func getRecentRuns(ctx context.Context, r *rwx, args map[string]any) (*mcp.ToolR
 	ra := mcp.NewArgs(args)
 	ref := ra.Str("ref")
 	limit := ra.Int("limit")
+	definitionPath := ra.Str("definition_path")
 	if err := ra.Err(); err != nil {
 		return mcp.ErrResult(err)
 	}
@@ -165,7 +173,7 @@ func getRecentRuns(ctx context.Context, r *rwx, args map[string]any) (*mcp.ToolR
 		fetchLimit = 100
 	}
 
-	apiURL := fmt.Sprintf("%s/mint/api/runs?limit=%d", rwxAPIBase, fetchLimit)
+	apiURL := fmt.Sprintf("%s/mint/api/runs?limit=%d", r.baseURL, fetchLimit)
 	req, err := http.NewRequestWithContext(ctx, "GET", apiURL, nil)
 	if err != nil {
 		return mcp.ErrResult(err)
@@ -207,7 +215,10 @@ func getRecentRuns(ctx context.Context, r *rwx, args map[string]any) (*mcp.ToolR
 
 	var runs []map[string]any
 	for _, run := range data.Runs {
-		if run.Branch != ref || run.DefinitionPath != ".rwx/ci.yml" {
+		if run.Branch != ref {
+			continue
+		}
+		if definitionPath != "" && run.DefinitionPath != definitionPath {
 			continue
 		}
 		status := "running"
@@ -215,11 +226,12 @@ func getRecentRuns(ctx context.Context, r *rwx, args map[string]any) (*mcp.ToolR
 			status = normalizeStatus(run.ResultStatus)
 		}
 		runs = append(runs, map[string]any{
-			"run_id":     run.ID,
-			"status":     status,
-			"commit_sha": run.CommitSHA,
-			"title":      run.Title,
-			"url":        fmt.Sprintf("%s/mint/%s/runs/%s", rwxAPIBase, r.org, run.ID),
+			"run_id":          run.ID,
+			"status":          status,
+			"commit_sha":      run.CommitSHA,
+			"title":           run.Title,
+			"definition_path": run.DefinitionPath,
+			"url":             fmt.Sprintf("%s/mint/%s/runs/%s", r.baseURL, r.org, run.ID),
 		})
 		if len(runs) >= limit {
 			break
@@ -260,7 +272,7 @@ func getRunResults(_ context.Context, r *rwx, args map[string]any) (*mcp.ToolRes
 		return mcp.ErrResult(fmt.Errorf("parse results: %w", err))
 	}
 
-	runURL := fmt.Sprintf("%s/mint/%s/runs/%s", rwxAPIBase, r.org, id)
+	runURL := fmt.Sprintf("%s/mint/%s/runs/%s", r.baseURL, r.org, id)
 	status := normalizeStatus(parsed.Result)
 
 	var failedKeys []string
@@ -307,7 +319,7 @@ func getRunResults(_ context.Context, r *rwx, args map[string]any) (*mcp.ToolRes
 // --- helpers ---
 
 func fetchRunStatus(ctx context.Context, r *rwx, runID string) (status string, isComplete bool, err error) {
-	apiURL := fmt.Sprintf("%s/mint/api/runs/%s", rwxAPIBase, runID)
+	apiURL := fmt.Sprintf("%s/mint/api/runs/%s", r.baseURL, runID)
 	req, err := http.NewRequestWithContext(ctx, "GET", apiURL, nil)
 	if err != nil {
 		return "", false, err

--- a/integrations/rwx/rwx.go
+++ b/integrations/rwx/rwx.go
@@ -13,9 +13,9 @@ import (
 )
 
 const (
-	minRWXVersion   = "3.0.0"
-	rwxAPIBase      = "https://cloud.rwx.com"
-	maxResponseSize = 10 * 1024 * 1024 // 10 MB
+	minRWXVersion     = "3.0.0"
+	defaultRWXAPIBase = "https://cloud.rwx.com"
+	maxResponseSize   = 10 * 1024 * 1024 // 10 MB
 )
 
 // Compile-time interface assertions.
@@ -28,6 +28,7 @@ type rwx struct {
 	accessToken string
 	org         string
 	cliPath     string
+	baseURL     string
 	client      *http.Client
 	proxy       *proxyClient
 	logCache    *logCache
@@ -36,6 +37,7 @@ type rwx struct {
 func New() mcp.Integration {
 	return &rwx{
 		client:   &http.Client{Timeout: 30 * time.Second},
+		baseURL:  defaultRWXAPIBase,
 		logCache: newLogCache(),
 	}
 }
@@ -59,7 +61,7 @@ func (r *rwx) Healthy(ctx context.Context) bool {
 	if r.accessToken == "" {
 		return false
 	}
-	req, err := http.NewRequestWithContext(ctx, "GET", rwxAPIBase+"/mint/api/runs?limit=1", nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", r.baseURL+"/mint/api/runs?limit=1", nil)
 	if err != nil {
 		return false
 	}

--- a/integrations/rwx/rwx_test.go
+++ b/integrations/rwx/rwx_test.go
@@ -188,11 +188,8 @@ func TestHealthy_Success(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	r := &rwx{accessToken: "test-token", org: "my-org", client: ts.Client(), logCache: newLogCache()}
-	// Override the rwxAPIBase for testing — we need to test via the actual method
-	// Since rwxAPIBase is a const, we test via an httptest redirect approach
-	// Instead, we can test the health check logic directly
-	assert.NotNil(t, r)
+	r := &rwx{accessToken: "test-token", org: "my-org", baseURL: ts.URL, client: ts.Client(), logCache: newLogCache()}
+	assert.True(t, r.Healthy(context.Background()))
 }
 
 func TestHealthy_NoToken(t *testing.T) {
@@ -213,17 +210,19 @@ func TestGetRecentRuns(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	r := &rwx{accessToken: "test-token", org: "my-org", client: ts.Client(), logCache: newLogCache()}
+	r := &rwx{accessToken: "test-token", org: "my-org", baseURL: ts.URL, client: ts.Client(), logCache: newLogCache()}
 
-	// We can't easily test since the API base URL is a const, but we can verify
-	// the function doesn't panic and the handler is properly wired
 	result, err := r.Execute(context.Background(), "rwx_get_recent_runs", map[string]any{
 		"ref": "main",
 	})
 	require.NoError(t, err)
-	// Will be an error because the httptest server URL doesn't match rwxAPIBase
-	// but the dispatch works correctly
 	assert.NotNil(t, result)
+	assert.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.Data), &parsed))
+	assert.Equal(t, "main", parsed["ref"])
+	assert.Equal(t, float64(1), parsed["count"])
 }
 
 func TestGetRecentRuns_Response(t *testing.T) {
@@ -231,20 +230,53 @@ func TestGetRecentRuns_Response(t *testing.T) {
 		_, _ = w.Write([]byte(`{"runs":[
 			{"id":"run-1","branch":"main","commit_sha":"abc","result_status":"succeeded","execution_status":"finished","title":"Test","definition_path":".rwx/ci.yml"},
 			{"id":"run-2","branch":"main","commit_sha":"def","result_status":"failed","execution_status":"finished","title":"Test 2","definition_path":".rwx/ci.yml"},
-			{"id":"run-3","branch":"feat","commit_sha":"ghi","result_status":"succeeded","execution_status":"finished","title":"Other","definition_path":".rwx/ci.yml"}
+			{"id":"run-3","branch":"feat","commit_sha":"ghi","result_status":"succeeded","execution_status":"finished","title":"Other","definition_path":".rwx/ci.yml"},
+			{"id":"run-4","branch":"main","commit_sha":"jkl","result_status":"succeeded","execution_status":"finished","title":"Deploy","definition_path":".rwx/auto-deploy.yml"}
 		]}`))
 	}))
 	defer ts.Close()
 
-	r := &rwx{accessToken: "test-token", org: "my-org", client: ts.Client(), logCache: newLogCache()}
+	r := &rwx{accessToken: "test-token", org: "my-org", baseURL: ts.URL, client: ts.Client(), logCache: newLogCache()}
 
-	// Call the handler directly to bypass const URL
-	result, err := getRecentRuns(context.Background(), r, map[string]any{"ref": "main", "limit": float64(5)})
+	t.Run("no definition_path returns all workflows for branch", func(t *testing.T) {
+		result, err := getRecentRuns(context.Background(), r, map[string]any{"ref": "main", "limit": float64(10)})
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
 
-	// This will fail due to const URL, but we can at least verify it executes
-	// If httptest URL matched, it would filter correctly
-	_ = result
-	_ = err
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(result.Data), &parsed))
+		assert.Equal(t, float64(3), parsed["count"], "should return all 3 main branch runs across workflows")
+
+		runs := parsed["runs"].([]any)
+		run4 := runs[2].(map[string]any)
+		assert.Equal(t, "run-4", run4["run_id"])
+		assert.Equal(t, ".rwx/auto-deploy.yml", run4["definition_path"])
+	})
+
+	t.Run("definition_path filters to specific workflow", func(t *testing.T) {
+		result, err := getRecentRuns(context.Background(), r, map[string]any{"ref": "main", "limit": float64(10), "definition_path": ".rwx/ci.yml"})
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(result.Data), &parsed))
+		assert.Equal(t, float64(2), parsed["count"], "should return only ci.yml runs")
+	})
+
+	t.Run("definition_path filters to deploy workflow", func(t *testing.T) {
+		result, err := getRecentRuns(context.Background(), r, map[string]any{"ref": "main", "limit": float64(10), "definition_path": ".rwx/auto-deploy.yml"})
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(result.Data), &parsed))
+		assert.Equal(t, float64(1), parsed["count"], "should return only auto-deploy.yml runs")
+
+		runs := parsed["runs"].([]any)
+		run := runs[0].(map[string]any)
+		assert.Equal(t, "run-4", run["run_id"])
+		assert.Equal(t, ".rwx/auto-deploy.yml", run["definition_path"])
+	})
 }
 
 func TestFetchRunStatus_Success(t *testing.T) {
@@ -253,9 +285,11 @@ func TestFetchRunStatus_Success(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	r := &rwx{accessToken: "test-token", org: "my-org", client: ts.Client(), logCache: newLogCache()}
-	// Direct call would need URL override — tested via integration
-	_ = r
+	r := &rwx{accessToken: "test-token", org: "my-org", baseURL: ts.URL, client: ts.Client(), logCache: newLogCache()}
+	status, isComplete, err := fetchRunStatus(context.Background(), r, "run-123")
+	require.NoError(t, err)
+	assert.True(t, isComplete)
+	assert.Equal(t, "success", status)
 }
 
 // --- Proxy tests ---

--- a/integrations/rwx/tools.go
+++ b/integrations/rwx/tools.go
@@ -6,10 +6,11 @@ var tools = []mcp.ToolDefinition{
 	// ── Runs ────────────────────────────────────────────────────────
 	{
 		Name:        mcp.ToolName("rwx_launch_ci_run"),
-		Description: "Launch a CI/CD pipeline run using the rwx CLI. Start here to run CI. Executes continuous integration tests and builds from .rwx/ci.yml by default.",
+		Description: "Launch a CI/CD pipeline run using the rwx CLI. Start here to run CI. Executes the specified workflow file (default: .rwx/ci.yml).",
 		Parameters: map[string]string{
-			"targets": "JSON array of specific task keys to target (optional)",
-			"wait":    "Wait for the run to complete before returning (true/false, default: false)",
+			"workflow": "Path to the RWX workflow YAML file to run (default: .rwx/ci.yml, e.g. .rwx/auto-deploy.yml)",
+			"targets":  "JSON array of specific task keys to target (optional)",
+			"wait":     "Wait for the run to complete before returning (true/false, default: false)",
 		},
 	},
 	{
@@ -24,10 +25,11 @@ var tools = []mcp.ToolDefinition{
 	},
 	{
 		Name:        mcp.ToolName("rwx_get_recent_runs"),
-		Description: "Get recent CI runs for a git branch, filtered to .rwx/ci.yml runs",
+		Description: "Get recent CI/CD runs for a git branch. Returns all workflow runs by default; use definition_path to filter to a specific workflow.",
 		Parameters: map[string]string{
-			"ref":   "Git ref (branch name) to filter runs by",
-			"limit": "Number of runs to return (default: 5)",
+			"ref":             "Git ref (branch name) to filter runs by",
+			"limit":           "Number of runs to return (default: 5)",
+			"definition_path": "Filter to a specific workflow file (e.g. .rwx/ci.yml, .rwx/auto-deploy.yml). Omit to return all workflows.",
 		},
 		Required: []string{"ref"},
 	},


### PR DESCRIPTION

## Summary

- **`rwx_get_recent_runs`** was hardcoded to filter runs to `.rwx/ci.yml` only, making other workflow runs (e.g. `auto-deploy.yml`) invisible. Now returns all workflows by default with an optional `definition_path` parameter to filter.
- **`rwx_launch_ci_run`** was hardcoded to launch `.rwx/ci.yml`. Now accepts an optional `workflow` parameter (default: `.rwx/ci.yml`).
- Converted `rwxAPIBase` const to a `baseURL` struct field, matching the pattern used by other integrations (YNAB, Suno, Snowflake), enabling proper httptest coverage.
- Each run in `rwx_get_recent_runs` response now includes `definition_path` so callers can distinguish workflow types.

## Changes

| File | Change |
|------|--------|
| `runs.go` | Added `workflow` param to `launchCIRun`, `definition_path` param to `getRecentRuns`, replaced `rwxAPIBase` const with `r.baseURL` |
| `rwx.go` | Added `baseURL` field to struct, renamed const to `defaultRWXAPIBase` |
| `tools.go` | Updated tool descriptions and parameters for both tools |
| `compact_specs.go` | Added `definition_path` to compaction spec |
| `extras.go` | Updated `rwxAPIBase` → `r.baseURL` |
| `rwx_test.go` | Tests now use `baseURL: ts.URL` for real HTTP assertions; added subtests for definition_path filtering |

## Test plan

- [x] `make ci` passes (build, vet, test-race, lint, security, govulncheck)
- [x] New subtests verify: no filter returns all workflows, `definition_path=.rwx/ci.yml` filters correctly, `definition_path=.rwx/auto-deploy.yml` filters correctly
- [x] Existing tests upgraded from no-ops to real HTTP assertions (Healthy, GetRecentRuns, FetchRunStatus)


🐾 Generated with Crush