### PR TITLE
Fix Docker push permission denied by using GITHUB_TOKEN for GHCR login

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,8 @@ jobs:
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.RELEASE_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: goreleaser/goreleaser-action@v6
         with:


### PR DESCRIPTION

## Summary

- The `RELEASE_TOKEN` PAT lacks the `write:packages` scope, causing Docker image pushes to GHCR to fail with `permission_denied: The token provided does not match expected scopes`
- Switch Docker login to use the built-in `GITHUB_TOKEN` which inherits `packages: write` from the workflow's `permissions` block
- `RELEASE_TOKEN` remains on goreleaser for cross-repo Homebrew tap pushes

## Test plan

- [ ] Tag a new release and verify the Docker images push to GHCR successfully
- [ ] Verify Homebrew tap still updates via `RELEASE_TOKEN`


🐨 Generated with Crush