### PR TITLE
Add custom field support to Jira create/update issue

### DIFF
--- a/integrations/jira/issues.go
+++ b/integrations/jira/issues.go
@@ -90,6 +90,15 @@ func createIssue(ctx context.Context, j *jira, args map[string]any) (*mcp.ToolRe
 	if v := r.Str("parent_key"); v != "" {
 		fields["parent"] = map[string]string{"key": v}
 	}
+	if cfStr := r.Str("custom_fields"); cfStr != "" {
+		var cf map[string]any
+		if err := json.Unmarshal([]byte(cfStr), &cf); err != nil {
+			return mcp.ErrResult(fmt.Errorf("invalid JSON for custom_fields: %w", err))
+		}
+		for k, v := range cf {
+			fields[k] = v
+		}
+	}
 	if err := r.Err(); err != nil {
 		return mcp.ErrResult(err)
 	}
@@ -127,6 +136,15 @@ func updateIssue(ctx context.Context, j *jira, args map[string]any) (*mcp.ToolRe
 			rawLabels[i] = strings.TrimSpace(l)
 		}
 		fields["labels"] = rawLabels
+	}
+	if cfStr := r.Str("custom_fields"); cfStr != "" {
+		var cf map[string]any
+		if err := json.Unmarshal([]byte(cfStr), &cf); err != nil {
+			return mcp.ErrResult(fmt.Errorf("invalid JSON for custom_fields: %w", err))
+		}
+		for k, v := range cf {
+			fields[k] = v
+		}
 	}
 	issueKey := r.Str("issue_key")
 	if err := r.Err(); err != nil {

--- a/integrations/jira/issues.go
+++ b/integrations/jira/issues.go
@@ -10,6 +10,15 @@ import (
 	mcp "github.com/daltoniam/switchboard"
 )
 
+// standardFields are the Jira field keys managed by explicit tool parameters.
+// Custom fields passed via custom_fields must not collide with these to prevent
+// overwriting already-formatted values (e.g. priority as {"name":"High"}).
+var standardFields = map[string]bool{
+	"project": true, "issuetype": true, "summary": true,
+	"description": true, "priority": true, "assignee": true,
+	"labels": true, "parent": true,
+}
+
 func searchIssues(ctx context.Context, j *jira, args map[string]any) (*mcp.ToolResult, error) {
 	r := mcp.NewArgs(args)
 	body := map[string]any{
@@ -96,7 +105,9 @@ func createIssue(ctx context.Context, j *jira, args map[string]any) (*mcp.ToolRe
 			return mcp.ErrResult(fmt.Errorf("invalid JSON for custom_fields: %w", err))
 		}
 		for k, v := range cf {
-			fields[k] = v
+			if !standardFields[k] {
+				fields[k] = v
+			}
 		}
 	}
 	if err := r.Err(); err != nil {
@@ -143,7 +154,9 @@ func updateIssue(ctx context.Context, j *jira, args map[string]any) (*mcp.ToolRe
 			return mcp.ErrResult(fmt.Errorf("invalid JSON for custom_fields: %w", err))
 		}
 		for k, v := range cf {
-			fields[k] = v
+			if !standardFields[k] {
+				fields[k] = v
+			}
 		}
 	}
 	issueKey := r.Str("issue_key")

--- a/integrations/jira/jira_test.go
+++ b/integrations/jira/jira_test.go
@@ -449,6 +449,22 @@ func TestUpdateIssue_CustomFields(t *testing.T) {
 			},
 		},
 		{
+			name: "standard field keys in custom_fields are ignored",
+			args: map[string]any{
+				"issue_key":     "PROJ-1",
+				"priority":      "High",
+				"custom_fields": `{"priority": "Low", "customfield_10001": "value"}`,
+			},
+			checkBody: func(t *testing.T, body map[string]any) {
+				fields := body["fields"].(map[string]any)
+				// explicit priority param wins — custom_fields must not overwrite it
+				prio := fields["priority"].(map[string]any)
+				assert.Equal(t, "High", prio["name"])
+				// non-standard field still set
+				assert.Equal(t, "value", fields["customfield_10001"])
+			},
+		},
+		{
 			name: "invalid JSON returns error",
 			args: map[string]any{
 				"issue_key":     "PROJ-1",

--- a/integrations/jira/jira_test.go
+++ b/integrations/jira/jira_test.go
@@ -400,6 +400,155 @@ func TestSearchIssues(t *testing.T) {
 	}
 }
 
+func TestUpdateIssue_CustomFields(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       map[string]any
+		wantErr    bool
+		wantErrMsg string
+		checkBody  func(t *testing.T, body map[string]any)
+	}{
+		{
+			name: "merges custom fields with standard fields",
+			args: map[string]any{
+				"issue_key":     "PROJ-1",
+				"summary":       "Updated title",
+				"custom_fields": `{"customfield_10001": "hello"}`,
+			},
+			checkBody: func(t *testing.T, body map[string]any) {
+				fields := body["fields"].(map[string]any)
+				assert.Equal(t, "Updated title", fields["summary"])
+				assert.Equal(t, "hello", fields["customfield_10001"])
+			},
+		},
+		{
+			name: "custom fields only",
+			args: map[string]any{
+				"issue_key":     "PROJ-1",
+				"custom_fields": `{"customfield_10001": "value"}`,
+			},
+			checkBody: func(t *testing.T, body map[string]any) {
+				fields := body["fields"].(map[string]any)
+				assert.Equal(t, "value", fields["customfield_10001"])
+				_, hasSummary := fields["summary"]
+				assert.False(t, hasSummary)
+			},
+		},
+		{
+			name: "complex custom field values",
+			args: map[string]any{
+				"issue_key":     "PROJ-1",
+				"custom_fields": `{"customfield_10002": {"id": "10100"}, "customfield_10003": [{"id": "10200"}]}`,
+			},
+			checkBody: func(t *testing.T, body map[string]any) {
+				fields := body["fields"].(map[string]any)
+				selectField := fields["customfield_10002"].(map[string]any)
+				assert.Equal(t, "10100", selectField["id"])
+				multiSelect := fields["customfield_10003"].([]any)
+				assert.Len(t, multiSelect, 1)
+			},
+		},
+		{
+			name: "invalid JSON returns error",
+			args: map[string]any{
+				"issue_key":     "PROJ-1",
+				"custom_fields": `{invalid`,
+			},
+			wantErr:    true,
+			wantErrMsg: "invalid JSON for custom_fields",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "PUT", r.Method)
+				if tt.checkBody != nil {
+					var body map[string]any
+					require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+					tt.checkBody(t, body)
+				}
+				w.WriteHeader(204)
+			}))
+			defer ts.Close()
+
+			j := &jira{email: "u@test.com", apiToken: "tok", client: ts.Client(), baseURL: ts.URL, agileURL: ts.URL}
+			result, err := updateIssue(context.Background(), j, tt.args)
+			require.NoError(t, err)
+			if tt.wantErr {
+				assert.True(t, result.IsError)
+				assert.Contains(t, result.Data, tt.wantErrMsg)
+			} else {
+				assert.False(t, result.IsError)
+			}
+		})
+	}
+}
+
+func TestCreateIssue_CustomFields(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       map[string]any
+		wantErr    bool
+		wantErrMsg string
+		checkBody  func(t *testing.T, body map[string]any)
+	}{
+		{
+			name: "merges custom fields into creation request",
+			args: map[string]any{
+				"project_key":   "PROJ",
+				"issue_type":    "Task",
+				"summary":       "New issue",
+				"custom_fields": `{"customfield_10001": "story points", "customfield_10002": {"id": "10100"}}`,
+			},
+			checkBody: func(t *testing.T, body map[string]any) {
+				fields := body["fields"].(map[string]any)
+				assert.Equal(t, "New issue", fields["summary"])
+				assert.Equal(t, "story points", fields["customfield_10001"])
+				selectField := fields["customfield_10002"].(map[string]any)
+				assert.Equal(t, "10100", selectField["id"])
+			},
+		},
+		{
+			name: "invalid JSON returns error",
+			args: map[string]any{
+				"project_key":   "PROJ",
+				"issue_type":    "Task",
+				"summary":       "New issue",
+				"custom_fields": `not json`,
+			},
+			wantErr:    true,
+			wantErrMsg: "invalid JSON for custom_fields",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "POST", r.Method)
+				if tt.checkBody != nil {
+					var body map[string]any
+					require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+					tt.checkBody(t, body)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.Write([]byte(`{"id":"10001","key":"PROJ-1"}`))
+			}))
+			defer ts.Close()
+
+			j := &jira{email: "u@test.com", apiToken: "tok", client: ts.Client(), baseURL: ts.URL, agileURL: ts.URL}
+			result, err := createIssue(context.Background(), j, tt.args)
+			require.NoError(t, err)
+			if tt.wantErr {
+				assert.True(t, result.IsError)
+				assert.Contains(t, result.Data, tt.wantErrMsg)
+			} else {
+				assert.False(t, result.IsError)
+			}
+		})
+	}
+}
+
 func TestTextToADF(t *testing.T) {
 	adf := textToADF("Hello\nWorld")
 	assert.Equal(t, "doc", adf["type"])

--- a/integrations/jira/tools.go
+++ b/integrations/jira/tools.go
@@ -15,13 +15,13 @@ var tools = []mcp.ToolDefinition{
 		Required:   []string{"issue_key"},
 	},
 	{
-		Name: mcp.ToolName("jira_create_issue"), Description: "Create a new issue. Use jira_list_issue_types to find valid issue type names for the project",
-		Parameters: map[string]string{"project_key": "Project key (e.g., PROJ)", "issue_type": "Issue type name (e.g., Bug, Task, Story)", "summary": "Issue summary/title", "description": "Issue description (plain text, converted to ADF)", "priority": "Priority name (e.g., High, Medium, Low)", "assignee_id": "Account ID of assignee (use jira_search_users to find)", "labels": "Comma-separated labels", "parent_key": "Parent issue key for subtasks (e.g., PROJ-100)"},
+		Name: mcp.ToolName("jira_create_issue"), Description: "Create a new issue. Use jira_list_issue_types to find valid issue type names. Supports custom fields — use jira_list_fields to discover field IDs",
+		Parameters: map[string]string{"project_key": "Project key (e.g., PROJ)", "issue_type": "Issue type name (e.g., Bug, Task, Story)", "summary": "Issue summary/title", "description": "Issue description (plain text, converted to ADF)", "priority": "Priority name (e.g., High, Medium, Low)", "assignee_id": "Account ID of assignee (use jira_search_users to find)", "labels": "Comma-separated labels", "parent_key": "Parent issue key for subtasks (e.g., PROJ-100)", "custom_fields": `JSON object of custom field values keyed by field ID (e.g. {"customfield_10001": "value", "customfield_10002": {"id": "10100"}}). Use jira_list_fields to discover field IDs and types`},
 		Required:   []string{"project_key", "issue_type", "summary"},
 	},
 	{
-		Name: mcp.ToolName("jira_update_issue"), Description: "Update an existing issue's fields",
-		Parameters: map[string]string{"issue_key": "Issue key (e.g., PROJ-123)", "summary": "New summary", "description": "New description (plain text, converted to ADF)", "priority": "Priority name", "assignee_id": "Account ID of assignee (empty string to unassign)", "labels": "Comma-separated labels (replaces existing)"},
+		Name: mcp.ToolName("jira_update_issue"), Description: "Update an existing issue's fields including custom fields — use jira_list_fields to discover custom field IDs",
+		Parameters: map[string]string{"issue_key": "Issue key (e.g., PROJ-123)", "summary": "New summary", "description": "New description (plain text, converted to ADF)", "priority": "Priority name", "assignee_id": "Account ID of assignee (empty string to unassign)", "labels": "Comma-separated labels (replaces existing)", "custom_fields": `JSON object of custom field values keyed by field ID (e.g. {"customfield_10001": "value", "customfield_10002": {"id": "10100"}}). Use jira_list_fields to discover field IDs and types`},
 		Required:   []string{"issue_key"},
 	},
 	{


### PR DESCRIPTION
## Summary
- Adds a `custom_fields` JSON parameter to `jira_create_issue` and `jira_update_issue` that accepts field values keyed by Jira field ID (e.g. `{"customfield_10001": "value"}`)
- Custom field values are merged into the fields payload sent to Jira's REST API, supporting all field types (text, select, multi-select, date, user, etc.)
- Users discover field IDs and types via the existing `jira_list_fields` tool — no client-side validation, Jira API returns clear errors for invalid fields

## Test plan
- [x] Table-driven tests for `updateIssue`: standard+custom merge, custom-only, complex values (select/multi-select objects), invalid JSON error
- [x] Table-driven tests for `createIssue`: custom fields in creation request, invalid JSON error
- [x] All existing tests pass
- [x] `go vet` clean
- [ ] Live smoke test: `jira_list_fields` → pick a custom field → `jira_update_issue` with `custom_fields`

🤖 Generated with [Claude Code](https://claude.com/claude-code)