### PR TITLE
fix: pganalyze_get_issues returns empty due to invalid state filter

### DIFF
--- a/integrations/pganalyze/issues.go
+++ b/integrations/pganalyze/issues.go
@@ -10,8 +10,8 @@ import (
 
 func getIssues(ctx context.Context, p *pganalyze, args map[string]any) (*mcp.ToolResult, error) {
 	query := `
-		query GetIssues($organizationSlug: ID, $serverId: ID, $databaseId: ID, $state: String) {
-			getIssues(organizationSlug: $organizationSlug, serverId: $serverId, databaseId: $databaseId, state: $state) {
+		query GetIssues($organizationSlug: ID, $serverId: ID, $databaseId: ID) {
+			getIssues(organizationSlug: $organizationSlug, serverId: $serverId, databaseId: $databaseId) {
 				id
 				checkGroupAndName
 				description
@@ -48,9 +48,6 @@ func getIssues(ctx context.Context, p *pganalyze, args map[string]any) (*mcp.Too
 	if databaseID != "" {
 		variables["databaseId"] = databaseID
 	}
-	if !includeResolved {
-		variables["state"] = "open"
-	}
 
 	data, err := p.gql(ctx, query, variables)
 	if err != nil {
@@ -64,19 +61,25 @@ func getIssues(ctx context.Context, p *pganalyze, args map[string]any) (*mcp.Too
 		return mcp.ErrResult(err)
 	}
 
-	if severity != "" {
-		var issues []map[string]any
-		if err := json.Unmarshal(resp.GetIssues, &issues); err != nil {
-			return mcp.ErrResult(err)
-		}
-		filtered := make([]map[string]any, 0, len(issues))
-		for _, issue := range issues {
-			if s, ok := issue["severity"].(string); ok && strings.EqualFold(s, severity) {
-				filtered = append(filtered, issue)
-			}
-		}
-		return mcp.JSONResult(filtered)
+	var issues []map[string]any
+	if err := json.Unmarshal(resp.GetIssues, &issues); err != nil {
+		return mcp.ErrResult(err)
 	}
 
-	return mcp.RawResult(resp.GetIssues)
+	filtered := make([]map[string]any, 0, len(issues))
+	for _, issue := range issues {
+		state, _ := issue["state"].(string)
+		if !includeResolved && strings.EqualFold(state, "resolved") {
+			continue
+		}
+		if severity != "" {
+			sev, _ := issue["severity"].(string)
+			if !strings.EqualFold(sev, severity) {
+				continue
+			}
+		}
+		filtered = append(filtered, issue)
+	}
+
+	return mcp.JSONResult(filtered)
 }

--- a/integrations/pganalyze/issues_test.go
+++ b/integrations/pganalyze/issues_test.go
@@ -1,0 +1,162 @@
+package pganalyze
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestPganalyze(t *testing.T, handler http.HandlerFunc) *pganalyze {
+	t.Helper()
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+	return &pganalyze{
+		apiKey:           "test-key",
+		graphqlURL:       ts.URL,
+		organizationSlug: "test-org",
+		client:           ts.Client(),
+	}
+}
+
+func gqlHandler(t *testing.T, response any) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"data": response})
+	}
+}
+
+func TestGetIssues_DefaultExcludesResolved(t *testing.T) {
+	issues := []map[string]any{
+		{"id": "1", "severity": "warning", "state": "triggered", "description": "active issue"},
+		{"id": "2", "severity": "info", "state": "resolved", "description": "resolved issue"},
+		{"id": "3", "severity": "critical", "state": "triggered", "description": "critical issue"},
+	}
+	p := newTestPganalyze(t, gqlHandler(t, map[string]any{"getIssues": issues}))
+
+	result, err := getIssues(context.Background(), p, map[string]any{})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	var got []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.Data), &got))
+	assert.Len(t, got, 2, "resolved issues should be excluded by default")
+	assert.Equal(t, "1", got[0]["id"])
+	assert.Equal(t, "3", got[1]["id"])
+}
+
+func TestGetIssues_IncludeResolvedReturnsAll(t *testing.T) {
+	issues := []map[string]any{
+		{"id": "1", "severity": "warning", "state": "triggered"},
+		{"id": "2", "severity": "info", "state": "resolved"},
+	}
+	p := newTestPganalyze(t, gqlHandler(t, map[string]any{"getIssues": issues}))
+
+	result, err := getIssues(context.Background(), p, map[string]any{"include_resolved": true})
+	require.NoError(t, err)
+
+	var got []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.Data), &got))
+	assert.Len(t, got, 2, "include_resolved should return all issues")
+}
+
+func TestGetIssues_SeverityFilter(t *testing.T) {
+	issues := []map[string]any{
+		{"id": "1", "severity": "warning", "state": "triggered"},
+		{"id": "2", "severity": "critical", "state": "triggered"},
+		{"id": "3", "severity": "warning", "state": "triggered"},
+	}
+	p := newTestPganalyze(t, gqlHandler(t, map[string]any{"getIssues": issues}))
+
+	result, err := getIssues(context.Background(), p, map[string]any{"severity": "critical"})
+	require.NoError(t, err)
+
+	var got []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.Data), &got))
+	assert.Len(t, got, 1)
+	assert.Equal(t, "2", got[0]["id"])
+}
+
+func TestGetIssues_SeverityFilterCaseInsensitive(t *testing.T) {
+	issues := []map[string]any{
+		{"id": "1", "severity": "Warning", "state": "triggered"},
+	}
+	p := newTestPganalyze(t, gqlHandler(t, map[string]any{"getIssues": issues}))
+
+	result, err := getIssues(context.Background(), p, map[string]any{"severity": "warning"})
+	require.NoError(t, err)
+
+	var got []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.Data), &got))
+	assert.Len(t, got, 1)
+}
+
+func TestGetIssues_SeverityPlusResolvedFilter(t *testing.T) {
+	issues := []map[string]any{
+		{"id": "1", "severity": "warning", "state": "triggered"},
+		{"id": "2", "severity": "warning", "state": "resolved"},
+		{"id": "3", "severity": "critical", "state": "triggered"},
+	}
+	p := newTestPganalyze(t, gqlHandler(t, map[string]any{"getIssues": issues}))
+
+	result, err := getIssues(context.Background(), p, map[string]any{"severity": "warning"})
+	require.NoError(t, err)
+
+	var got []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.Data), &got))
+	assert.Len(t, got, 1, "should exclude resolved even when filtering by severity")
+	assert.Equal(t, "1", got[0]["id"])
+}
+
+func TestGetIssues_NoStateVariableSentToAPI(t *testing.T) {
+	var capturedBody map[string]any
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&capturedBody)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{"getIssues": []any{}},
+		})
+	}
+	p := newTestPganalyze(t, handler)
+
+	_, err := getIssues(context.Background(), p, map[string]any{})
+	require.NoError(t, err)
+
+	vars, _ := capturedBody["variables"].(map[string]any)
+	assert.NotContains(t, vars, "state", "state should not be sent as a GraphQL variable")
+}
+
+func TestGetIssues_PassesOrgSlugToAPI(t *testing.T) {
+	var capturedBody map[string]any
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&capturedBody)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{"getIssues": []any{}},
+		})
+	}
+	p := newTestPganalyze(t, handler)
+
+	_, err := getIssues(context.Background(), p, map[string]any{})
+	require.NoError(t, err)
+
+	vars, _ := capturedBody["variables"].(map[string]any)
+	assert.Equal(t, "test-org", vars["organizationSlug"])
+}
+
+func TestGetIssues_EmptyResponse(t *testing.T) {
+	p := newTestPganalyze(t, gqlHandler(t, map[string]any{"getIssues": []any{}}))
+
+	result, err := getIssues(context.Background(), p, map[string]any{})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	var got []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.Data), &got))
+	assert.Empty(t, got)
+}


### PR DESCRIPTION

## Summary

- `pganalyze_get_issues` was passing `state: "open"` as a GraphQL variable, but pganalyze's API uses `"triggered"` for active issues — not `"open"`. The API silently returned empty results.
- Removed the undocumented server-side `$state` variable from the GraphQL query and switched to client-side filtering: exclude issues with `state: "resolved"` when `include_resolved` is false.
- Unified the severity + resolved filtering into a single pass over results.

## Test plan

- [x] Added `issues_test.go` with 8 tests covering: default excludes resolved, include_resolved returns all, severity filter, case-insensitive severity, combined severity+resolved, no state variable sent to API, org slug passthrough, empty response
- [x] All 37 pganalyze integration tests pass


🐘 Generated with Crush