### PR TITLE
fix(slack): resolve false EXPIRED badge and add multi-browser token extraction

### DIFF
--- a/integrations/slack/extract.go
+++ b/integrations/slack/extract.go
@@ -94,7 +94,7 @@ func ExtractAllFromBrowsersForWeb() (int, error) {
 	}
 
 	type extractedWorkspace struct {
-		chromeWorkspace
+		browserWorkspace
 		cookie string
 		source string
 	}
@@ -131,9 +131,9 @@ func ExtractAllFromBrowsersForWeb() (int, error) {
 				}
 				seen[ws.TeamID] = true
 				result = append(result, extractedWorkspace{
-					chromeWorkspace: ws,
-					cookie:          cookie,
-					source:          strings.ToLower(src.name),
+					browserWorkspace: ws,
+					cookie:           cookie,
+					source:           strings.ToLower(src.name),
 				})
 			}
 		}

--- a/integrations/slack/extract.go
+++ b/integrations/slack/extract.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 )
 
@@ -37,27 +38,33 @@ type TokenInfo struct {
 	Status         string    `json:"status"`
 }
 
-// ListWorkspacesFromChrome returns all Slack workspaces found in Chrome's localStorage.
+// ListWorkspacesFromBrowsers returns all Slack workspaces found in any supported
+// browser's localStorage (Chrome, Brave, Slack desktop app).
 // Exported for use by the web UI to let the user pick which workspace to extract.
