### PR TITLE
fix: correct github_create_update_file content param description

### DIFF
--- a/integrations/github/tools.go
+++ b/integrations/github/tools.go
@@ -76,7 +76,7 @@ var tools = []mcp.ToolDefinition{
 	},
 	{
 		Name: mcp.ToolName("github_create_update_file"), Description: "Create or update a file in a repository",
-		Parameters: map[string]string{"owner": "Repository owner", "repo": "Repository name", "path": "File path", "message": "Commit message", "content": "Base64-encoded file content", "sha": "SHA of file being replaced (required for update)", "branch": "Target branch"},
+		Parameters: map[string]string{"owner": "Repository owner", "repo": "Repository name", "path": "File path", "message": "Commit message", "content": "Raw file content (plain text, not base64 — encoding is handled automatically)", "sha": "SHA of file being replaced (required for update)", "branch": "Target branch"},
 		Required:   []string{"owner", "repo", "path", "message", "content"},
 	},
 	{


### PR DESCRIPTION

## Summary

- The `github_create_update_file` tool description said content should be "Base64-encoded file content", but `go-github`'s `RepositoryContentFileOptions.Content` field (`[]byte`) expects **raw unencoded bytes** — Go's `encoding/json` marshaler handles base64 encoding automatically when serializing `[]byte` to JSON.
- This misleading description caused AI agents to pre-encode file content to base64, resulting in **double-encoding** — files were written containing raw base64 text instead of source code (e.g. [teamcurri/curri#20000](https://github.com/teamcurri/curri/pull/20000)).

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./integrations/github/...` passes
- [ ] Verify an agent using `github_create_update_file` writes plain text correctly


🐰 Generated with Crush