### PR TITLE
feat: add Docker image publishing to release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   release:
@@ -20,6 +21,14 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.RELEASE_TOKEN }}
 
       - uses: goreleaser/goreleaser-action@v6
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -105,6 +105,34 @@ nfpms:
       postinstall: scripts/postinstall.sh
       preremove: scripts/preremove.sh
 
+dockers:
+  - image_templates:
+      - "ghcr.io/daltoniam/switchboard:{{ .Version }}-amd64"
+    use: buildx
+    goos: linux
+    goarch: amd64
+    dockerfile: Dockerfile
+    build_flag_templates:
+      - "--platform=linux/amd64"
+  - image_templates:
+      - "ghcr.io/daltoniam/switchboard:{{ .Version }}-arm64"
+    use: buildx
+    goos: linux
+    goarch: arm64
+    dockerfile: Dockerfile
+    build_flag_templates:
+      - "--platform=linux/arm64"
+
+docker_manifests:
+  - name_template: "ghcr.io/daltoniam/switchboard:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/daltoniam/switchboard:{{ .Version }}-amd64"
+      - "ghcr.io/daltoniam/switchboard:{{ .Version }}-arm64"
+  - name_template: "ghcr.io/daltoniam/switchboard:latest"
+    image_templates:
+      - "ghcr.io/daltoniam/switchboard:{{ .Version }}-amd64"
+      - "ghcr.io/daltoniam/switchboard:{{ .Version }}-arm64"
+
 release:
   github:
     owner: daltoniam

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine:3.21 AS certs
+RUN apk add --no-cache ca-certificates
+
+FROM scratch
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY switchboard /switchboard
+
+EXPOSE 3847
+ENTRYPOINT ["/switchboard"]
+CMD ["--port", "3847"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM alpine:3.21 AS certs
 RUN apk add --no-cache ca-certificates
 
 FROM scratch
+ENV HOME=/root
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY switchboard /switchboard
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  switchboard:
+    image: ghcr.io/daltoniam/switchboard:latest
+    ports:
+      - "3847:3847"
+    environment:
+      - GITHUB_TOKEN=${GITHUB_TOKEN}
+      - LINEAR_API_KEY=${LINEAR_API_KEY}
+      - SLACK_TOKEN=${SLACK_TOKEN}
+      - SENTRY_AUTH_TOKEN=${SENTRY_AUTH_TOKEN}
+      - DD_API_KEY=${DD_API_KEY}
+      - DD_APP_KEY=${DD_APP_KEY}
+    volumes:
+      - switchboard-config:/root/.config/switchboard
+    restart: unless-stopped
+
+volumes:
+  switchboard-config:


### PR DESCRIPTION
## Summary

- Add multi-arch Docker images (amd64/arm64) to the release pipeline, published to `ghcr.io/daltoniam/switchboard` via goreleaser buildx
- Minimal `scratch`-based Dockerfile with CA certs for HTTPS connectivity
- Example `docker-compose.yml` for quick local setup with env var passthrough and config volume persistence

## Changes

| File | What |
|------|------|
| `Dockerfile` | Multi-stage: Alpine for CA certs → `scratch` final with static binary |
| `.goreleaser.yml` | `dockers` (amd64 + arm64 buildx) + `docker_manifests` (versioned + `latest`) |
| `.github/workflows/release.yml` | `packages: write` perm, `setup-buildx-action`, `login-action` for GHCR |
| `docker-compose.yml` | Example compose with env vars and named config volume |

## Usage

```bash
# Env vars (simplest)
docker run -d -p 3847:3847 \
  -e GITHUB_TOKEN=ghp_xxx \
  ghcr.io/daltoniam/switchboard:latest

# With persistent config
docker run -d -p 3847:3847 \
  -v ~/.config/switchboard:/root/.config/switchboard \
  ghcr.io/daltoniam/switchboard:latest

# Docker Compose
docker compose up -d
```

## Test plan

- [ ] Verify `RELEASE_TOKEN` has `write:packages` scope for GHCR push
- [ ] Trigger a test release and confirm images appear at `ghcr.io/daltoniam/switchboard`
- [ ] Pull and run the image locally to verify the server starts and responds on `:3847`


🐘 Generated with Crush