-func ListWorkspacesFromChrome() ([]WorkspaceInfo, error) {
+func ListWorkspacesFromBrowsers() ([]WorkspaceInfo, error) {
 	if runtime.GOOS != "darwin" {
-		return nil, fmt.Errorf("chrome extraction is only available on macOS")
+		return nil, fmt.Errorf("browser extraction is only available on macOS")
 	}
-	return listWorkspacesFromChrome()
+	return listWorkspacesFromAllBrowsers()
 }
 
-// ExtractFromChromeForWeb triggers Chrome extraction and returns the result.
-// If teamID is non-empty, only the token for that workspace is extracted.
+// ListWorkspacesFromChrome is an alias kept for backward compatibility.
+func ListWorkspacesFromChrome() ([]WorkspaceInfo, error) {
+	return ListWorkspacesFromBrowsers()
+}
+
+// ExtractFromBrowserForWeb triggers extraction from all supported browsers and
+// returns the result. If teamID is non-empty, only that workspace's token is extracted.
 // This is exported for use by the web UI server.
-func ExtractFromChromeForWeb(teamID string) *ExtractResult {
+func ExtractFromBrowserForWeb(teamID string) *ExtractResult {
 	if runtime.GOOS != "darwin" {
 		return &ExtractResult{
 			Success: false,
-			Error:   "Chrome extraction is only available on macOS. Use the manual method below.",
+			Error:   "Browser extraction is only available on macOS. Use the manual method below.",
 		}
 	}
 
-	extracted, err := extractFromChromeWithError(teamID)
+	extracted, err := extractFromBrowserWithError(teamID)
 	if err != nil {
 		return &ExtractResult{
 			Success: false,
@@ -68,39 +75,70 @@ func ExtractFromChromeForWeb(teamID string) *ExtractResult {
 	return &ExtractResult{
 		Token:   extracted.token,
 		Cookie:  extracted.cookie,
-		Source:  "chrome",
+		Source:  extracted.source,
 		Success: true,
 	}
 }
 
-// ExtractAllFromChromeForWeb extracts tokens for every workspace in Chrome
-// and saves them all to the persistent file. Returns the count of workspaces
-// extracted and any error.
-func ExtractAllFromChromeForWeb() (int, error) {
+// ExtractFromChromeForWeb is an alias kept for backward compatibility.
+func ExtractFromChromeForWeb(teamID string) *ExtractResult {
+	return ExtractFromBrowserForWeb(teamID)
+}
+
+// ExtractAllFromBrowsersForWeb extracts tokens for every workspace from all
+// supported browsers and saves them to the persistent file. Returns the count
+// of workspaces extracted and any error.
+func ExtractAllFromBrowsersForWeb() (int, error) {
 	if runtime.GOOS != "darwin" {
-		return 0, fmt.Errorf("chrome extraction is only available on macOS")
+		return 0, fmt.Errorf("browser extraction is only available on macOS")
 	}
 
 	extractMu.Lock()
-	profiles, err := findChromeProfiles()
-	if err != nil {
-		extractMu.Unlock()
-		return 0, fmt.Errorf("could not find Chrome profiles: %w", err)
+
+	type extractedWorkspace struct {
+		chromeWorkspace
+		cookie string
+		source string
 	}
 
-	// Extract cookie and all workspace tokens in a single pass.
-	var cookie string
-	for _, profile := range profiles {
-		if c, err := extractCookieFromChrome(profile); err == nil {
-			cookie = c
-			break
+	var allWorkspaces []extractedWorkspace
+	seen := make(map[string]bool)
+
+	for _, src := range browserSources {
+		profiles, err := findBrowserProfiles(src)
+		if err != nil {
+			continue
+		}
+
+		password, pwErr := browserKeychainPassword(src.keychainService)
+
+		var cookie string
+		if pwErr == nil {
+			for _, profile := range profiles {
+				if c, err := extractCookieFromBrowser(profile, password); err == nil {
+					cookie = c
+					break
+				}
+			}
+		}
+
+		workspaces := listWorkspacesWithTokensFromBrowser(profiles)
+		for _, ws := range workspaces {
+			if seen[ws.TeamID] {
+				continue
+			}
+			seen[ws.TeamID] = true
+			allWorkspaces = append(allWorkspaces, extractedWorkspace{
+				chromeWorkspace: ws,
+				cookie:          cookie,
+				source:          strings.ToLower(src.name),
+			})
 		}
 	}
-	workspaces := listWorkspacesWithTokensFromChrome(profiles)
 	extractMu.Unlock()
 
-	if len(workspaces) == 0 {
-		return 0, fmt.Errorf("no Slack workspaces with xoxc-* tokens found in Chrome")
+	if len(allWorkspaces) == 0 {
+		return 0, fmt.Errorf("no Slack workspaces with xoxc-* tokens found in any browser or Slack app")
 	}
 
 	home, _ := os.UserHomeDir()
@@ -111,20 +149,25 @@ func ExtractAllFromChromeForWeb() (int, error) {
 	}
 	store.loadFromFile()
 
-	for _, ws := range workspaces {
+	for _, ws := range allWorkspaces {
 		store.setWorkspace(&workspace{
 			TeamID:   ws.TeamID,
 			TeamName: ws.Name,
 			Token:    ws.Token,
-			Cookie:   cookie,
-			Source:   "chrome",
+			Cookie:   ws.cookie,
+			Source:   ws.source,
 		})
 	}
 
 	if err := store.saveToFile(); err != nil {
-		return len(workspaces), err
+		return len(allWorkspaces), err
 	}
-	return len(workspaces), nil
+	return len(allWorkspaces), nil
+}
+
+// ExtractAllFromChromeForWeb is an alias kept for backward compatibility.
+func ExtractAllFromChromeForWeb() (int, error) {
+	return ExtractAllFromBrowsersForWeb()
 }
 
 // SaveTokensForWeb saves the given token/cookie to the persistent file
@@ -222,10 +265,15 @@ func GetTokenInfoForWeb() *TokenInfo {
 	return info
 }
 
-// CanExtractFromChrome returns true if the current platform supports
-// automatic Chrome extraction (macOS only).
-func CanExtractFromChrome() bool {
+// CanExtractFromBrowser returns true if the current platform supports
+// automatic browser extraction (macOS only).
+func CanExtractFromBrowser() bool {
 	return runtime.GOOS == "darwin"
+}
+
+// CanExtractFromChrome is an alias kept for backward compatibility.
+func CanExtractFromChrome() bool {
+	return CanExtractFromBrowser()
 }
 
 // ConfiguredWorkspaceInfo describes a workspace from the persistent token file.

--- a/integrations/slack/extract.go
+++ b/integrations/slack/extract.go
@@ -93,49 +93,52 @@ func ExtractAllFromBrowsersForWeb() (int, error) {
 		return 0, fmt.Errorf("browser extraction is only available on macOS")
 	}
 
-	extractMu.Lock()
-
 	type extractedWorkspace struct {
 		chromeWorkspace
 		cookie string
 		source string
 	}
 
-	var allWorkspaces []extractedWorkspace
-	seen := make(map[string]bool)
+	allWorkspaces := func() []extractedWorkspace {
+		extractMu.Lock()
+		defer extractMu.Unlock()
 
-	for _, src := range browserSources {
-		profiles, err := findBrowserProfiles(src)
-		if err != nil {
-			continue
-		}
+		var result []extractedWorkspace
+		seen := make(map[string]bool)
 
-		password, pwErr := browserKeychainPassword(src.keychainService)
-
-		var cookie string
-		if pwErr == nil {
-			for _, profile := range profiles {
-				if c, err := extractCookieFromBrowser(profile, password); err == nil {
-					cookie = c
-					break
-				}
-			}
-		}
-
-		workspaces := listWorkspacesWithTokensFromBrowser(profiles)
-		for _, ws := range workspaces {
-			if seen[ws.TeamID] {
+		for _, src := range browserSources {
+			profiles, err := findBrowserProfiles(src)
+			if err != nil {
 				continue
 			}
-			seen[ws.TeamID] = true
-			allWorkspaces = append(allWorkspaces, extractedWorkspace{
-				chromeWorkspace: ws,
-				cookie:          cookie,
-				source:          strings.ToLower(src.name),
-			})
+
+			password, pwErr := browserKeychainPassword(src.keychainService)
+
+			var cookie string
+			if pwErr == nil {
+				for _, profile := range profiles {
+					if c, err := extractCookieFromBrowser(profile, password); err == nil {
+						cookie = c
+						break
+					}
+				}
+			}
+
+			workspaces := listWorkspacesWithTokensFromBrowser(profiles)
+			for _, ws := range workspaces {
+				if seen[ws.TeamID] {
+					continue
+				}
+				seen[ws.TeamID] = true
+				result = append(result, extractedWorkspace{
+					chromeWorkspace: ws,
+					cookie:          cookie,
+					source:          strings.ToLower(src.name),
+				})
+			}
 		}
-	}
-	extractMu.Unlock()
+		return result
+	}()
 
 	if len(allWorkspaces) == 0 {
 		return 0, fmt.Errorf("no Slack workspaces with xoxc-* tokens found in any browser or Slack app")

--- a/integrations/slack/extract_test.go
+++ b/integrations/slack/extract_test.go
@@ -59,13 +59,27 @@ func TestBrowserSources_Coverage(t *testing.T) {
 }
 
 func TestFindBrowserProfiles_NonProfileSource(t *testing.T) {
-	dir := t.TempDir()
-	src := browserSource{name: "Test", dataDir: "nonexistent", hasProfiles: false}
-	// Point to a real temp dir for the non-profile case
-	srcWithRealDir := browserSource{name: "Test", dataDir: "", hasProfiles: false}
-	_ = srcWithRealDir
-	_ = src
-	_ = dir
+	t.Run("nonexistent directory returns error", func(t *testing.T) {
+		src := browserSource{name: "Test", dataDir: "nonexistent", hasProfiles: false}
+		profiles, err := findBrowserProfiles(src)
+		assert.Error(t, err)
+		assert.Nil(t, profiles)
+	})
+
+	t.Run("existing directory returns single-element slice", func(t *testing.T) {
+		home, err := os.UserHomeDir()
+		require.NoError(t, err)
+
+		dir := t.TempDir()
+		rel, err := filepath.Rel(filepath.Join(home, "Library", "Application Support"), dir)
+		require.NoError(t, err)
+
+		src := browserSource{name: "Test", dataDir: rel, hasProfiles: false}
+		profiles, err := findBrowserProfiles(src)
+		require.NoError(t, err)
+		assert.Len(t, profiles, 1)
+		assert.Equal(t, dir, profiles[0])
+	})
 }
 
 func TestListWorkspacesWithTokensFromBrowser(t *testing.T) {

--- a/integrations/slack/extract_test.go
+++ b/integrations/slack/extract_test.go
@@ -35,6 +35,57 @@ func TestCanExtractFromChrome(t *testing.T) {
 	assert.IsType(t, true, result)
 }
 
+func TestCanExtractFromBrowser(t *testing.T) {
+	result := CanExtractFromBrowser()
+	if runtime.GOOS == "darwin" {
+		assert.True(t, result)
+	} else {
+		assert.False(t, result)
+	}
+}
+
+func TestBrowserSources_Coverage(t *testing.T) {
+	assert.GreaterOrEqual(t, len(browserSources), 3, "should have Chrome, Brave, and Slack sources")
+	names := make(map[string]bool)
+	for _, src := range browserSources {
+		assert.NotEmpty(t, src.name)
+		assert.NotEmpty(t, src.dataDir)
+		assert.NotEmpty(t, src.keychainService)
+		names[src.name] = true
+	}
+	assert.True(t, names["Chrome"], "should include Chrome")
+	assert.True(t, names["Brave"], "should include Brave")
+	assert.True(t, names["Slack"], "should include Slack")
+}
+
+func TestFindBrowserProfiles_NonProfileSource(t *testing.T) {
+	dir := t.TempDir()
+	src := browserSource{name: "Test", dataDir: "nonexistent", hasProfiles: false}
+	// Point to a real temp dir for the non-profile case
+	srcWithRealDir := browserSource{name: "Test", dataDir: "", hasProfiles: false}
+	_ = srcWithRealDir
+	_ = src
+	_ = dir
+}
+
+func TestListWorkspacesWithTokensFromBrowser(t *testing.T) {
+	profile := writeSyntheticLevelDB(t, "localConfig_v2", map[string]any{
+		"T001": map[string]any{
+			"token": "xoxc-from-browser",
+			"name":  "Browser Workspace",
+		},
+		"T002": map[string]any{
+			"token": "xoxb-bot-token",
+			"name":  "Bot Only",
+		},
+	})
+
+	workspaces := listWorkspacesWithTokensFromBrowser([]string{profile})
+	assert.Len(t, workspaces, 1)
+	assert.Equal(t, "T001", workspaces[0].TeamID)
+	assert.Equal(t, "xoxc-from-browser", workspaces[0].Token)
+}
+
 func TestWorkspaceInfo_Fields(t *testing.T) {
 	w := WorkspaceInfo{
 		TeamID: "T12345",

--- a/integrations/slack/refresh.go
+++ b/integrations/slack/refresh.go
@@ -159,14 +159,14 @@ func (s *slackIntegration) RefreshStatus() map[string]any {
 	}
 
 	return map[string]any{
-		"token_type":         tokenType,
-		"has_cookie":         ws.Cookie != "",
-		"source":             ws.Source,
-		"updated_at":         ws.UpdatedAt.Format("2006-01-02T15:04:05Z"),
-		"can_cookie_refresh": ws.Cookie != "" && strings.HasPrefix(ws.Token, "xoxc-"),
-		"can_chrome_refresh": CanExtractFromChrome(),
-		"oauth_token":        strings.HasPrefix(ws.Token, "xoxp-"),
-		"needs_refresh":      strings.HasPrefix(ws.Token, "xoxc-"),
+		"token_type":          tokenType,
+		"has_cookie":          ws.Cookie != "",
+		"source":              ws.Source,
+		"updated_at":          ws.UpdatedAt.Format("2006-01-02T15:04:05Z"),
+		"can_cookie_refresh":  ws.Cookie != "" && strings.HasPrefix(ws.Token, "xoxc-"),
+		"can_browser_refresh": CanExtractFromBrowser(),
+		"oauth_token":         strings.HasPrefix(ws.Token, "xoxp-"),
+		"needs_refresh":       strings.HasPrefix(ws.Token, "xoxc-"),
 	}
 }
 

--- a/integrations/slack/slack.go
+++ b/integrations/slack/slack.go
@@ -67,7 +67,7 @@ func (s *slackIntegration) Configure(ctx context.Context, creds mcp.Credentials)
 		s.store.loadFromFile()
 
 		if len(s.store.allWorkspaces()) == 0 {
-			wss, _ := listWorkspacesFromChrome()
+			wss, _ := listWorkspacesFromAllBrowsers()
 			for _, ws := range wss {
 				s.store.setWorkspace(&workspace{
 					TeamID:   ws.TeamID,
@@ -245,7 +245,7 @@ func (s *slackIntegration) tryRefreshWorkspace(teamID string) bool {
 	if s.tryRefreshViaCookieForTeam(teamID) {
 		return true
 	}
-	extracted := extractFromChrome(teamID)
+	extracted := extractFromBrowser(teamID)
 	if extracted == nil {
 		return false
 	}
@@ -255,7 +255,7 @@ func (s *slackIntegration) tryRefreshWorkspace(teamID string) bool {
 		s.buildClientForWorkspace(ws)
 	}
 	_ = s.store.saveToFile()
-	log.Printf("slack: tokens refreshed from Chrome for %s", teamID)
+	log.Printf("slack: tokens refreshed from %s for %s", extracted.source, teamID)
 	return true
 }
 

--- a/integrations/slack/slack.go
+++ b/integrations/slack/slack.go
@@ -249,7 +249,13 @@ func (s *slackIntegration) tryRefreshWorkspace(teamID string) bool {
 	if extracted == nil || extracted.token == "" {
 		return false
 	}
-	s.store.updateTokens(teamID, extracted.token, extracted.cookie)
+	cookie := extracted.cookie
+	if cookie == "" {
+		if ws := s.store.getWorkspace(teamID); ws != nil {
+			cookie = ws.Cookie
+		}
+	}
+	s.store.updateTokens(teamID, extracted.token, cookie)
 	ws := s.store.getWorkspace(teamID)
 	if ws != nil {
 		s.buildClientForWorkspace(ws)

--- a/integrations/slack/slack.go
+++ b/integrations/slack/slack.go
@@ -246,7 +246,7 @@ func (s *slackIntegration) tryRefreshWorkspace(teamID string) bool {
 		return true
 	}
 	extracted := extractFromBrowser(teamID)
-	if extracted == nil {
+	if extracted == nil || extracted.token == "" {
 		return false
 	}
 	s.store.updateTokens(teamID, extracted.token, extracted.cookie)

--- a/integrations/slack/tokens.go
+++ b/integrations/slack/tokens.go
@@ -271,41 +271,79 @@ func (ts *tokenStore) get() (token, cookie string) {
 	return ws.Token, ws.Cookie
 }
 
-// --- Chrome extraction (macOS only) ---
+// --- browser extraction (macOS only) ---
 //
-// Reads tokens directly from Chrome's on-disk storage:
+// Reads tokens from Chromium-based browsers and the Slack desktop app:
 //   - Token (xoxc-*): LevelDB localStorage at <profile>/Local Storage/leveldb/
 //   - Cookie (xoxd-*): Encrypted SQLite cookie DB at <profile>/Cookies
 //
+// Supported sources: Chrome, Brave, Slack desktop app.
 // No AppleScript, no "Allow JavaScript from Apple Events" setting required.
 
-type chromeTokens struct {
+// browserSource describes a Chromium-based browser or Electron app that stores
+// Slack session data in LevelDB + encrypted SQLite cookies.
+type browserSource struct {
+	name            string // human-readable name
+	dataDir         string // relative to ~/Library/Application Support/
+	keychainService string // macOS Keychain "Safe Storage" service name
+	hasProfiles     bool   // true for browsers with Default/Profile dirs
+}
+
+var browserSources = []browserSource{
+	{name: "Chrome", dataDir: "Google/Chrome", keychainService: "Chrome Safe Storage", hasProfiles: true},
+	{name: "Brave", dataDir: "BraveSoftware/Brave-Browser", keychainService: "Brave Safe Storage", hasProfiles: true},
+	{name: "Slack", dataDir: "Slack", keychainService: "Slack Safe Storage", hasProfiles: false},
+}
+
+type browserTokens struct {
 	token  string
 	cookie string
+	source string
 }
 
 var extractMu sync.Mutex
 
-func extractFromChrome(teamID string) *chromeTokens {
-	result, _ := extractFromChromeWithError(teamID)
+func extractFromBrowser(teamID string) *browserTokens {
+	result, _ := extractFromBrowserWithError(teamID)
 	return result
 }
 
-func extractFromChromeWithError(teamID string) (*chromeTokens, error) {
+func extractFromBrowserWithError(teamID string) (*browserTokens, error) {
 	if runtime.GOOS != "darwin" {
-		return nil, fmt.Errorf("chrome extraction is only available on macOS")
+		return nil, fmt.Errorf("browser extraction is only available on macOS")
 	}
 
 	extractMu.Lock()
 	defer extractMu.Unlock()
 
-	profiles, err := findChromeProfiles()
+	var lastErr error
+	for _, src := range browserSources {
+		result, err := extractFromSource(src, teamID)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if result != nil {
+			return result, nil
+		}
+	}
+
+	if lastErr != nil {
+		return nil, fmt.Errorf("could not extract Slack credentials from any browser: %w", lastErr)
+	}
+	return nil, fmt.Errorf("no Chromium-based browser or Slack app found with Slack credentials")
+}
+
+func extractFromSource(src browserSource, teamID string) (*browserTokens, error) {
+	profiles, err := findBrowserProfiles(src)
 	if err != nil {
-		return nil, fmt.Errorf("could not find Chrome profiles: %w", err)
+		return nil, err
 	}
 	if len(profiles) == 0 {
-		return nil, fmt.Errorf("no Chrome profiles found at ~/Library/Application Support/Google/Chrome/")
+		return nil, fmt.Errorf("no profiles found for %s", src.name)
 	}
+
+	password, pwErr := browserKeychainPassword(src.keychainService)
 
 	var token, cookie string
 	var lastTokenErr, lastCookieErr error
@@ -318,8 +356,8 @@ func extractFromChromeWithError(teamID string) (*chromeTokens, error) {
 				token = t
 			}
 		}
-		if cookie == "" {
-			if c, err := extractCookieFromChrome(profile); err != nil {
+		if cookie == "" && pwErr == nil {
+			if c, err := extractCookieFromBrowser(profile, password); err != nil {
 				lastCookieErr = err
 			} else {
 				cookie = c
@@ -331,42 +369,36 @@ func extractFromChromeWithError(teamID string) (*chromeTokens, error) {
 	}
 
 	if token == "" && cookie == "" {
-		msg := "could not extract Slack credentials from Chrome."
+		msg := fmt.Sprintf("no Slack credentials in %s.", src.name)
 		if lastTokenErr != nil {
 			msg += " Token: " + lastTokenErr.Error() + "."
 		}
 		if lastCookieErr != nil {
 			msg += " Cookie: " + lastCookieErr.Error() + "."
 		}
-		msg += " Make sure you are logged in to Slack (app.slack.com) in Chrome."
-		return nil, fmt.Errorf("%s", msg)
-	}
-	if token == "" {
-		msg := "found cookie but no xoxc-* token in Chrome localStorage."
-		if lastTokenErr != nil {
-			msg += " " + lastTokenErr.Error()
-		}
-		return nil, fmt.Errorf("%s", msg)
-	}
-	if cookie == "" {
-		msg := "found token but no xoxd-* cookie in Chrome cookie store."
-		if lastCookieErr != nil {
-			msg += " " + lastCookieErr.Error()
-		}
 		return nil, fmt.Errorf("%s", msg)
 	}
 
-	return &chromeTokens{token: token, cookie: cookie}, nil
+	sourceName := strings.ToLower(src.name)
+	return &browserTokens{token: token, cookie: cookie, source: sourceName}, nil
 }
 
-// findChromeProfiles returns paths to all Chrome profile directories.
-func findChromeProfiles() ([]string, error) {
+// findBrowserProfiles returns profile directory paths for a given browser source.
+func findBrowserProfiles(src browserSource) ([]string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return nil, err
 	}
-	chromeDir := filepath.Join(home, "Library", "Application Support", "Google", "Chrome")
-	entries, err := os.ReadDir(chromeDir)
+	baseDir := filepath.Join(home, "Library", "Application Support", src.dataDir)
+
+	if !src.hasProfiles {
+		if _, err := os.Stat(baseDir); err != nil {
+			return nil, err
+		}
+		return []string{baseDir}, nil
+	}
+
+	entries, err := os.ReadDir(baseDir)
 	if err != nil {
 		return nil, err
 	}
@@ -378,7 +410,7 @@ func findChromeProfiles() ([]string, error) {
 		}
 		name := e.Name()
 		if name == "Default" || strings.HasPrefix(name, "Profile ") {
-			profiles = append(profiles, filepath.Join(chromeDir, name))
+			profiles = append(profiles, filepath.Join(baseDir, name))
 		}
 	}
 	return profiles, nil
@@ -457,46 +489,45 @@ func readSlackLocalConfig(profilePath string) (*slackLocalConfig, error) {
 	return &cfg, nil
 }
 
-// listWorkspacesFromChrome scans all Chrome profiles and returns every Slack
-// workspace that has an xoxc-* token.
-func listWorkspacesFromChrome() ([]WorkspaceInfo, error) {
+// listWorkspacesFromAllBrowsers scans all supported browsers and returns every
+// Slack workspace that has an xoxc-* token.
+func listWorkspacesFromAllBrowsers() ([]WorkspaceInfo, error) {
 	extractMu.Lock()
 	defer extractMu.Unlock()
 
-	profiles, err := findChromeProfiles()
-	if err != nil {
-		return nil, fmt.Errorf("could not find Chrome profiles: %w", err)
-	}
-	if len(profiles) == 0 {
-		return nil, fmt.Errorf("no Chrome profiles found at ~/Library/Application Support/Google/Chrome/")
-	}
-
 	seen := make(map[string]bool)
 	var workspaces []WorkspaceInfo
-	for _, profile := range profiles {
-		cfg, err := readSlackLocalConfig(profile)
+
+	for _, src := range browserSources {
+		profiles, err := findBrowserProfiles(src)
 		if err != nil {
 			continue
 		}
-		for id, team := range cfg.Teams {
-			if seen[id] || !strings.HasPrefix(team.Token, "xoxc-") {
+		for _, profile := range profiles {
+			cfg, err := readSlackLocalConfig(profile)
+			if err != nil {
 				continue
 			}
-			seen[id] = true
-			name := team.Name
-			if name == "" {
-				name = id
+			for id, team := range cfg.Teams {
+				if seen[id] || !strings.HasPrefix(team.Token, "xoxc-") {
+					continue
+				}
+				seen[id] = true
+				name := team.Name
+				if name == "" {
+					name = id
+				}
+				workspaces = append(workspaces, WorkspaceInfo{
+					TeamID: id,
+					Name:   name,
+					URL:    team.URL,
+				})
 			}
-			workspaces = append(workspaces, WorkspaceInfo{
-				TeamID: id,
-				Name:   name,
-				URL:    team.URL,
-			})
 		}
 	}
 
 	if len(workspaces) == 0 {
-		return nil, fmt.Errorf("no Slack workspaces with xoxc-* tokens found in Chrome, make sure you are logged in to Slack at app.slack.com")
+		return nil, fmt.Errorf("no Slack workspaces with xoxc-* tokens found in any browser or Slack app")
 	}
 	return workspaces, nil
 }
@@ -508,11 +539,9 @@ type chromeWorkspace struct {
 	Token  string
 }
 
-// listWorkspacesWithTokensFromChrome scans all Chrome profiles and returns
-// every Slack workspace with its xoxc-* token. Unlike listWorkspacesFromChrome,
-// this includes the token so callers don't need to re-read the LevelDB.
-// Must be called with extractMu held.
-func listWorkspacesWithTokensFromChrome(profiles []string) []chromeWorkspace {
+// listWorkspacesWithTokensFromBrowser scans profiles and returns every Slack
+// workspace with its xoxc-* token. Must be called with extractMu held.
+func listWorkspacesWithTokensFromBrowser(profiles []string) []chromeWorkspace {
 	seen := make(map[string]bool)
 	var workspaces []chromeWorkspace
 	for _, profile := range profiles {
@@ -568,11 +597,11 @@ func extractTokenFromLevelDB(profilePath, teamID string) (string, error) {
 	return "", fmt.Errorf("no xoxc-* token in localConfig_v2 for profile %s", filepath.Base(profilePath))
 }
 
-// extractCookieFromChrome reads the xoxd-* session cookie from Chrome's
-// encrypted SQLite cookie database. It copies the DB to a temp file (Chrome
-// holds a lock while running), reads the Chrome Safe Storage password from
-// the macOS Keychain, and decrypts the cookie value using AES-128-CBC.
-func extractCookieFromChrome(profilePath string) (string, error) {
+// extractCookieFromBrowser reads the xoxd-* session cookie from a Chromium-based
+// browser's encrypted SQLite cookie database. It copies the DB to a temp file
+// (the browser holds a lock while running) and decrypts the cookie value using
+// AES-128-CBC with the provided keychain password.
+func extractCookieFromBrowser(profilePath, password string) (string, error) {
 	cookiesFile := filepath.Join(profilePath, "Cookies")
 	if _, err := os.Stat(cookiesFile); err != nil {
 		return "", fmt.Errorf("no Cookies file at %s", cookiesFile)
@@ -587,11 +616,6 @@ func extractCookieFromChrome(profilePath string) (string, error) {
 	tmpFile := filepath.Join(tmpDir, "Cookies")
 	if err := copyFile(cookiesFile, tmpFile); err != nil {
 		return "", fmt.Errorf("copying Cookies DB: %w", err)
-	}
-
-	password, err := chromeKeychainPassword()
-	if err != nil {
-		return "", err
 	}
 
 	db, err := sqlite3.Open(tmpFile)
@@ -633,13 +657,13 @@ func extractCookieFromChrome(profilePath string) (string, error) {
 	return cookie, nil
 }
 
-// chromeKeychainPassword retrieves the Chrome Safe Storage encryption key
-// from the macOS Keychain via the security command.
-func chromeKeychainPassword() (string, error) {
-	out, err := exec.Command("security", "find-generic-password",
-		"-s", "Chrome Safe Storage", "-w").Output()
+// browserKeychainPassword retrieves the Safe Storage encryption key for a
+// browser/app from the macOS Keychain via the security command.
+func browserKeychainPassword(service string) (string, error) {
+	out, err := exec.Command("security", "find-generic-password", // #nosec G204 — service is from hardcoded browserSources
+		"-s", service, "-w").Output()
 	if err != nil {
-		return "", fmt.Errorf("could not read Chrome Safe Storage from Keychain: %w", err)
+		return "", fmt.Errorf("could not read %s from Keychain: %w", service, err)
 	}
 	return strings.TrimSpace(string(out)), nil
 }
@@ -756,10 +780,10 @@ func tokenStatus(_ context.Context, s *slackIntegration, args map[string]any) (*
 	}
 
 	refreshInfo := map[string]any{
-		"enabled":        true,
-		"interval":       "4 hours",
-		"chrome_refresh": CanExtractFromChrome(),
-		"platform":       runtime.GOOS,
+		"enabled":         true,
+		"interval":        "4 hours",
+		"browser_refresh": CanExtractFromBrowser(),
+		"platform":        runtime.GOOS,
 	}
 
 	return mcp.JSONResult(map[string]any{
@@ -788,7 +812,7 @@ func refreshTokens(ctx context.Context, s *slackIntegration, args map[string]any
 
 	if ok := s.tryRefresh(); !ok {
 		return &mcp.ToolResult{
-			Data:    "Could not refresh tokens. Tried cookie-based refresh and Chrome extraction. Make sure you have a valid cookie or Chrome is running with Slack open.",
+			Data:    "Could not refresh tokens. Tried cookie-based refresh and browser extraction. Make sure you have a valid cookie or a supported browser (Chrome, Brave, Slack app) is running with Slack open.",
 			IsError: true,
 		}, nil
 	}

--- a/integrations/slack/tokens.go
+++ b/integrations/slack/tokens.go
@@ -416,7 +416,7 @@ func findBrowserProfiles(src browserSource) ([]string, error) {
 	return profiles, nil
 }
 
-// slackLocalConfig represents the parsed structure of Chrome's localStorage
+// slackLocalConfig represents the parsed structure of the browser's localStorage
 // localConfig_v2 (or later versions) for Slack.
 type slackLocalConfig struct {
 	Teams map[string]struct {
@@ -426,7 +426,7 @@ type slackLocalConfig struct {
 	} `json:"teams"`
 }
 
-// readSlackLocalConfig reads and parses Chrome's localStorage LevelDB for Slack
+// readSlackLocalConfig reads and parses the browser's localStorage LevelDB for Slack
 // config data from the given profile path. Returns the parsed config.
 func readSlackLocalConfig(profilePath string) (*slackLocalConfig, error) {
 	ldbDir := filepath.Join(profilePath, "Local Storage", "leveldb")
@@ -532,8 +532,8 @@ func listWorkspacesFromAllBrowsers() ([]WorkspaceInfo, error) {
 	return workspaces, nil
 }
 
-// chromeWorkspace is an internal type that includes the token from Chrome extraction.
-type chromeWorkspace struct {
+// browserWorkspace is an internal type that includes the token from browser extraction.
+type browserWorkspace struct {
 	TeamID string
 	Name   string
 	Token  string
@@ -541,9 +541,9 @@ type chromeWorkspace struct {
 
 // listWorkspacesWithTokensFromBrowser scans profiles and returns every Slack
 // workspace with its xoxc-* token. Must be called with extractMu held.
-func listWorkspacesWithTokensFromBrowser(profiles []string) []chromeWorkspace {
+func listWorkspacesWithTokensFromBrowser(profiles []string) []browserWorkspace {
 	seen := make(map[string]bool)
-	var workspaces []chromeWorkspace
+	var workspaces []browserWorkspace
 	for _, profile := range profiles {
 		cfg, err := readSlackLocalConfig(profile)
 		if err != nil {
@@ -558,7 +558,7 @@ func listWorkspacesWithTokensFromBrowser(profiles []string) []chromeWorkspace {
 			if name == "" {
 				name = id
 			}
-			workspaces = append(workspaces, chromeWorkspace{
+			workspaces = append(workspaces, browserWorkspace{
 				TeamID: id,
 				Name:   name,
 				Token:  team.Token,
@@ -568,8 +568,8 @@ func listWorkspacesWithTokensFromBrowser(profiles []string) []chromeWorkspace {
 	return workspaces
 }
 
-// extractTokenFromLevelDB reads the xoxc-* token from Chrome's localStorage
-// LevelDB. Chrome holds a lock on the DB while running, so we copy the files
+// extractTokenFromLevelDB reads the xoxc-* token from the browser's localStorage
+// LevelDB. The browser holds a lock on the DB while running, so we copy the files
 // to a temp directory first. If teamID is non-empty, only that workspace's
 // token is returned.
 func extractTokenFromLevelDB(profilePath, teamID string) (string, error) {

--- a/web/templates/pages/slack_setup.templ
+++ b/web/templates/pages/slack_setup.templ
@@ -122,12 +122,12 @@ templ SlackSetup(page layouts.PageData, data SlackSetupData) {
 
 		if data.CanAutoExtract {
 			<div class="card">
-				<div class="card-title" style="margin-bottom: 0.75rem;">Option 1: Auto-Extract from Chrome</div>
+				<div class="card-title" style="margin-bottom: 0.75rem;">Option 1: Auto-Extract from Browser</div>
 				<p class="slack-desc">
-					Automatically extracts session tokens and cookies for <strong>all workspaces</strong> from a running Chrome browser with Slack open. Requires macOS and Chrome with a Slack tab at <code>app.slack.com</code>.
+					Automatically extracts session tokens and cookies for <strong>all workspaces</strong> from Chrome, Brave, or the Slack desktop app. Requires macOS with at least one of these installed and signed in to Slack.
 				</p>
 				<form method="POST" action="/api/slack/extract-chrome" style="margin-top: 0.75rem;">
-					<button type="submit" class="btn">Extract All Workspaces from Chrome</button>
+					<button type="submit" class="btn">Extract All Workspaces</button>
 				</form>
 			</div>
 		}

--- a/web/templates/pages/slack_setup.templ
+++ b/web/templates/pages/slack_setup.templ
@@ -126,7 +126,7 @@ templ SlackSetup(page layouts.PageData, data SlackSetupData) {
 				<p class="slack-desc">
 					Automatically extracts session tokens and cookies for <strong>all workspaces</strong> from Chrome, Brave, or the Slack desktop app. Requires macOS with at least one of these installed and signed in to Slack.
 				</p>
-				<form method="POST" action="/api/slack/extract-chrome" style="margin-top: 0.75rem;">
+				<form method="POST" action="/api/slack/extract-browser" style="margin-top: 0.75rem;">
 					<button type="submit" class="btn">Extract All Workspaces</button>
 				</form>
 			</div>

--- a/web/templates/pages/slack_setup_templ.go
+++ b/web/templates/pages/slack_setup_templ.go
@@ -322,7 +322,7 @@ func SlackSetup(page layouts.PageData, data SlackSetupData) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			if data.CanAutoExtract {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "<div class=\"card\"><div class=\"card-title\" style=\"margin-bottom: 0.75rem;\">Option 1: Auto-Extract from Browser</div><p class=\"slack-desc\">Automatically extracts session tokens and cookies for <strong>all workspaces</strong> from Chrome, Brave, or the Slack desktop app. Requires macOS with at least one of these installed and signed in to Slack.</p><form method=\"POST\" action=\"/api/slack/extract-chrome\" style=\"margin-top: 0.75rem;\"><button type=\"submit\" class=\"btn\">Extract All Workspaces</button></form></div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "<div class=\"card\"><div class=\"card-title\" style=\"margin-bottom: 0.75rem;\">Option 1: Auto-Extract from Browser</div><p class=\"slack-desc\">Automatically extracts session tokens and cookies for <strong>all workspaces</strong> from Chrome, Brave, or the Slack desktop app. Requires macOS with at least one of these installed and signed in to Slack.</p><form method=\"POST\" action=\"/api/slack/extract-browser\" style=\"margin-top: 0.75rem;\"><button type=\"submit\" class=\"btn\">Extract All Workspaces</button></form></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}

--- a/web/templates/pages/slack_setup_templ.go
+++ b/web/templates/pages/slack_setup_templ.go
@@ -322,7 +322,7 @@ func SlackSetup(page layouts.PageData, data SlackSetupData) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			if data.CanAutoExtract {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "<div class=\"card\"><div class=\"card-title\" style=\"margin-bottom: 0.75rem;\">Option 1: Auto-Extract from Chrome</div><p class=\"slack-desc\">Automatically extracts session tokens and cookies for <strong>all workspaces</strong> from a running Chrome browser with Slack open. Requires macOS and Chrome with a Slack tab at <code>app.slack.com</code>.</p><form method=\"POST\" action=\"/api/slack/extract-chrome\" style=\"margin-top: 0.75rem;\"><button type=\"submit\" class=\"btn\">Extract All Workspaces from Chrome</button></form></div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "<div class=\"card\"><div class=\"card-title\" style=\"margin-bottom: 0.75rem;\">Option 1: Auto-Extract from Browser</div><p class=\"slack-desc\">Automatically extracts session tokens and cookies for <strong>all workspaces</strong> from Chrome, Brave, or the Slack desktop app. Requires macOS with at least one of these installed and signed in to Slack.</p><form method=\"POST\" action=\"/api/slack/extract-chrome\" style=\"margin-top: 0.75rem;\"><button type=\"submit\" class=\"btn\">Extract All Workspaces</button></form></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}

--- a/web/web.go
+++ b/web/web.go
@@ -600,11 +600,16 @@ func (w *WebServer) handleSlackSetup(rw http.ResponseWriter, r *http.Request) {
 		tokenSource = info.Source
 	}
 
+	tokenStatus := info.Status
+	if healthy && tokenStatus != "healthy" {
+		tokenStatus = "healthy"
+	}
+
 	page := w.pageData(r, "Slack Setup", "/integrations")
 	data := pages.SlackSetupData{
 		HasToken:       info.HasToken,
 		HasCookie:      info.HasCookie,
-		TokenStatus:    info.Status,
+		TokenStatus:    tokenStatus,
 		TokenAge:       info.AgeHours,
 		TokenSource:    tokenSource,
 		CanAutoExtract: slackInt.CanExtractFromChrome(),

--- a/web/web.go
+++ b/web/web.go
@@ -667,10 +667,10 @@ func (w *WebServer) handleSlackExtractChrome(rw http.ResponseWriter, r *http.Req
 		ic = &mcp.IntegrationConfig{Credentials: mcp.Credentials{}}
 	}
 	ic.Enabled = true
-	ic.Credentials[mcp.CredKeyTokenSource] = "chrome"
+	ic.Credentials[mcp.CredKeyTokenSource] = "browser"
 	_ = w.services.Config.SetIntegration("slack", ic)
 
-	http.Redirect(rw, r, fmt.Sprintf("/integrations/slack/setup?result=Extracted+%d+workspaces+from+Chrome", count), http.StatusSeeOther)
+	http.Redirect(rw, r, fmt.Sprintf("/integrations/slack/setup?result=Extracted+%d+workspaces+from+browser", count), http.StatusSeeOther)
 }
 
 func (w *WebServer) handleGitHubSetup(rw http.ResponseWriter, r *http.Request) {

--- a/web/web.go
+++ b/web/web.go
@@ -58,7 +58,7 @@ func (w *WebServer) Handler() http.Handler {
 
 	mux.HandleFunc("GET /integrations/slack/setup", w.handleSlackSetup)
 	mux.HandleFunc("GET /api/slack/list-workspaces", w.handleSlackListWorkspaces)
-	mux.HandleFunc("POST /api/slack/extract-chrome", w.handleSlackExtractChrome)
+	mux.HandleFunc("POST /api/slack/extract-browser", w.handleSlackExtractBrowser)
 	mux.HandleFunc("POST /api/slack/save-tokens", w.handleSlackSaveTokens)
 	mux.HandleFunc("POST /api/slack/set-default", w.handleSlackSetDefault)
 
@@ -649,7 +649,7 @@ func (w *WebServer) handleSlackListWorkspaces(rw http.ResponseWriter, r *http.Re
 	json.NewEncoder(rw).Encode(map[string]any{"workspaces": workspaces})
 }
 
-func (w *WebServer) handleSlackExtractChrome(rw http.ResponseWriter, r *http.Request) {
+func (w *WebServer) handleSlackExtractBrowser(rw http.ResponseWriter, r *http.Request) {
 	if err := r.ParseForm(); err != nil {
 		http.Redirect(rw, r, "/integrations/slack/setup?error=Invalid+form+data", http.StatusSeeOther)
 		return

--- a/web/web.go
+++ b/web/web.go
@@ -612,7 +612,7 @@ func (w *WebServer) handleSlackSetup(rw http.ResponseWriter, r *http.Request) {
 		TokenStatus:    tokenStatus,
 		TokenAge:       info.AgeHours,
 		TokenSource:    tokenSource,
-		CanAutoExtract: slackInt.CanExtractFromChrome(),
+		CanAutoExtract: slackInt.CanExtractFromBrowser(),
 		ExtractSnippet: slackInt.ExtractionSnippet(),
 		Healthy:        healthy,
 		WorkspaceCount: info.WorkspaceCount,
@@ -641,7 +641,7 @@ func (w *WebServer) handleSlackSetup(rw http.ResponseWriter, r *http.Request) {
 
 func (w *WebServer) handleSlackListWorkspaces(rw http.ResponseWriter, r *http.Request) {
 	rw.Header().Set("Content-Type", "application/json")
-	workspaces, err := slackInt.ListWorkspacesFromChrome()
+	workspaces, err := slackInt.ListWorkspacesFromBrowsers()
 	if err != nil {
 		json.NewEncoder(rw).Encode(map[string]any{"error": err.Error()})
 		return
@@ -655,7 +655,7 @@ func (w *WebServer) handleSlackExtractChrome(rw http.ResponseWriter, r *http.Req
 		return
 	}
 
-	count, err := slackInt.ExtractAllFromChromeForWeb()
+	count, err := slackInt.ExtractAllFromBrowsersForWeb()
 	if err != nil {
 		http.Redirect(rw, r, "/integrations/slack/setup?error="+strings.ReplaceAll(err.Error(), " ", "+"), http.StatusSeeOther)
 		return


### PR DESCRIPTION

## Summary

- **Fix EXPIRED badge**: The Slack Token Setup page showed "EXPIRED" even when the token was connected and working. The badge now uses the actual `auth.test` result instead of a stale age-based heuristic.
- **Multi-browser extraction**: Auto-extraction now supports **Chrome, Brave, and the Slack desktop app** (all Chromium/Electron-based with the same LevelDB + encrypted SQLite cookie format). Introduces a `browserSource` abstraction so adding more browsers is a one-liner.
- **Slack desktop app support**: Reads tokens directly from `~/Library/Application Support/Slack/` using "Slack Safe Storage" Keychain entry — no browser needed at all.

## Test plan

- [x] `go test ./integrations/slack/` passes (new tests for `browserSources`, `listWorkspacesWithTokensFromBrowser`)
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [ ] Manual: verify web UI shows "Healthy" badge when token is connected
- [ ] Manual: verify "Extract All Workspaces" pulls from Slack app when Chrome is not installed


🐰 Generated with Crush