### PR TITLE
Add Nomad integration for cluster orchestration

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/daltoniam/switchboard/integrations/jira"
 	"github.com/daltoniam/switchboard/integrations/linear"
 	"github.com/daltoniam/switchboard/integrations/metabase"
+	nomadInt "github.com/daltoniam/switchboard/integrations/nomad"
 	notionInt "github.com/daltoniam/switchboard/integrations/notion"
 	"github.com/daltoniam/switchboard/integrations/pganalyze"
 	"github.com/daltoniam/switchboard/integrations/postgres"
@@ -229,6 +230,7 @@ func runServer(stdioMode bool, port int, discoverAll bool) {
 		snowflakeInt.New(),
 		acpInt.New(),
 		webfetchInt.New(),
+		nomadInt.New(),
 		botidentity.New(),
 		xInt.New(),
 	} {

--- a/config/config.go
+++ b/config/config.go
@@ -126,6 +126,10 @@ var envMapping = map[string]map[string]string{
 	"x": {
 		"bearer_token": "X_BEARER_TOKEN",
 	},
+	"nomad": {
+		"address": "NOMAD_ADDR",
+		"token":   "NOMAD_TOKEN",
+	},
 }
 
 // EnvMapping returns the env var mapping table. Useful for documentation and debugging.
@@ -289,6 +293,10 @@ func defaultConfig() *mcp.Config {
 			"x": {
 				Enabled:     false,
 				Credentials: mcp.Credentials{"bearer_token": "", "client_id": "", "client_secret": ""},
+			},
+			"nomad": {
+				Enabled:     false,
+				Credentials: mcp.Credentials{"address": "", "token": ""},
 			},
 		},
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -33,7 +33,7 @@ func TestLoad_CreatesDefaultWhenMissing(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Len(t, m.cfg.Integrations, 32)
-	for _, name := range []string{"github", "datadog", "linear", "sentry", "slack", "metabase", "aws", "posthog", "postgres", "clickhouse", "elasticsearch", "pganalyze", "rwx", "gmail", "notion", "ynab", "gcp", "suno", "amazon", "jira", "confluence", "readarr", "salesforce", "cloudflare", "digitalocean", "fly", "snowflake", "acp", "web", "botidentity", "x"} {
+	for _, name := range []string{"github", "datadog", "linear", "sentry", "slack", "metabase", "aws", "posthog", "postgres", "clickhouse", "elasticsearch", "pganalyze", "rwx", "gmail", "notion", "ynab", "gcp", "suno", "amazon", "jira", "confluence", "readarr", "salesforce", "cloudflare", "digitalocean", "fly", "snowflake", "acp", "web", "botidentity", "x", "nomad"} {
 		ic, ok := m.cfg.Integrations[name]
 		assert.True(t, ok, "missing default integration: %s", name)
 		assert.False(t, ic.Enabled)
@@ -280,6 +280,7 @@ func TestDefaultConfig(t *testing.T) {
 		"digitalocean":  {"api_token"},
 		"fly":           {"api_token", "base_url"},
 		"web":           {},
+		"nomad":         {"address", "token"},
 	}
 
 	for name, keys := range expected {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -32,7 +32,7 @@ func TestLoad_CreatesDefaultWhenMissing(t *testing.T) {
 	_, err = os.Stat(path)
 	assert.NoError(t, err)
 
-	assert.Len(t, m.cfg.Integrations, 31)
+	assert.Len(t, m.cfg.Integrations, 32)
 	for _, name := range []string{"github", "datadog", "linear", "sentry", "slack", "metabase", "aws", "posthog", "postgres", "clickhouse", "elasticsearch", "pganalyze", "rwx", "gmail", "notion", "ynab", "gcp", "suno", "amazon", "jira", "confluence", "readarr", "salesforce", "cloudflare", "digitalocean", "fly", "snowflake", "acp", "web", "botidentity", "x"} {
 		ic, ok := m.cfg.Integrations[name]
 		assert.True(t, ok, "missing default integration: %s", name)
@@ -134,7 +134,7 @@ func TestSave(t *testing.T) {
 
 	var cfg mcp.Config
 	require.NoError(t, json.Unmarshal(data, &cfg))
-	assert.Len(t, cfg.Integrations, 31)
+	assert.Len(t, cfg.Integrations, 32)
 }
 
 func TestGet(t *testing.T) {
@@ -143,7 +143,7 @@ func TestGet(t *testing.T) {
 
 	cfg := m.Get()
 	assert.NotNil(t, cfg)
-	assert.Len(t, cfg.Integrations, 31)
+	assert.Len(t, cfg.Integrations, 32)
 }
 
 func TestUpdate(t *testing.T) {
@@ -253,7 +253,7 @@ func TestEnabledIntegrations_Multiple(t *testing.T) {
 func TestDefaultConfig(t *testing.T) {
 	cfg := defaultConfig()
 	require.NotNil(t, cfg)
-	assert.Len(t, cfg.Integrations, 31)
+	assert.Len(t, cfg.Integrations, 32)
 
 	expected := map[string][]string{
 		"github":        {"token", "client_id", "token_source"},
@@ -496,7 +496,9 @@ func TestEnvMapping_ReturnsMapping(t *testing.T) {
 	assert.Equal(t, "BOTIDENTITY_SLACK_CONFIG_TOKEN", m["botidentity"]["slack_config_token"])
 	assert.Equal(t, "BOTIDENTITY_SLACK_REFRESH_TOKEN", m["botidentity"]["slack_refresh_token"])
 	assert.Equal(t, "X_BEARER_TOKEN", m["x"]["bearer_token"])
-	assert.Len(t, m, 22)
+	assert.Equal(t, "NOMAD_ADDR", m["nomad"]["address"])
+	assert.Equal(t, "NOMAD_TOKEN", m["nomad"]["token"])
+	assert.Len(t, m, 23)
 }
 
 func TestToolGlobs_PersistThroughSaveLoad(t *testing.T) {

--- a/integrations/nomad/compact_specs.go
+++ b/integrations/nomad/compact_specs.go
@@ -1,0 +1,52 @@
+package nomad
+
+import (
+	"fmt"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+var rawFieldCompactionSpecs = map[mcp.ToolName][]string{
+	// ── Jobs ─────────────────────────────────────────────────────────
+	mcp.ToolName("nomad_list_jobs"):        {"ID", "Name", "Type", "Status", "StatusDescription", "Priority", "Namespace", "Datacenters", "SubmitTime", "JobSummary.Summary"},
+	mcp.ToolName("nomad_get_job"):          {"ID", "Name", "Type", "Status", "Priority", "Namespace", "Datacenters", "TaskGroups[].Name", "TaskGroups[].Count", "TaskGroups[].Tasks[].Name", "TaskGroups[].Tasks[].Driver", "TaskGroups[].Tasks[].Resources", "Constraints", "SubmitTime", "Version"},
+	mcp.ToolName("nomad_get_job_versions"): {"Versions[].ID", "Versions[].Version", "Versions[].SubmitTime", "Versions[].Status", "Versions[].Stable"},
+
+	// ── Allocations ──────────────────────────────────────────────────
+	mcp.ToolName("nomad_list_allocations"):    {"ID", "JobID", "TaskGroup", "NodeID", "NodeName", "DesiredStatus", "ClientStatus", "ClientDescription", "CreateTime", "ModifyTime"},
+	mcp.ToolName("nomad_get_allocation"):      {"ID", "JobID", "TaskGroup", "NodeID", "NodeName", "DesiredStatus", "ClientStatus", "ClientDescription", "TaskStates", "CreateTime", "ModifyTime", "Resources", "DeploymentID"},
+	mcp.ToolName("nomad_get_job_allocations"): {"ID", "TaskGroup", "NodeID", "NodeName", "DesiredStatus", "ClientStatus", "ClientDescription", "CreateTime"},
+
+	// ── Nodes ────────────────────────────────────────────────────────
+	mcp.ToolName("nomad_list_nodes"):           {"ID", "Name", "Address", "Datacenter", "NodeClass", "NodePool", "Status", "StatusDescription", "Drain", "SchedulingEligibility", "Drivers", "Version"},
+	mcp.ToolName("nomad_get_node"):             {"ID", "Name", "Address", "Datacenter", "NodeClass", "NodePool", "Status", "Drain", "SchedulingEligibility", "Drivers", "HostVolumes", "Attributes", "Resources", "Reserved", "Meta", "Version"},
+	mcp.ToolName("nomad_get_node_allocations"): {"ID", "JobID", "TaskGroup", "DesiredStatus", "ClientStatus", "ClientDescription", "CreateTime"},
+
+	// ── Deployments ──────────────────────────────────────────────────
+	mcp.ToolName("nomad_list_deployments"): {"ID", "JobID", "Namespace", "Status", "StatusDescription", "TaskGroups", "IsMultiregion", "CreateIndex", "ModifyIndex"},
+	mcp.ToolName("nomad_get_deployment"):   {"ID", "JobID", "Namespace", "Status", "StatusDescription", "TaskGroups", "IsMultiregion", "JobVersion", "JobCreateIndex"},
+
+	// ── Evaluations ──────────────────────────────────────────────────
+	mcp.ToolName("nomad_list_evaluations"): {"ID", "JobID", "Type", "Status", "StatusDescription", "Priority", "TriggeredBy", "CreateTime", "ModifyTime"},
+
+	// ── Services ─────────────────────────────────────────────────────
+	mcp.ToolName("nomad_list_services"): {"Namespace", "Services[].ServiceName", "Services[].Tags"},
+
+	// ── Cluster ──────────────────────────────────────────────────────
+	mcp.ToolName("nomad_get_agent_self"):    {"config.Datacenter", "config.Region", "config.Version", "config.Server.Enabled", "config.Client.Enabled", "member.Name", "member.Addr", "member.Status", "stats.nomad", "stats.raft"},
+	mcp.ToolName("nomad_get_cluster_status"): {"leader", "peers"},
+}
+
+var fieldCompactionSpecs = mustBuildFieldCompactionSpecs(rawFieldCompactionSpecs)
+
+func mustBuildFieldCompactionSpecs(raw map[mcp.ToolName][]string) map[mcp.ToolName][]mcp.CompactField {
+	parsed := make(map[mcp.ToolName][]mcp.CompactField, len(raw))
+	for tool, specs := range raw {
+		fields, err := mcp.ParseCompactSpecs(specs)
+		if err != nil {
+			panic(fmt.Sprintf("nomad: invalid field compaction spec for %q: %v", tool, err))
+		}
+		parsed[tool] = fields
+	}
+	return parsed
+}

--- a/integrations/nomad/compact_specs.go
+++ b/integrations/nomad/compact_specs.go
@@ -33,7 +33,7 @@ var rawFieldCompactionSpecs = map[mcp.ToolName][]string{
 	mcp.ToolName("nomad_list_services"): {"Namespace", "Services[].ServiceName", "Services[].Tags"},
 
 	// ── Cluster ──────────────────────────────────────────────────────
-	mcp.ToolName("nomad_get_agent_self"):    {"config.Datacenter", "config.Region", "config.Version", "config.Server.Enabled", "config.Client.Enabled", "member.Name", "member.Addr", "member.Status", "stats.nomad", "stats.raft"},
+	mcp.ToolName("nomad_get_agent_self"):     {"config.Datacenter", "config.Region", "config.Version", "config.Server.Enabled", "config.Client.Enabled", "member.Name", "member.Addr", "member.Status", "stats.nomad", "stats.raft"},
 	mcp.ToolName("nomad_get_cluster_status"): {"leader", "peers"},
 }
 

--- a/integrations/nomad/compact_specs_test.go
+++ b/integrations/nomad/compact_specs_test.go
@@ -1,0 +1,52 @@
+package nomad
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFieldCompactionSpecs_AllParse(t *testing.T) {
+	require.NotEmpty(t, fieldCompactionSpecs, "fieldCompactionSpecs should not be empty")
+}
+
+func TestFieldCompactionSpecs_NoDuplicateTools(t *testing.T) {
+	assert.Equal(t, len(rawFieldCompactionSpecs), len(fieldCompactionSpecs))
+}
+
+func TestFieldCompactionSpecs_NoOrphanSpecs(t *testing.T) {
+	for toolName := range fieldCompactionSpecs {
+		_, ok := dispatch[toolName]
+		assert.True(t, ok, "field compaction spec for %q has no dispatch handler", toolName)
+	}
+}
+
+func TestFieldCompactionSpecs_OnlyReadTools(t *testing.T) {
+	mutationPrefixes := []string{"register", "stop", "restart", "drain", "promote", "fail"}
+	for toolName := range fieldCompactionSpecs {
+		for _, prefix := range mutationPrefixes {
+			assert.NotContains(t, string(toolName), "_"+prefix+"_",
+				"mutation tool %q should not have a field compaction spec", toolName)
+		}
+	}
+}
+
+func TestFieldCompactionSpec_ReturnsFieldsForListTool(t *testing.T) {
+	n := &nomad{}
+	fields, ok := n.CompactSpec("nomad_list_jobs")
+	require.True(t, ok, "nomad_list_jobs should have field compaction spec")
+	assert.NotEmpty(t, fields)
+}
+
+func TestFieldCompactionSpec_ReturnsFalseForMutationTool(t *testing.T) {
+	n := &nomad{}
+	_, ok := n.CompactSpec("nomad_register_job")
+	assert.False(t, ok, "mutation tools should return false")
+}
+
+func TestFieldCompactionSpec_ReturnsFalseForUnknownTool(t *testing.T) {
+	n := &nomad{}
+	_, ok := n.CompactSpec("nomad_nonexistent")
+	assert.False(t, ok, "unknown tools should return false")
+}

--- a/integrations/nomad/handlers.go
+++ b/integrations/nomad/handlers.go
@@ -1,0 +1,509 @@
+package nomad
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+func listJobs(ctx context.Context, n *nomad, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	ns := r.Str("namespace")
+	prefix := r.Str("prefix")
+	filter := r.Str("filter")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	q := queryEncode(map[string]string{"namespace": ns, "prefix": prefix, "filter": filter})
+	data, err := n.get(ctx, "/v1/jobs%s", q)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func getJob(ctx context.Context, n *nomad, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	jobID := r.Str("job_id")
+	ns := r.Str("namespace")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	q := queryEncode(map[string]string{"namespace": ns})
+	data, err := n.get(ctx, "/v1/job/%s%s", jobID, q)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func getJobVersions(ctx context.Context, n *nomad, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	jobID := r.Str("job_id")
+	ns := r.Str("namespace")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	q := queryEncode(map[string]string{"namespace": ns})
+	data, err := n.get(ctx, "/v1/job/%s/versions%s", jobID, q)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func registerJob(ctx context.Context, n *nomad, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	ns := r.Str("namespace")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	jobSpec, ok := args["job"]
+	if !ok {
+		return mcp.ErrResult(fmt.Errorf("job is required"))
+	}
+
+	body := map[string]any{"Job": jobSpec}
+	q := queryEncode(map[string]string{"namespace": ns})
+	data, err := n.post(ctx, "/v1/jobs"+q, body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func stopJob(ctx context.Context, n *nomad, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	jobID := r.Str("job_id")
+	purge := r.Str("purge")
+	ns := r.Str("namespace")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	q := queryEncode(map[string]string{"namespace": ns, "purge": purge})
+	data, err := n.del(ctx, "/v1/job/%s%s", jobID, q)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func forceEvaluate(ctx context.Context, n *nomad, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	jobID := r.Str("job_id")
+	ns := r.Str("namespace")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	q := queryEncode(map[string]string{"namespace": ns})
+	data, err := n.post(ctx, fmt.Sprintf("/v1/job/%s/evaluate%s", jobID, q), nil)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func getJobAllocations(ctx context.Context, n *nomad, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	jobID := r.Str("job_id")
+	ns := r.Str("namespace")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	q := queryEncode(map[string]string{"namespace": ns})
+	data, err := n.get(ctx, "/v1/job/%s/allocations%s", jobID, q)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+// ── Allocations ──────────────────────────────────────────────────────
+
+func listAllocations(ctx context.Context, n *nomad, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	ns := r.Str("namespace")
+	prefix := r.Str("prefix")
+	filter := r.Str("filter")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	q := queryEncode(map[string]string{"namespace": ns, "prefix": prefix, "filter": filter})
+	data, err := n.get(ctx, "/v1/allocations%s", q)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func getAllocation(ctx context.Context, n *nomad, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	allocID := r.Str("alloc_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := n.get(ctx, "/v1/allocation/%s", allocID)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func stopAllocation(ctx context.Context, n *nomad, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	allocID := r.Str("alloc_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := n.post(ctx, fmt.Sprintf("/v1/allocation/%s/stop", allocID), nil)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func restartAllocation(ctx context.Context, n *nomad, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	allocID := r.Str("alloc_id")
+	task := r.Str("task")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	body := map[string]any{}
+	if task != "" {
+		body["TaskName"] = task
+	}
+	data, err := n.put(ctx, fmt.Sprintf("/v1/client/allocation/%s/restart", allocID), body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func readAllocationLogs(ctx context.Context, n *nomad, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	allocID := r.Str("alloc_id")
+	task := r.Str("task")
+	logType := r.Str("log_type")
+	plain := r.Str("plain")
+	origin := r.Str("origin")
+	offset := r.Str("offset")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if logType == "" {
+		logType = "stdout"
+	}
+	if plain == "" {
+		plain = "true"
+	}
+	if origin == "" {
+		origin = "end"
+	}
+	params := map[string]string{
+		"task":   task,
+		"type":   logType,
+		"plain":  plain,
+		"origin": origin,
+		"offset": offset,
+	}
+	q := queryEncode(params)
+	data, err := n.get(ctx, "/v1/client/fs/logs/%s%s", allocID, q)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	// When plain=true, Nomad returns raw text, not JSON
+	if strings.ToLower(plain) == "true" {
+		return &mcp.ToolResult{Data: string(data)}, nil
+	}
+	return mcp.RawResult(data)
+}
+
+// ── Nodes ────────────────────────────────────────────────────────────
+
+func listNodes(ctx context.Context, n *nomad, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	prefix := r.Str("prefix")
+	filter := r.Str("filter")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	q := queryEncode(map[string]string{"prefix": prefix, "filter": filter})
+	data, err := n.get(ctx, "/v1/nodes%s", q)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func getNode(ctx context.Context, n *nomad, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	nodeID := r.Str("node_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := n.get(ctx, "/v1/node/%s", nodeID)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func getNodeAllocations(ctx context.Context, n *nomad, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	nodeID := r.Str("node_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := n.get(ctx, "/v1/node/%s/allocations", nodeID)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func drainNode(ctx context.Context, n *nomad, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	nodeID := r.Str("node_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	enable, err := mcp.ArgBool(args, "enable")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	deadline := r.Str("deadline")
+	ignoreSystemJobs := r.Str("ignore_system_jobs")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	var body map[string]any
+	if enable {
+		drainSpec := map[string]any{}
+		if deadline != "" {
+			// Nomad expects a nanosecond duration — parse human-readable later if needed.
+			// For now, pass it through and let the API handle validation.
+			drainSpec["Deadline"] = parseDuration(deadline)
+		}
+		if strings.EqualFold(ignoreSystemJobs, "true") {
+			drainSpec["IgnoreSystemJobs"] = true
+		}
+		body = map[string]any{
+			"DrainSpec": drainSpec,
+		}
+	} else {
+		body = map[string]any{
+			"DrainSpec": nil,
+		}
+	}
+
+	data, err := n.post(ctx, fmt.Sprintf("/v1/node/%s/drain", nodeID), body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func nodeEligibility(ctx context.Context, n *nomad, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	nodeID := r.Str("node_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	eligible, err := mcp.ArgBool(args, "eligible")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	eligibility := "ineligible"
+	if eligible {
+		eligibility = "eligible"
+	}
+	body := map[string]any{
+		"Eligibility": eligibility,
+	}
+	data, err := n.post(ctx, fmt.Sprintf("/v1/node/%s/eligibility", nodeID), body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+// ── Deployments ──────────────────────────────────────────────────────
+
+func listDeployments(ctx context.Context, n *nomad, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	ns := r.Str("namespace")
+	prefix := r.Str("prefix")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	q := queryEncode(map[string]string{"namespace": ns, "prefix": prefix})
+	data, err := n.get(ctx, "/v1/deployments%s", q)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func getDeployment(ctx context.Context, n *nomad, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	deploymentID := r.Str("deployment_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := n.get(ctx, "/v1/deployment/%s", deploymentID)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func promoteDeployment(ctx context.Context, n *nomad, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	deploymentID := r.Str("deployment_id")
+	all := r.Str("all")
+	groups := r.Str("groups")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	body := map[string]any{
+		"DeploymentID": deploymentID,
+		"All":          all != "false",
+	}
+	if groups != "" {
+		body["Groups"] = strings.Split(groups, ",")
+		body["All"] = false
+	}
+	data, err := n.post(ctx, fmt.Sprintf("/v1/deployment/promote/%s", deploymentID), body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func failDeployment(ctx context.Context, n *nomad, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	deploymentID := r.Str("deployment_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	body := map[string]any{
+		"DeploymentID": deploymentID,
+	}
+	data, err := n.post(ctx, fmt.Sprintf("/v1/deployment/fail/%s", deploymentID), body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+// ── Evaluations ──────────────────────────────────────────────────────
+
+func listEvaluations(ctx context.Context, n *nomad, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	ns := r.Str("namespace")
+	prefix := r.Str("prefix")
+	filter := r.Str("filter")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	q := queryEncode(map[string]string{"namespace": ns, "prefix": prefix, "filter": filter})
+	data, err := n.get(ctx, "/v1/evaluations%s", q)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+// ── Services ─────────────────────────────────────────────────────────
+
+func listServices(ctx context.Context, n *nomad, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	ns := r.Str("namespace")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	q := queryEncode(map[string]string{"namespace": ns})
+	data, err := n.get(ctx, "/v1/services%s", q)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+// ── Cluster ──────────────────────────────────────────────────────────
+
+func getAgentSelf(ctx context.Context, n *nomad, _ map[string]any) (*mcp.ToolResult, error) {
+	data, err := n.get(ctx, "/v1/agent/self")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func getClusterStatus(ctx context.Context, n *nomad, _ map[string]any) (*mcp.ToolResult, error) {
+	leader, err := n.get(ctx, "/v1/status/leader")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	peers, err := n.get(ctx, "/v1/status/peers")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	combined := map[string]json.RawMessage{
+		"leader": leader,
+		"peers":  peers,
+	}
+	return mcp.JSONResult(combined)
+}
+
+func gc(ctx context.Context, n *nomad, _ map[string]any) (*mcp.ToolResult, error) {
+	data, err := n.put(ctx, "/v1/system/gc", nil)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+// parseDuration converts a human-readable duration (e.g., "1h", "30m") to nanoseconds
+// for the Nomad API. Returns 0 for empty or invalid input; -1 maps to -1ns (no deadline).
+func parseDuration(s string) int64 {
+	if s == "" {
+		return 0
+	}
+	if s == "-1" {
+		return -1
+	}
+	// Simple parser: support s, m, h suffixes
+	s = strings.TrimSpace(s)
+	if len(s) < 2 {
+		return 0
+	}
+	suffix := s[len(s)-1]
+	numStr := s[:len(s)-1]
+	var num int64
+	for _, c := range numStr {
+		if c < '0' || c > '9' {
+			return 0
+		}
+		num = num*10 + int64(c-'0')
+	}
+	switch suffix {
+	case 's':
+		return num * 1e9
+	case 'm':
+		return num * 60 * 1e9
+	case 'h':
+		return num * 3600 * 1e9
+	default:
+		return 0
+	}
+}

--- a/integrations/nomad/handlers.go
+++ b/integrations/nomad/handlers.go
@@ -283,7 +283,10 @@ func drainNode(ctx context.Context, n *nomad, args map[string]any) (*mcp.ToolRes
 	if err := r.Err(); err != nil {
 		return mcp.ErrResult(err)
 	}
-	ignoreSystemJobs, _ := mcp.ArgBool(args, "ignore_system_jobs")
+	ignoreSystemJobs, err := mcp.ArgBool(args, "ignore_system_jobs")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
 
 	var body map[string]any
 	if enable {
@@ -376,7 +379,7 @@ func promoteDeployment(ctx context.Context, n *nomad, args map[string]any) (*mcp
 
 	body := map[string]any{
 		"DeploymentID": deploymentID,
-		"All":          all != "false",
+		"All":          all == "" || all == "true",
 	}
 	if groups != "" {
 		body["Groups"] = strings.Split(groups, ",")

--- a/integrations/nomad/handlers.go
+++ b/integrations/nomad/handlers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	mcp "github.com/daltoniam/switchboard"
 )
@@ -473,8 +474,9 @@ func gc(ctx context.Context, n *nomad, _ map[string]any) (*mcp.ToolResult, error
 	return mcp.RawResult(data)
 }
 
-// parseDuration converts a human-readable duration (e.g., "1h", "30m") to nanoseconds
-// for the Nomad API. Returns 0 for empty or invalid input; -1 maps to -1ns (no deadline).
+// parseDuration converts a human-readable duration (e.g., "1h", "30m", "1h30m") to
+// nanoseconds for the Nomad API. Returns 0 for empty or invalid input; "-1" maps to
+// -1 (no deadline).
 func parseDuration(s string) int64 {
 	if s == "" {
 		return 0
@@ -482,28 +484,9 @@ func parseDuration(s string) int64 {
 	if s == "-1" {
 		return -1
 	}
-	// Simple parser: support s, m, h suffixes
-	s = strings.TrimSpace(s)
-	if len(s) < 2 {
+	d, err := time.ParseDuration(s)
+	if err != nil {
 		return 0
 	}
-	suffix := s[len(s)-1]
-	numStr := s[:len(s)-1]
-	var num int64
-	for _, c := range numStr {
-		if c < '0' || c > '9' {
-			return 0
-		}
-		num = num*10 + int64(c-'0')
-	}
-	switch suffix {
-	case 's':
-		return num * 1e9
-	case 'm':
-		return num * 60 * 1e9
-	case 'h':
-		return num * 3600 * 1e9
-	default:
-		return 0
-	}
+	return d.Nanoseconds()
 }

--- a/integrations/nomad/handlers.go
+++ b/integrations/nomad/handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 
@@ -34,7 +35,7 @@ func getJob(ctx context.Context, n *nomad, args map[string]any) (*mcp.ToolResult
 		return mcp.ErrResult(err)
 	}
 	q := queryEncode(map[string]string{"namespace": ns})
-	data, err := n.get(ctx, "/v1/job/%s%s", jobID, q)
+	data, err := n.get(ctx, "/v1/job/%s%s", url.PathEscape(jobID), q)
 	if err != nil {
 		return mcp.ErrResult(err)
 	}
@@ -49,7 +50,7 @@ func getJobVersions(ctx context.Context, n *nomad, args map[string]any) (*mcp.To
 		return mcp.ErrResult(err)
 	}
 	q := queryEncode(map[string]string{"namespace": ns})
-	data, err := n.get(ctx, "/v1/job/%s/versions%s", jobID, q)
+	data, err := n.get(ctx, "/v1/job/%s/versions%s", url.PathEscape(jobID), q)
 	if err != nil {
 		return mcp.ErrResult(err)
 	}
@@ -86,7 +87,7 @@ func stopJob(ctx context.Context, n *nomad, args map[string]any) (*mcp.ToolResul
 		return mcp.ErrResult(err)
 	}
 	q := queryEncode(map[string]string{"namespace": ns, "purge": purge})
-	data, err := n.del(ctx, "/v1/job/%s%s", jobID, q)
+	data, err := n.del(ctx, "/v1/job/%s%s", url.PathEscape(jobID), q)
 	if err != nil {
 		return mcp.ErrResult(err)
 	}
@@ -101,7 +102,7 @@ func forceEvaluate(ctx context.Context, n *nomad, args map[string]any) (*mcp.Too
 		return mcp.ErrResult(err)
 	}
 	q := queryEncode(map[string]string{"namespace": ns})
-	data, err := n.post(ctx, fmt.Sprintf("/v1/job/%s/evaluate%s", jobID, q), nil)
+	data, err := n.post(ctx, fmt.Sprintf("/v1/job/%s/evaluate%s", url.PathEscape(jobID), q), nil)
 	if err != nil {
 		return mcp.ErrResult(err)
 	}
@@ -116,7 +117,7 @@ func getJobAllocations(ctx context.Context, n *nomad, args map[string]any) (*mcp
 		return mcp.ErrResult(err)
 	}
 	q := queryEncode(map[string]string{"namespace": ns})
-	data, err := n.get(ctx, "/v1/job/%s/allocations%s", jobID, q)
+	data, err := n.get(ctx, "/v1/job/%s/allocations%s", url.PathEscape(jobID), q)
 	if err != nil {
 		return mcp.ErrResult(err)
 	}
@@ -147,7 +148,7 @@ func getAllocation(ctx context.Context, n *nomad, args map[string]any) (*mcp.Too
 	if err := r.Err(); err != nil {
 		return mcp.ErrResult(err)
 	}
-	data, err := n.get(ctx, "/v1/allocation/%s", allocID)
+	data, err := n.get(ctx, "/v1/allocation/%s", url.PathEscape(allocID))
 	if err != nil {
 		return mcp.ErrResult(err)
 	}
@@ -160,7 +161,7 @@ func stopAllocation(ctx context.Context, n *nomad, args map[string]any) (*mcp.To
 	if err := r.Err(); err != nil {
 		return mcp.ErrResult(err)
 	}
-	data, err := n.post(ctx, fmt.Sprintf("/v1/allocation/%s/stop", allocID), nil)
+	data, err := n.post(ctx, fmt.Sprintf("/v1/allocation/%s/stop", url.PathEscape(allocID)), nil)
 	if err != nil {
 		return mcp.ErrResult(err)
 	}
@@ -178,7 +179,7 @@ func restartAllocation(ctx context.Context, n *nomad, args map[string]any) (*mcp
 	if task != "" {
 		body["TaskName"] = task
 	}
-	data, err := n.put(ctx, fmt.Sprintf("/v1/client/allocation/%s/restart", allocID), body)
+	data, err := n.put(ctx, fmt.Sprintf("/v1/client/allocation/%s/restart", url.PathEscape(allocID)), body)
 	if err != nil {
 		return mcp.ErrResult(err)
 	}
@@ -213,7 +214,7 @@ func readAllocationLogs(ctx context.Context, n *nomad, args map[string]any) (*mc
 		"offset": offset,
 	}
 	q := queryEncode(params)
-	data, err := n.get(ctx, "/v1/client/fs/logs/%s%s", allocID, q)
+	data, err := n.get(ctx, "/v1/client/fs/logs/%s%s", url.PathEscape(allocID), q)
 	if err != nil {
 		return mcp.ErrResult(err)
 	}
@@ -247,7 +248,7 @@ func getNode(ctx context.Context, n *nomad, args map[string]any) (*mcp.ToolResul
 	if err := r.Err(); err != nil {
 		return mcp.ErrResult(err)
 	}
-	data, err := n.get(ctx, "/v1/node/%s", nodeID)
+	data, err := n.get(ctx, "/v1/node/%s", url.PathEscape(nodeID))
 	if err != nil {
 		return mcp.ErrResult(err)
 	}
@@ -260,7 +261,7 @@ func getNodeAllocations(ctx context.Context, n *nomad, args map[string]any) (*mc
 	if err := r.Err(); err != nil {
 		return mcp.ErrResult(err)
 	}
-	data, err := n.get(ctx, "/v1/node/%s/allocations", nodeID)
+	data, err := n.get(ctx, "/v1/node/%s/allocations", url.PathEscape(nodeID))
 	if err != nil {
 		return mcp.ErrResult(err)
 	}
@@ -279,20 +280,18 @@ func drainNode(ctx context.Context, n *nomad, args map[string]any) (*mcp.ToolRes
 	}
 
 	deadline := r.Str("deadline")
-	ignoreSystemJobs := r.Str("ignore_system_jobs")
 	if err := r.Err(); err != nil {
 		return mcp.ErrResult(err)
 	}
+	ignoreSystemJobs, _ := mcp.ArgBool(args, "ignore_system_jobs")
 
 	var body map[string]any
 	if enable {
 		drainSpec := map[string]any{}
 		if deadline != "" {
-			// Nomad expects a nanosecond duration — parse human-readable later if needed.
-			// For now, pass it through and let the API handle validation.
 			drainSpec["Deadline"] = parseDuration(deadline)
 		}
-		if strings.EqualFold(ignoreSystemJobs, "true") {
+		if ignoreSystemJobs {
 			drainSpec["IgnoreSystemJobs"] = true
 		}
 		body = map[string]any{
@@ -304,7 +303,7 @@ func drainNode(ctx context.Context, n *nomad, args map[string]any) (*mcp.ToolRes
 		}
 	}
 
-	data, err := n.post(ctx, fmt.Sprintf("/v1/node/%s/drain", nodeID), body)
+	data, err := n.post(ctx, fmt.Sprintf("/v1/node/%s/drain", url.PathEscape(nodeID)), body)
 	if err != nil {
 		return mcp.ErrResult(err)
 	}
@@ -329,7 +328,7 @@ func nodeEligibility(ctx context.Context, n *nomad, args map[string]any) (*mcp.T
 	body := map[string]any{
 		"Eligibility": eligibility,
 	}
-	data, err := n.post(ctx, fmt.Sprintf("/v1/node/%s/eligibility", nodeID), body)
+	data, err := n.post(ctx, fmt.Sprintf("/v1/node/%s/eligibility", url.PathEscape(nodeID)), body)
 	if err != nil {
 		return mcp.ErrResult(err)
 	}
@@ -359,7 +358,7 @@ func getDeployment(ctx context.Context, n *nomad, args map[string]any) (*mcp.Too
 	if err := r.Err(); err != nil {
 		return mcp.ErrResult(err)
 	}
-	data, err := n.get(ctx, "/v1/deployment/%s", deploymentID)
+	data, err := n.get(ctx, "/v1/deployment/%s", url.PathEscape(deploymentID))
 	if err != nil {
 		return mcp.ErrResult(err)
 	}
@@ -383,7 +382,7 @@ func promoteDeployment(ctx context.Context, n *nomad, args map[string]any) (*mcp
 		body["Groups"] = strings.Split(groups, ",")
 		body["All"] = false
 	}
-	data, err := n.post(ctx, fmt.Sprintf("/v1/deployment/promote/%s", deploymentID), body)
+	data, err := n.post(ctx, fmt.Sprintf("/v1/deployment/promote/%s", url.PathEscape(deploymentID)), body)
 	if err != nil {
 		return mcp.ErrResult(err)
 	}
@@ -399,7 +398,7 @@ func failDeployment(ctx context.Context, n *nomad, args map[string]any) (*mcp.To
 	body := map[string]any{
 		"DeploymentID": deploymentID,
 	}
-	data, err := n.post(ctx, fmt.Sprintf("/v1/deployment/fail/%s", deploymentID), body)
+	data, err := n.post(ctx, fmt.Sprintf("/v1/deployment/fail/%s", url.PathEscape(deploymentID)), body)
 	if err != nil {
 		return mcp.ErrResult(err)
 	}

--- a/integrations/nomad/nomad.go
+++ b/integrations/nomad/nomad.go
@@ -97,7 +97,8 @@ func (n *nomad) doRequest(ctx context.Context, method, path string, body any) (j
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	data, err := io.ReadAll(resp.Body)
+	const maxResponseSize = 10 * 1024 * 1024 // 10 MB
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
 	if err != nil {
 		return nil, err
 	}

--- a/integrations/nomad/nomad.go
+++ b/integrations/nomad/nomad.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	mcp "github.com/daltoniam/switchboard"
 )
@@ -27,7 +28,7 @@ type nomad struct {
 
 func New() mcp.Integration {
 	return &nomad{
-		client: &http.Client{},
+		client: &http.Client{Timeout: 30 * time.Second},
 	}
 }
 

--- a/integrations/nomad/nomad.go
+++ b/integrations/nomad/nomad.go
@@ -1,0 +1,194 @@
+package nomad
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+// Compile-time interface assertions.
+var (
+	_ mcp.Integration                = (*nomad)(nil)
+	_ mcp.FieldCompactionIntegration = (*nomad)(nil)
+)
+
+type nomad struct {
+	address string
+	token   string
+	client  *http.Client
+}
+
+func New() mcp.Integration {
+	return &nomad{
+		client: &http.Client{},
+	}
+}
+
+func (n *nomad) Name() string { return "nomad" }
+
+func (n *nomad) Configure(_ context.Context, creds mcp.Credentials) error {
+	n.address = creds["address"]
+	if n.address == "" {
+		return fmt.Errorf("nomad: address is required")
+	}
+	n.address = strings.TrimRight(n.address, "/")
+	n.token = creds["token"]
+	return nil
+}
+
+func (n *nomad) Healthy(ctx context.Context) bool {
+	if n.client == nil {
+		return false
+	}
+	_, err := n.get(ctx, "/v1/agent/self")
+	return err == nil
+}
+
+func (n *nomad) Tools() []mcp.ToolDefinition {
+	return tools
+}
+
+func (n *nomad) CompactSpec(toolName mcp.ToolName) ([]mcp.CompactField, bool) {
+	fields, ok := fieldCompactionSpecs[toolName]
+	return fields, ok
+}
+
+func (n *nomad) Execute(ctx context.Context, toolName mcp.ToolName, args map[string]any) (*mcp.ToolResult, error) {
+	fn, ok := dispatch[toolName]
+	if !ok {
+		return &mcp.ToolResult{Data: fmt.Sprintf("unknown tool: %s", toolName), IsError: true}, nil
+	}
+	return fn(ctx, n, args)
+}
+
+// --- HTTP helpers ---
+
+func (n *nomad) doRequest(ctx context.Context, method, path string, body any) (json.RawMessage, error) {
+	var bodyReader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return nil, err
+		}
+		bodyReader = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, n.address+path, bodyReader)
+	if err != nil {
+		return nil, err
+	}
+	if n.token != "" {
+		req.Header.Set("X-Nomad-Token", n.token)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := n.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == 429 || resp.StatusCode >= 500 {
+		re := &mcp.RetryableError{StatusCode: resp.StatusCode, Err: fmt.Errorf("nomad API error (%d): %s", resp.StatusCode, string(data))}
+		re.RetryAfter = mcp.ParseRetryAfter(resp.Header.Get("Retry-After"))
+		return nil, re
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("nomad API error (%d): %s", resp.StatusCode, string(data))
+	}
+	if resp.StatusCode == 204 || len(data) == 0 {
+		return json.RawMessage(`{"status":"success"}`), nil
+	}
+	return json.RawMessage(data), nil
+}
+
+func (n *nomad) get(ctx context.Context, pathFmt string, args ...any) (json.RawMessage, error) {
+	return n.doRequest(ctx, "GET", fmt.Sprintf(pathFmt, args...), nil)
+}
+
+func (n *nomad) post(ctx context.Context, path string, body any) (json.RawMessage, error) {
+	return n.doRequest(ctx, "POST", path, body)
+}
+
+func (n *nomad) put(ctx context.Context, path string, body any) (json.RawMessage, error) {
+	return n.doRequest(ctx, "PUT", path, body)
+}
+
+func (n *nomad) del(ctx context.Context, pathFmt string, args ...any) (json.RawMessage, error) {
+	return n.doRequest(ctx, "DELETE", fmt.Sprintf(pathFmt, args...), nil)
+}
+
+// --- Result helpers ---
+
+type handlerFunc func(ctx context.Context, n *nomad, args map[string]any) (*mcp.ToolResult, error)
+
+// queryEncode builds a query string from non-empty key/value pairs.
+func queryEncode(params map[string]string) string {
+	vals := url.Values{}
+	for k, v := range params {
+		if v != "" {
+			vals.Set(k, v)
+		}
+	}
+	if len(vals) == 0 {
+		return ""
+	}
+	return "?" + vals.Encode()
+}
+
+// --- Dispatch map ---
+
+var dispatch = map[mcp.ToolName]handlerFunc{
+	// Jobs
+	mcp.ToolName("nomad_list_jobs"):       listJobs,
+	mcp.ToolName("nomad_get_job"):         getJob,
+	mcp.ToolName("nomad_get_job_versions"): getJobVersions,
+	mcp.ToolName("nomad_register_job"):    registerJob,
+	mcp.ToolName("nomad_stop_job"):        stopJob,
+	mcp.ToolName("nomad_force_evaluate"):  forceEvaluate,
+
+	// Allocations
+	mcp.ToolName("nomad_list_allocations"):    listAllocations,
+	mcp.ToolName("nomad_get_allocation"):      getAllocation,
+	mcp.ToolName("nomad_get_job_allocations"): getJobAllocations,
+	mcp.ToolName("nomad_stop_allocation"):     stopAllocation,
+	mcp.ToolName("nomad_restart_allocation"):  restartAllocation,
+	mcp.ToolName("nomad_read_allocation_logs"): readAllocationLogs,
+
+	// Nodes
+	mcp.ToolName("nomad_list_nodes"):           listNodes,
+	mcp.ToolName("nomad_get_node"):             getNode,
+	mcp.ToolName("nomad_get_node_allocations"): getNodeAllocations,
+	mcp.ToolName("nomad_drain_node"):           drainNode,
+	mcp.ToolName("nomad_node_eligibility"):     nodeEligibility,
+
+	// Deployments
+	mcp.ToolName("nomad_list_deployments"):   listDeployments,
+	mcp.ToolName("nomad_get_deployment"):     getDeployment,
+	mcp.ToolName("nomad_promote_deployment"): promoteDeployment,
+	mcp.ToolName("nomad_fail_deployment"):    failDeployment,
+
+	// Evaluations
+	mcp.ToolName("nomad_list_evaluations"): listEvaluations,
+
+	// Services
+	mcp.ToolName("nomad_list_services"): listServices,
+
+	// Cluster
+	mcp.ToolName("nomad_get_agent_self"):    getAgentSelf,
+	mcp.ToolName("nomad_get_cluster_status"): getClusterStatus,
+	mcp.ToolName("nomad_gc"):                gc,
+}

--- a/integrations/nomad/nomad.go
+++ b/integrations/nomad/nomad.go
@@ -153,19 +153,19 @@ func queryEncode(params map[string]string) string {
 
 var dispatch = map[mcp.ToolName]handlerFunc{
 	// Jobs
-	mcp.ToolName("nomad_list_jobs"):       listJobs,
-	mcp.ToolName("nomad_get_job"):         getJob,
+	mcp.ToolName("nomad_list_jobs"):        listJobs,
+	mcp.ToolName("nomad_get_job"):          getJob,
 	mcp.ToolName("nomad_get_job_versions"): getJobVersions,
-	mcp.ToolName("nomad_register_job"):    registerJob,
-	mcp.ToolName("nomad_stop_job"):        stopJob,
-	mcp.ToolName("nomad_force_evaluate"):  forceEvaluate,
+	mcp.ToolName("nomad_register_job"):     registerJob,
+	mcp.ToolName("nomad_stop_job"):         stopJob,
+	mcp.ToolName("nomad_force_evaluate"):   forceEvaluate,
 
 	// Allocations
-	mcp.ToolName("nomad_list_allocations"):    listAllocations,
-	mcp.ToolName("nomad_get_allocation"):      getAllocation,
-	mcp.ToolName("nomad_get_job_allocations"): getJobAllocations,
-	mcp.ToolName("nomad_stop_allocation"):     stopAllocation,
-	mcp.ToolName("nomad_restart_allocation"):  restartAllocation,
+	mcp.ToolName("nomad_list_allocations"):     listAllocations,
+	mcp.ToolName("nomad_get_allocation"):       getAllocation,
+	mcp.ToolName("nomad_get_job_allocations"):  getJobAllocations,
+	mcp.ToolName("nomad_stop_allocation"):      stopAllocation,
+	mcp.ToolName("nomad_restart_allocation"):   restartAllocation,
 	mcp.ToolName("nomad_read_allocation_logs"): readAllocationLogs,
 
 	// Nodes
@@ -188,7 +188,7 @@ var dispatch = map[mcp.ToolName]handlerFunc{
 	mcp.ToolName("nomad_list_services"): listServices,
 
 	// Cluster
-	mcp.ToolName("nomad_get_agent_self"):    getAgentSelf,
+	mcp.ToolName("nomad_get_agent_self"):     getAgentSelf,
 	mcp.ToolName("nomad_get_cluster_status"): getClusterStatus,
-	mcp.ToolName("nomad_gc"):                gc,
+	mcp.ToolName("nomad_gc"):                 gc,
 }

--- a/integrations/nomad/nomad_test.go
+++ b/integrations/nomad/nomad_test.go
@@ -1,0 +1,398 @@
+package nomad
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	i := New()
+	require.NotNil(t, i)
+	assert.Equal(t, "nomad", i.Name())
+}
+
+func TestConfigure_Success(t *testing.T) {
+	i := New()
+	err := i.Configure(context.Background(), mcp.Credentials{"address": "http://localhost:4646", "token": "secret"})
+	assert.NoError(t, err)
+}
+
+func TestConfigure_SuccessWithoutToken(t *testing.T) {
+	i := New()
+	err := i.Configure(context.Background(), mcp.Credentials{"address": "http://localhost:4646"})
+	assert.NoError(t, err)
+}
+
+func TestConfigure_MissingAddress(t *testing.T) {
+	i := New()
+	err := i.Configure(context.Background(), mcp.Credentials{"address": "", "token": "secret"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "address is required")
+}
+
+func TestConfigure_TrimsTrailingSlash(t *testing.T) {
+	n := &nomad{client: &http.Client{}}
+	err := n.Configure(context.Background(), mcp.Credentials{"address": "http://localhost:4646/"})
+	assert.NoError(t, err)
+	assert.Equal(t, "http://localhost:4646", n.address)
+}
+
+func TestTools(t *testing.T) {
+	i := New()
+	tools := i.Tools()
+	assert.NotEmpty(t, tools)
+
+	for _, tool := range tools {
+		assert.NotEmpty(t, tool.Name, "tool has empty name")
+		assert.NotEmpty(t, tool.Description, "tool %s has empty description", tool.Name)
+	}
+}
+
+func TestTools_AllHaveNomadPrefix(t *testing.T) {
+	i := New()
+	for _, tool := range i.Tools() {
+		assert.Contains(t, string(tool.Name), "nomad_", "tool %s missing nomad_ prefix", tool.Name)
+	}
+}
+
+func TestTools_NoDuplicateNames(t *testing.T) {
+	i := New()
+	seen := make(map[mcp.ToolName]bool)
+	for _, tool := range i.Tools() {
+		assert.False(t, seen[tool.Name], "duplicate tool name: %s", tool.Name)
+		seen[tool.Name] = true
+	}
+}
+
+func TestExecute_UnknownTool(t *testing.T) {
+	n := &nomad{address: "http://localhost:4646", client: &http.Client{}}
+	result, err := n.Execute(context.Background(), "nomad_nonexistent", nil)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "unknown tool")
+}
+
+func TestDispatchMap_AllToolsCovered(t *testing.T) {
+	i := New()
+	for _, tool := range i.Tools() {
+		_, ok := dispatch[tool.Name]
+		assert.True(t, ok, "tool %s has no dispatch handler", tool.Name)
+	}
+}
+
+func TestDispatchMap_NoOrphanHandlers(t *testing.T) {
+	i := New()
+	toolNames := make(map[mcp.ToolName]bool)
+	for _, tool := range i.Tools() {
+		toolNames[tool.Name] = true
+	}
+	for name := range dispatch {
+		assert.True(t, toolNames[name], "dispatch handler %s has no tool definition", name)
+	}
+}
+
+// --- HTTP helper tests ---
+
+func TestDoRequest_Success(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"ID":"test-job"}`))
+	}))
+	defer ts.Close()
+
+	n := &nomad{address: ts.URL, client: ts.Client()}
+	data, err := n.get(context.Background(), "/v1/jobs")
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "test-job")
+}
+
+func TestDoRequest_WithToken(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "my-token", r.Header.Get("X-Nomad-Token"))
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer ts.Close()
+
+	n := &nomad{address: ts.URL, token: "my-token", client: ts.Client()}
+	_, err := n.get(context.Background(), "/v1/agent/self")
+	require.NoError(t, err)
+}
+
+func TestDoRequest_NoTokenHeader_WhenEmpty(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Empty(t, r.Header.Get("X-Nomad-Token"))
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer ts.Close()
+
+	n := &nomad{address: ts.URL, client: ts.Client()}
+	_, err := n.get(context.Background(), "/v1/agent/self")
+	require.NoError(t, err)
+}
+
+func TestDoRequest_APIError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(403)
+		w.Write([]byte(`Permission denied`))
+	}))
+	defer ts.Close()
+
+	n := &nomad{address: ts.URL, client: ts.Client()}
+	_, err := n.get(context.Background(), "/v1/jobs")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "nomad API error (403)")
+}
+
+func TestDoRequest_204NoContent(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(204)
+	}))
+	defer ts.Close()
+
+	n := &nomad{address: ts.URL, client: ts.Client()}
+	data, err := n.doRequest(context.Background(), "PUT", "/v1/system/gc", nil)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "success")
+}
+
+func TestPost(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body)
+		assert.NotNil(t, body["Job"])
+		w.Write([]byte(`{"EvalID":"eval-123"}`))
+	}))
+	defer ts.Close()
+
+	n := &nomad{address: ts.URL, client: ts.Client()}
+	data, err := n.post(context.Background(), "/v1/jobs", map[string]any{"Job": map[string]string{"ID": "test"}})
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "eval-123")
+}
+
+func TestDoRequest_RetryableOn429(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "30")
+		w.WriteHeader(429)
+		w.Write([]byte(`rate limited`))
+	}))
+	defer ts.Close()
+
+	n := &nomad{address: ts.URL, client: ts.Client()}
+	_, err := n.get(context.Background(), "/v1/jobs")
+	require.Error(t, err)
+	assert.True(t, mcp.IsRetryable(err), "429 should produce RetryableError")
+
+	var re *mcp.RetryableError
+	require.ErrorAs(t, err, &re)
+	assert.Equal(t, 429, re.StatusCode)
+	assert.Equal(t, 30*time.Second, re.RetryAfter)
+}
+
+func TestDoRequest_RetryableOn5xx(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(503)
+		w.Write([]byte(`service unavailable`))
+	}))
+	defer ts.Close()
+
+	n := &nomad{address: ts.URL, client: ts.Client()}
+	_, err := n.get(context.Background(), "/v1/jobs")
+	require.Error(t, err)
+	assert.True(t, mcp.IsRetryable(err), "503 should produce RetryableError")
+}
+
+func TestDoRequest_NonRetryableOn4xx(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(404)
+		w.Write([]byte(`not found`))
+	}))
+	defer ts.Close()
+
+	n := &nomad{address: ts.URL, client: ts.Client()}
+	_, err := n.get(context.Background(), "/v1/jobs")
+	require.Error(t, err)
+	assert.False(t, mcp.IsRetryable(err), "404 should NOT be retryable")
+}
+
+func TestQueryEncode(t *testing.T) {
+	t.Run("with values", func(t *testing.T) {
+		result := queryEncode(map[string]string{"namespace": "default", "empty": ""})
+		assert.Contains(t, result, "namespace=default")
+		assert.NotContains(t, result, "empty")
+		assert.True(t, result[0] == '?')
+	})
+
+	t.Run("all empty", func(t *testing.T) {
+		result := queryEncode(map[string]string{"empty": ""})
+		assert.Empty(t, result)
+	})
+}
+
+func TestParseDuration(t *testing.T) {
+	tests := []struct {
+		input string
+		want  int64
+	}{
+		{"", 0},
+		{"-1", -1},
+		{"30s", 30_000_000_000},
+		{"5m", 300_000_000_000},
+		{"1h", 3_600_000_000_000},
+		{"invalid", 0},
+		{"x", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.want, parseDuration(tt.input))
+		})
+	}
+}
+
+// --- Handler tests ---
+
+func TestListJobs(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/jobs", r.URL.Path)
+		w.Write([]byte(`[{"ID":"web","Status":"running"}]`))
+	}))
+	defer ts.Close()
+
+	n := &nomad{address: ts.URL, client: ts.Client()}
+	result, err := n.Execute(context.Background(), "nomad_list_jobs", map[string]any{})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "web")
+}
+
+func TestGetJob(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/job/web", r.URL.Path)
+		w.Write([]byte(`{"ID":"web","Name":"web","Status":"running"}`))
+	}))
+	defer ts.Close()
+
+	n := &nomad{address: ts.URL, client: ts.Client()}
+	result, err := n.Execute(context.Background(), "nomad_get_job", map[string]any{"job_id": "web"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "web")
+}
+
+func TestListNodes(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/nodes", r.URL.Path)
+		w.Write([]byte(`[{"ID":"node-1","Status":"ready"}]`))
+	}))
+	defer ts.Close()
+
+	n := &nomad{address: ts.URL, client: ts.Client()}
+	result, err := n.Execute(context.Background(), "nomad_list_nodes", map[string]any{})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "node-1")
+}
+
+func TestGetClusterStatus(t *testing.T) {
+	callCount := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		switch r.URL.Path {
+		case "/v1/status/leader":
+			w.Write([]byte(`"192.168.0.23:4647"`))
+		case "/v1/status/peers":
+			w.Write([]byte(`["192.168.0.23:4647"]`))
+		default:
+			w.WriteHeader(404)
+		}
+	}))
+	defer ts.Close()
+
+	n := &nomad{address: ts.URL, client: ts.Client()}
+	result, err := n.Execute(context.Background(), "nomad_get_cluster_status", map[string]any{})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "leader")
+	assert.Contains(t, result.Data, "peers")
+	assert.Equal(t, 2, callCount)
+}
+
+func TestDrainNode(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/node/node-1/drain", r.URL.Path)
+		assert.Equal(t, "POST", r.Method)
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body)
+		assert.NotNil(t, body["DrainSpec"])
+		w.Write([]byte(`{"EvalIDs":["eval-1"]}`))
+	}))
+	defer ts.Close()
+
+	n := &nomad{address: ts.URL, client: ts.Client()}
+	result, err := n.Execute(context.Background(), "nomad_drain_node", map[string]any{"node_id": "node-1", "enable": true, "deadline": "1h"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+}
+
+func TestNodeEligibility(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/node/node-1/eligibility", r.URL.Path)
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body)
+		assert.Equal(t, "ineligible", body["Eligibility"])
+		w.Write([]byte(`{"EvalIDs":[]}`))
+	}))
+	defer ts.Close()
+
+	n := &nomad{address: ts.URL, client: ts.Client()}
+	result, err := n.Execute(context.Background(), "nomad_node_eligibility", map[string]any{"node_id": "node-1", "eligible": false})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+}
+
+func TestErrResult_PropagatesRetryableError(t *testing.T) {
+	retryErr := &mcp.RetryableError{StatusCode: 503, Err: fmt.Errorf("service unavailable")}
+	result, err := mcp.ErrResult(retryErr)
+	assert.Nil(t, result, "retryable error should not produce a ToolResult")
+	assert.Error(t, err, "retryable error should be propagated as Go error")
+	assert.True(t, mcp.IsRetryable(err))
+}
+
+func TestHealthy(t *testing.T) {
+	t.Run("healthy", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Write([]byte(`{"config":{}}`))
+		}))
+		defer ts.Close()
+
+		n := &nomad{address: ts.URL, client: ts.Client()}
+		assert.True(t, n.Healthy(context.Background()))
+	})
+
+	t.Run("unhealthy", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(500)
+			w.Write([]byte(`error`))
+		}))
+		defer ts.Close()
+
+		n := &nomad{address: ts.URL, client: ts.Client()}
+		assert.False(t, n.Healthy(context.Background()))
+	})
+
+	t.Run("nil client", func(t *testing.T) {
+		n := &nomad{}
+		assert.False(t, n.Healthy(context.Background()))
+	})
+}

--- a/integrations/nomad/nomad_test.go
+++ b/integrations/nomad/nomad_test.go
@@ -250,8 +250,9 @@ func TestParseDuration(t *testing.T) {
 		{"30s", 30_000_000_000},
 		{"5m", 300_000_000_000},
 		{"1h", 3_600_000_000_000},
+		{"1h30m", 5_400_000_000_000},
+		{"100ms", 100_000_000},
 		{"invalid", 0},
-		{"x", 0},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {

--- a/integrations/nomad/tools.go
+++ b/integrations/nomad/tools.go
@@ -1,0 +1,140 @@
+package nomad
+
+import mcp "github.com/daltoniam/switchboard"
+
+var tools = []mcp.ToolDefinition{
+	// ── Jobs ─────────────────────────────────────────────────────────
+	{
+		Name: mcp.ToolName("nomad_list_jobs"), Description: "List all jobs in the Nomad cluster. Start here for workload orchestration, container scheduling, and discovering running services.",
+		Parameters: map[string]string{"namespace": "Namespace (default: default)", "prefix": "Filter by job ID prefix", "filter": "Filter expression (e.g., Status == \"running\")"},
+	},
+	{
+		Name: mcp.ToolName("nomad_get_job"), Description: "Get full specification and status of a specific Nomad job, including task groups, constraints, and resource requirements. Use after list_jobs.",
+		Parameters: map[string]string{"job_id": "Job ID", "namespace": "Namespace (default: default)"},
+		Required:   []string{"job_id"},
+	},
+	{
+		Name: mcp.ToolName("nomad_get_job_versions"), Description: "Get version history for a Nomad job. Shows previous configurations and when changes were made.",
+		Parameters: map[string]string{"job_id": "Job ID", "namespace": "Namespace (default: default)"},
+		Required:   []string{"job_id"},
+	},
+	{
+		Name: mcp.ToolName("nomad_register_job"), Description: "Register (create or update) a Nomad job. Accepts a full job specification as JSON.",
+		Parameters: map[string]string{"job": "Full job specification as JSON object", "namespace": "Namespace (default: default)"},
+		Required:   []string{"job"},
+	},
+	{
+		Name: mcp.ToolName("nomad_stop_job"), Description: "Stop (deregister) a running Nomad job. All allocations will be stopped.",
+		Parameters: map[string]string{"job_id": "Job ID", "purge": "Completely purge the job from the system (true/false, default: false)", "namespace": "Namespace (default: default)"},
+		Required:   []string{"job_id"},
+	},
+	{
+		Name: mcp.ToolName("nomad_force_evaluate"), Description: "Force a new evaluation for a Nomad job, triggering rescheduling. Useful when allocations are unhealthy or stuck.",
+		Parameters: map[string]string{"job_id": "Job ID", "namespace": "Namespace (default: default)"},
+		Required:   []string{"job_id"},
+	},
+
+	// ── Allocations ──────────────────────────────────────────────────
+	{
+		Name: mcp.ToolName("nomad_list_allocations"), Description: "List all allocations across the Nomad cluster. Shows where tasks are placed and their health status.",
+		Parameters: map[string]string{"namespace": "Namespace (default: default)", "prefix": "Filter by allocation ID prefix", "filter": "Filter expression"},
+	},
+	{
+		Name: mcp.ToolName("nomad_get_allocation"), Description: "Get details of a specific Nomad allocation, including task states, events, restart history, and resource usage.",
+		Parameters: map[string]string{"alloc_id": "Allocation ID"},
+		Required:   []string{"alloc_id"},
+	},
+	{
+		Name: mcp.ToolName("nomad_get_job_allocations"), Description: "List all allocations for a specific Nomad job. Shows placement, health, and status of each task instance.",
+		Parameters: map[string]string{"job_id": "Job ID", "namespace": "Namespace (default: default)"},
+		Required:   []string{"job_id"},
+	},
+	{
+		Name: mcp.ToolName("nomad_stop_allocation"), Description: "Stop a specific Nomad allocation. The scheduler may place a replacement depending on job configuration.",
+		Parameters: map[string]string{"alloc_id": "Allocation ID"},
+		Required:   []string{"alloc_id"},
+	},
+	{
+		Name: mcp.ToolName("nomad_restart_allocation"), Description: "Restart a task within a Nomad allocation. Optionally specify which task to restart.",
+		Parameters: map[string]string{"alloc_id": "Allocation ID", "task": "Task name (optional, restarts all tasks if omitted)"},
+		Required:   []string{"alloc_id"},
+	},
+	{
+		Name: mcp.ToolName("nomad_read_allocation_logs"), Description: "Read stdout or stderr logs from a task in a Nomad allocation. Use for debugging container and workload issues.",
+		Parameters: map[string]string{"alloc_id": "Allocation ID", "task": "Task name", "log_type": "Log type: stdout or stderr (default: stdout)", "plain": "Return plain text instead of JSON (true/false, default: true)", "origin": "Log origin: start or end (default: end)", "offset": "Byte offset to start reading from"},
+		Required:   []string{"alloc_id", "task"},
+	},
+
+	// ── Nodes ────────────────────────────────────────────────────────
+	{
+		Name: mcp.ToolName("nomad_list_nodes"), Description: "List all client nodes in the Nomad cluster. Shows node status, datacenter, drivers, and scheduling eligibility.",
+		Parameters: map[string]string{"prefix": "Filter by node ID prefix", "filter": "Filter expression (e.g., Status == \"ready\")"},
+	},
+	{
+		Name: mcp.ToolName("nomad_get_node"), Description: "Get full details of a specific Nomad node, including attributes, resources, drivers, host volumes, and metadata.",
+		Parameters: map[string]string{"node_id": "Node ID"},
+		Required:   []string{"node_id"},
+	},
+	{
+		Name: mcp.ToolName("nomad_get_node_allocations"), Description: "List all allocations placed on a specific Nomad node. Shows what workloads are running on the node.",
+		Parameters: map[string]string{"node_id": "Node ID"},
+		Required:   []string{"node_id"},
+	},
+	{
+		Name: mcp.ToolName("nomad_drain_node"), Description: "Enable or disable drain mode on a Nomad node. Draining migrates all allocations off the node for maintenance.",
+		Parameters: map[string]string{"node_id": "Node ID", "enable": "Enable drain (true) or disable (false)", "deadline": "Drain deadline duration (e.g., '1h', '30m'). Use -1 for no deadline", "ignore_system_jobs": "Skip draining system jobs (true/false, default: false)"},
+		Required:   []string{"node_id", "enable"},
+	},
+	{
+		Name: mcp.ToolName("nomad_node_eligibility"), Description: "Toggle scheduling eligibility for a Nomad node. Ineligible nodes won't receive new allocations but keep existing ones.",
+		Parameters: map[string]string{"node_id": "Node ID", "eligible": "Set eligible (true) or ineligible (false)"},
+		Required:   []string{"node_id", "eligible"},
+	},
+
+	// ── Deployments ──────────────────────────────────────────────────
+	{
+		Name: mcp.ToolName("nomad_list_deployments"), Description: "List deployments across the Nomad cluster. Shows rolling update status, canary progress, and deployment health.",
+		Parameters: map[string]string{"namespace": "Namespace (default: default)", "prefix": "Filter by deployment ID prefix"},
+	},
+	{
+		Name: mcp.ToolName("nomad_get_deployment"), Description: "Get details of a specific Nomad deployment, including task group status, health, and canary information.",
+		Parameters: map[string]string{"deployment_id": "Deployment ID"},
+		Required:   []string{"deployment_id"},
+	},
+	{
+		Name: mcp.ToolName("nomad_promote_deployment"), Description: "Promote canary allocations in a Nomad deployment. Moves canaries to production after validation.",
+		Parameters: map[string]string{"deployment_id": "Deployment ID", "all": "Promote all task groups (true/false, default: true)", "groups": "Comma-separated list of task groups to promote (alternative to all)"},
+		Required:   []string{"deployment_id"},
+	},
+	{
+		Name: mcp.ToolName("nomad_fail_deployment"), Description: "Mark a Nomad deployment as failed, triggering automatic rollback to the previous job version.",
+		Parameters: map[string]string{"deployment_id": "Deployment ID"},
+		Required:   []string{"deployment_id"},
+	},
+
+	// ── Evaluations ──────────────────────────────────────────────────
+	{
+		Name: mcp.ToolName("nomad_list_evaluations"), Description: "List evaluations in the Nomad scheduler queue. Shows scheduling decisions, blocked evaluations, and failures.",
+		Parameters: map[string]string{"namespace": "Namespace (default: default)", "prefix": "Filter by evaluation ID prefix", "filter": "Filter expression (e.g., Status == \"blocked\")"},
+	},
+
+	// ── Services ─────────────────────────────────────────────────────
+	{
+		Name: mcp.ToolName("nomad_list_services"), Description: "List all registered services in the Nomad service discovery catalog.",
+		Parameters: map[string]string{"namespace": "Namespace (default: default)"},
+	},
+
+	// ── Cluster ──────────────────────────────────────────────────────
+	{
+		Name: mcp.ToolName("nomad_get_agent_self"), Description: "Get the current Nomad agent's configuration, stats, and node information. Useful for diagnosing agent state.",
+		Parameters: map[string]string{},
+	},
+	{
+		Name: mcp.ToolName("nomad_get_cluster_status"), Description: "Get Nomad cluster status including Raft leader address and peer list. Use for cluster health checks.",
+		Parameters: map[string]string{},
+	},
+	{
+		Name: mcp.ToolName("nomad_gc"), Description: "Trigger garbage collection on the Nomad cluster to clean up dead allocations, evaluations, and deployments.",
+		Parameters: map[string]string{},
+	},
+}


### PR DESCRIPTION
## Summary

- Add 28-tool Nomad integration covering jobs, allocations, nodes, deployments, evaluations, services, and cluster management
- Raw HTTP adapter against the Nomad v1 API (no SDK dependency) with `X-Nomad-Token` auth support
- Field compaction specs for all 18 read tools, keeping list responses compact for LLM consumption

## Tools

**Jobs** (6): list, get, versions, register, stop, force-evaluate
**Allocations** (6): list, get, job-allocs, stop, restart, logs
**Nodes** (5): list, get, node-allocs, drain, eligibility
**Deployments** (4): list, get, promote, fail
**Evaluations** (1): list
**Services** (1): list
**Cluster** (3): agent-self, cluster-status, gc

## Config

```json
{ "nomad": { "address": "http://host:4646", "token": "" } }
```

Env vars: `NOMAD_ADDR`, `NOMAD_TOKEN`

## Test plan

- [x] `make ci` passes (build, vet, test-race, lint, security)
- [x] Dispatch parity tests: all tools have handlers, no orphan handlers
- [x] Compaction spec parity: no orphan specs, no mutation tool specs
- [x] HTTP helper tests: success, 4xx, 204, 429 retryable, 5xx retryable
- [x] Handler tests: list_jobs, get_job, list_nodes, cluster_status, drain_node, node_eligibility
- [x] Configure tests: success, missing address, trailing slash trim, token optional
- [x] Healthy tests: healthy, unhealthy, nil client


🐨 Generated with Crush