### PR TITLE
Add switchboard self-management integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ dist/
 coverage.out
 *.local.md
 tmp/
-switchboard
+/switchboard

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -45,6 +45,7 @@ import (
 	slackInt "github.com/daltoniam/switchboard/integrations/slack"
 	snowflakeInt "github.com/daltoniam/switchboard/integrations/snowflake"
 	"github.com/daltoniam/switchboard/integrations/suno"
+	switchboardInt "github.com/daltoniam/switchboard/integrations/switchboard"
 	webfetchInt "github.com/daltoniam/switchboard/integrations/webfetch"
 	xInt "github.com/daltoniam/switchboard/integrations/x"
 	"github.com/daltoniam/switchboard/integrations/ynab"
@@ -247,6 +248,11 @@ func runServer(stdioMode bool, port int, discoverAll bool) {
 		Metrics:  mcp.NewMetrics(),
 	}
 
+	switchboardIntegration := switchboardInt.New(services)
+	if err := reg.Register(switchboardIntegration); err != nil {
+		log.Fatalf("Failed to register switchboard integration: %v", err)
+	}
+
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
@@ -389,6 +395,8 @@ func runServer(stdioMode bool, port int, discoverAll bool) {
 		cfgNow.Marketplace = mc
 		return cfgMgr.Update(cfgNow)
 	})
+
+	switchboardInt.SetMarketplace(switchboardIntegration, mp)
 
 	cancelAutoUpdate := mp.StartAutoUpdateLoop(ctx)
 	defer cancelAutoUpdate()

--- a/config/config.go
+++ b/config/config.go
@@ -306,6 +306,10 @@ func defaultConfig() *mcp.Config {
 				Enabled:     false,
 				Credentials: mcp.Credentials{"address": "", "token": ""},
 			},
+			"switchboard": {
+				Enabled:     false,
+				Credentials: mcp.Credentials{},
+			},
 		},
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -32,8 +32,8 @@ func TestLoad_CreatesDefaultWhenMissing(t *testing.T) {
 	_, err = os.Stat(path)
 	assert.NoError(t, err)
 
-	assert.Len(t, m.cfg.Integrations, 33)
-	for _, name := range []string{"github", "datadog", "linear", "sentry", "slack", "metabase", "aws", "posthog", "postgres", "clickhouse", "elasticsearch", "pganalyze", "rwx", "gmail", "notion", "ynab", "gcp", "suno", "amazon", "jira", "confluence", "readarr", "salesforce", "cloudflare", "digitalocean", "fly", "snowflake", "acp", "web", "botidentity", "x", "signoz", "nomad"} {
+	assert.Len(t, m.cfg.Integrations, 34)
+	for _, name := range []string{"github", "datadog", "linear", "sentry", "slack", "metabase", "aws", "posthog", "postgres", "clickhouse", "elasticsearch", "pganalyze", "rwx", "gmail", "notion", "ynab", "gcp", "suno", "amazon", "jira", "confluence", "readarr", "salesforce", "cloudflare", "digitalocean", "fly", "snowflake", "acp", "web", "botidentity", "x", "signoz", "nomad", "switchboard"} {
 		ic, ok := m.cfg.Integrations[name]
 		assert.True(t, ok, "missing default integration: %s", name)
 		assert.False(t, ic.Enabled)
@@ -134,7 +134,7 @@ func TestSave(t *testing.T) {
 
 	var cfg mcp.Config
 	require.NoError(t, json.Unmarshal(data, &cfg))
-	assert.Len(t, cfg.Integrations, 33)
+	assert.Len(t, cfg.Integrations, 34)
 }
 
 func TestGet(t *testing.T) {
@@ -143,7 +143,7 @@ func TestGet(t *testing.T) {
 
 	cfg := m.Get()
 	assert.NotNil(t, cfg)
-	assert.Len(t, cfg.Integrations, 33)
+	assert.Len(t, cfg.Integrations, 34)
 }
 
 func TestUpdate(t *testing.T) {
@@ -253,7 +253,7 @@ func TestEnabledIntegrations_Multiple(t *testing.T) {
 func TestDefaultConfig(t *testing.T) {
 	cfg := defaultConfig()
 	require.NotNil(t, cfg)
-	assert.Len(t, cfg.Integrations, 33)
+	assert.Len(t, cfg.Integrations, 34)
 
 	expected := map[string][]string{
 		"github":        {"token", "client_id", "token_source"},

--- a/integrations/switchboard/compact_specs.go
+++ b/integrations/switchboard/compact_specs.go
@@ -1,0 +1,36 @@
+package switchboard
+
+import (
+	"fmt"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+// rawFieldCompactionSpecs maps tool names to dot-notation field compaction specs.
+// Only list/read tools get specs — mutation tools return full confirmation responses.
+var rawFieldCompactionSpecs = map[mcp.ToolName][]string{
+	mcp.ToolName("switchboard_list_integrations"): {
+		"name", "enabled", "healthy", "tool_count",
+	},
+	mcp.ToolName("switchboard_check_health"): {
+		"name", "healthy", "enabled",
+	},
+	mcp.ToolName("switchboard_browse_plugins"): {
+		"name", "description", "latest_version", "installed", "update_available",
+	},
+}
+
+// fieldCompactionSpecs holds pre-parsed CompactFields, built once at package init.
+var fieldCompactionSpecs = mustBuildFieldCompactionSpecs(rawFieldCompactionSpecs)
+
+func mustBuildFieldCompactionSpecs(raw map[mcp.ToolName][]string) map[mcp.ToolName][]mcp.CompactField {
+	parsed := make(map[mcp.ToolName][]mcp.CompactField, len(raw))
+	for tool, specs := range raw {
+		fields, err := mcp.ParseCompactSpecs(specs)
+		if err != nil {
+			panic(fmt.Sprintf("switchboard: invalid field compaction spec for %q: %v", tool, err))
+		}
+		parsed[tool] = fields
+	}
+	return parsed
+}

--- a/integrations/switchboard/switchboard.go
+++ b/integrations/switchboard/switchboard.go
@@ -1,0 +1,438 @@
+package switchboard
+
+import (
+	"context"
+	"sort"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/daltoniam/switchboard/marketplace"
+)
+
+var (
+	_ mcp.Integration                = (*switchboardInt)(nil)
+	_ mcp.FieldCompactionIntegration = (*switchboardInt)(nil)
+)
+
+type switchboardInt struct {
+	services    *mcp.Services
+	marketplace *marketplace.Manager
+}
+
+// New creates a switchboard self-management integration.
+// Call SetMarketplace after construction if marketplace is available.
+func New(services *mcp.Services) mcp.Integration {
+	return &switchboardInt{
+		services: services,
+	}
+}
+
+// SetMarketplace attaches the marketplace manager for plugin tools.
+// Must be called on the concrete type returned by New.
+func SetMarketplace(i mcp.Integration, mp *marketplace.Manager) {
+	if s, ok := i.(*switchboardInt); ok {
+		s.marketplace = mp
+	}
+}
+
+func (s *switchboardInt) Name() string { return "switchboard" }
+
+func (s *switchboardInt) Configure(_ context.Context, _ mcp.Credentials) error {
+	return nil
+}
+
+func (s *switchboardInt) Tools() []mcp.ToolDefinition { return tools }
+
+func (s *switchboardInt) Execute(ctx context.Context, toolName mcp.ToolName, args map[string]any) (*mcp.ToolResult, error) {
+	fn, ok := dispatch[toolName]
+	if !ok {
+		return &mcp.ToolResult{Data: "unknown tool: " + string(toolName), IsError: true}, nil
+	}
+	return fn(ctx, s, args)
+}
+
+func (s *switchboardInt) Healthy(_ context.Context) bool {
+	return s.services != nil && s.services.Config != nil && s.services.Registry != nil
+}
+
+func (s *switchboardInt) CompactSpec(toolName mcp.ToolName) ([]mcp.CompactField, bool) {
+	fields, ok := fieldCompactionSpecs[toolName]
+	return fields, ok
+}
+
+type handlerFunc func(ctx context.Context, s *switchboardInt, args map[string]any) (*mcp.ToolResult, error)
+
+var dispatch = map[mcp.ToolName]handlerFunc{
+	"switchboard_list_integrations":     listIntegrations,
+	"switchboard_get_integration":       getIntegration,
+	"switchboard_configure_integration": configureIntegration,
+	"switchboard_check_health":          checkHealth,
+	"switchboard_browse_plugins":        browsePlugins,
+	"switchboard_install_plugin":        installPlugin,
+	"switchboard_uninstall_plugin":      uninstallPlugin,
+	"switchboard_server_info":           serverInfo,
+}
+
+// listIntegrations returns all registered integrations with their status.
+func listIntegrations(_ context.Context, s *switchboardInt, args map[string]any) (*mcp.ToolResult, error) {
+	enabledOnly, _ := mcp.ArgBool(args, "enabled_only")
+
+	type integrationSummary struct {
+		Name           string   `json:"name"`
+		Enabled        bool     `json:"enabled"`
+		Healthy        bool     `json:"healthy,omitempty"`
+		ToolCount      int      `json:"tool_count"`
+		CredentialKeys []string `json:"credential_keys"`
+	}
+
+	var results []integrationSummary
+	for _, a := range s.services.Registry.All() {
+		ic, exists := s.services.Config.GetIntegration(a.Name())
+		enabled := exists && ic.Enabled
+
+		if enabledOnly && !enabled {
+			continue
+		}
+
+		credKeys := s.services.Config.DefaultCredentialKeys(a.Name())
+		sort.Strings(credKeys)
+
+		results = append(results, integrationSummary{
+			Name:           a.Name(),
+			Enabled:        enabled,
+			ToolCount:      len(a.Tools()),
+			CredentialKeys: credKeys,
+		})
+	}
+
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Name < results[j].Name
+	})
+
+	return mcp.JSONResult(results)
+}
+
+// getIntegration returns detailed info about a specific integration.
+func getIntegration(ctx context.Context, s *switchboardInt, args map[string]any) (*mcp.ToolResult, error) {
+	name, err := mcp.ArgStr(args, "name")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	a, ok := s.services.Registry.Get(name)
+	if !ok {
+		return &mcp.ToolResult{
+			Data:    "integration not found: " + name,
+			IsError: true,
+		}, nil
+	}
+
+	ic, exists := s.services.Config.GetIntegration(name)
+	enabled := exists && ic.Enabled
+
+	var healthy bool
+	if enabled {
+		healthy = a.Healthy(ctx)
+	}
+
+	type toolInfo struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+	}
+
+	var toolList []toolInfo
+	for _, t := range a.Tools() {
+		toolList = append(toolList, toolInfo{
+			Name:        string(t.Name),
+			Description: t.Description,
+		})
+	}
+
+	credKeys := s.services.Config.DefaultCredentialKeys(name)
+	sort.Strings(credKeys)
+
+	// Show which credential keys have values set (without showing the values).
+	configuredKeys := []string{}
+	if exists {
+		for _, k := range credKeys {
+			if ic.Credentials[k] != "" {
+				configuredKeys = append(configuredKeys, k)
+			}
+		}
+	}
+
+	type integrationDetail struct {
+		Name           string     `json:"name"`
+		Enabled        bool       `json:"enabled"`
+		Healthy        bool       `json:"healthy"`
+		ToolCount      int        `json:"tool_count"`
+		CredentialKeys []string   `json:"credential_keys"`
+		ConfiguredKeys []string   `json:"configured_keys"`
+		Tools          []toolInfo `json:"tools"`
+	}
+
+	return mcp.JSONResult(integrationDetail{
+		Name:           name,
+		Enabled:        enabled,
+		Healthy:        healthy,
+		ToolCount:      len(a.Tools()),
+		CredentialKeys: credKeys,
+		ConfiguredKeys: configuredKeys,
+		Tools:          toolList,
+	})
+}
+
+// configureIntegration sets credentials and enables/disables an integration.
+func configureIntegration(ctx context.Context, s *switchboardInt, args map[string]any) (*mcp.ToolResult, error) {
+	name, err := mcp.ArgStr(args, "name")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	a, ok := s.services.Registry.Get(name)
+	if !ok {
+		return &mcp.ToolResult{
+			Data:    "integration not found: " + name,
+			IsError: true,
+		}, nil
+	}
+
+	// Get existing config or create a new one.
+	ic, exists := s.services.Config.GetIntegration(name)
+	if !exists || ic == nil {
+		ic = &mcp.IntegrationConfig{
+			Credentials: mcp.Credentials{},
+		}
+	}
+
+	// Merge credentials if provided.
+	if credsRaw, ok := args["credentials"]; ok {
+		if credsMap, ok := credsRaw.(map[string]any); ok {
+			for k, v := range credsMap {
+				if vs, ok := v.(string); ok {
+					ic.Credentials[k] = vs
+				}
+			}
+		}
+	}
+
+	// Set enabled (default true).
+	enabled := true
+	if v, ok := args["enabled"]; ok {
+		if b, ok := v.(bool); ok {
+			enabled = b
+		}
+	}
+	ic.Enabled = enabled
+
+	// Attempt to configure the integration to validate credentials.
+	if enabled {
+		if err := a.Configure(ctx, ic.Credentials); err != nil {
+			return &mcp.ToolResult{
+				Data:    "configure failed: " + err.Error(),
+				IsError: true,
+			}, nil
+		}
+	}
+
+	if err := s.services.Config.SetIntegration(name, ic); err != nil {
+		return &mcp.ToolResult{
+			Data:    "save config failed: " + err.Error(),
+			IsError: true,
+		}, nil
+	}
+
+	status := "enabled"
+	if !enabled {
+		status = "disabled"
+	}
+
+	return mcp.JSONResult(map[string]string{
+		"status":      "ok",
+		"integration": name,
+		"state":       status,
+	})
+}
+
+// checkHealth checks connectivity for one or all enabled integrations.
+func checkHealth(ctx context.Context, s *switchboardInt, args map[string]any) (*mcp.ToolResult, error) {
+	name, _ := mcp.ArgStr(args, "name")
+
+	type healthResult struct {
+		Name    string `json:"name"`
+		Healthy bool   `json:"healthy"`
+		Enabled bool   `json:"enabled"`
+	}
+
+	if name != "" {
+		a, ok := s.services.Registry.Get(name)
+		if !ok {
+			return &mcp.ToolResult{
+				Data:    "integration not found: " + name,
+				IsError: true,
+			}, nil
+		}
+
+		ic, exists := s.services.Config.GetIntegration(name)
+		enabled := exists && ic.Enabled
+
+		var healthy bool
+		if enabled {
+			healthy = a.Healthy(ctx)
+		}
+
+		return mcp.JSONResult(healthResult{
+			Name:    name,
+			Healthy: healthy,
+			Enabled: enabled,
+		})
+	}
+
+	var results []healthResult
+	for _, a := range s.services.Registry.All() {
+		ic, exists := s.services.Config.GetIntegration(a.Name())
+		enabled := exists && ic.Enabled
+
+		var healthy bool
+		if enabled {
+			healthy = a.Healthy(ctx)
+		}
+
+		results = append(results, healthResult{
+			Name:    a.Name(),
+			Healthy: healthy,
+			Enabled: enabled,
+		})
+	}
+
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Name < results[j].Name
+	})
+
+	return mcp.JSONResult(results)
+}
+
+// browsePlugins returns available plugins from configured manifest sources.
+func browsePlugins(ctx context.Context, s *switchboardInt, _ map[string]any) (*mcp.ToolResult, error) {
+	if s.marketplace == nil {
+		return &mcp.ToolResult{
+			Data:    "marketplace is not configured",
+			IsError: true,
+		}, nil
+	}
+
+	results, err := s.marketplace.BrowsePlugins(ctx)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	if len(results) == 0 {
+		return mcp.JSONResult(map[string]string{
+			"message": "No plugins available. Add manifest sources via the web UI or config file.",
+		})
+	}
+
+	return mcp.JSONResult(results)
+}
+
+// installPlugin installs a plugin from the marketplace by name or URL.
+func installPlugin(ctx context.Context, s *switchboardInt, args map[string]any) (*mcp.ToolResult, error) {
+	if s.marketplace == nil {
+		return &mcp.ToolResult{
+			Data:    "marketplace is not configured",
+			IsError: true,
+		}, nil
+	}
+
+	name, _ := mcp.ArgStr(args, "name")
+	url, _ := mcp.ArgStr(args, "url")
+
+	if name == "" && url == "" {
+		return &mcp.ToolResult{
+			Data:    "either name or url is required",
+			IsError: true,
+		}, nil
+	}
+
+	var ip *marketplace.InstalledPlugin
+	var err error
+
+	if url != "" {
+		ip, err = s.marketplace.InstallFromURL(ctx, url)
+	} else {
+		ip, err = s.marketplace.InstallPlugin(ctx, name)
+	}
+
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	return mcp.JSONResult(map[string]any{
+		"status":  "installed",
+		"name":    ip.Name,
+		"version": ip.Version,
+		"path":    ip.Path,
+		"note":    "Restart Switchboard to load the plugin.",
+	})
+}
+
+// uninstallPlugin removes an installed marketplace plugin.
+func uninstallPlugin(_ context.Context, s *switchboardInt, args map[string]any) (*mcp.ToolResult, error) {
+	if s.marketplace == nil {
+		return &mcp.ToolResult{
+			Data:    "marketplace is not configured",
+			IsError: true,
+		}, nil
+	}
+
+	name, err := mcp.ArgStr(args, "name")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	if err := s.marketplace.UninstallPlugin(name); err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	return mcp.JSONResult(map[string]string{
+		"status": "uninstalled",
+		"name":   name,
+		"note":   "Restart Switchboard to fully remove the plugin.",
+	})
+}
+
+// serverInfo returns server version, metrics, and configuration summary.
+func serverInfo(_ context.Context, s *switchboardInt, _ map[string]any) (*mcp.ToolResult, error) {
+	allIntegrations := s.services.Registry.All()
+	enabledCount := 0
+	totalTools := 0
+	for _, a := range allIntegrations {
+		totalTools += len(a.Tools())
+		ic, exists := s.services.Config.GetIntegration(a.Name())
+		if exists && ic.Enabled {
+			enabledCount++
+		}
+	}
+
+	info := map[string]any{
+		"total_integrations":   len(allIntegrations),
+		"enabled_integrations": enabledCount,
+		"total_tools":          totalTools,
+	}
+
+	if s.services.Metrics != nil {
+		snap := s.services.Metrics.Snapshot()
+		info["metrics"] = snap
+	}
+
+	if s.marketplace != nil {
+		installed := s.marketplace.InstalledPlugins()
+		cfg := s.marketplace.Config()
+		info["marketplace"] = map[string]any{
+			"installed_plugins": len(installed),
+			"manifest_sources":  len(cfg.ManifestSources),
+			"auto_update":       cfg.AutoUpdate,
+		}
+	}
+
+	return mcp.JSONResult(info)
+}

--- a/integrations/switchboard/switchboard_test.go
+++ b/integrations/switchboard/switchboard_test.go
@@ -1,0 +1,443 @@
+package switchboard
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/daltoniam/switchboard/registry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- mock config service ---
+
+type mockConfigService struct {
+	cfg *mcp.Config
+}
+
+func newMockConfigService(integrations map[string]*mcp.IntegrationConfig) *mockConfigService {
+	return &mockConfigService{cfg: &mcp.Config{Integrations: integrations}}
+}
+
+func (m *mockConfigService) Load() error                  { return nil }
+func (m *mockConfigService) Save() error                  { return nil }
+func (m *mockConfigService) Get() *mcp.Config             { return m.cfg }
+func (m *mockConfigService) Update(cfg *mcp.Config) error { m.cfg = cfg; return nil }
+func (m *mockConfigService) GetIntegration(name string) (*mcp.IntegrationConfig, bool) {
+	ic, ok := m.cfg.Integrations[name]
+	return ic, ok
+}
+func (m *mockConfigService) SetIntegration(name string, ic *mcp.IntegrationConfig) error {
+	m.cfg.Integrations[name] = ic
+	return nil
+}
+func (m *mockConfigService) SetWasmModules(modules []mcp.WasmModuleConfig) error {
+	m.cfg.WasmModules = modules
+	return nil
+}
+func (m *mockConfigService) EnabledIntegrations() []string {
+	var names []string
+	for name, ic := range m.cfg.Integrations {
+		if ic.Enabled {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+func (m *mockConfigService) DefaultCredentialKeys(name string) []string {
+	defaults := map[string][]string{
+		"fake":  {"api_key", "base_url"},
+		"other": {"token"},
+	}
+	return defaults[name]
+}
+
+// --- fake integration for test setup ---
+
+type fakeIntegration struct {
+	name       string
+	configured bool
+	healthy    bool
+	configErr  error
+}
+
+func (f *fakeIntegration) Name() string { return f.name }
+func (f *fakeIntegration) Configure(_ context.Context, _ mcp.Credentials) error {
+	if f.configErr != nil {
+		return f.configErr
+	}
+	f.configured = true
+	return nil
+}
+func (f *fakeIntegration) Tools() []mcp.ToolDefinition {
+	return []mcp.ToolDefinition{
+		{Name: mcp.ToolName(f.name + "_do_thing"), Description: "Does a thing"},
+		{Name: mcp.ToolName(f.name + "_list_things"), Description: "Lists things"},
+	}
+}
+func (f *fakeIntegration) Execute(_ context.Context, toolName mcp.ToolName, _ map[string]any) (*mcp.ToolResult, error) {
+	return &mcp.ToolResult{Data: "executed " + string(toolName)}, nil
+}
+func (f *fakeIntegration) Healthy(_ context.Context) bool { return f.healthy }
+
+// --- test helpers ---
+
+func newTestServices(fakeIntegrations ...*fakeIntegration) *mcp.Services {
+	reg := registry.New()
+	integrations := map[string]*mcp.IntegrationConfig{}
+	for _, fi := range fakeIntegrations {
+		_ = reg.Register(fi)
+		integrations[fi.name] = &mcp.IntegrationConfig{
+			Enabled:     fi.healthy,
+			Credentials: mcp.Credentials{"api_key": "test-key"},
+		}
+	}
+	return &mcp.Services{
+		Config:   newMockConfigService(integrations),
+		Registry: reg,
+		Metrics:  mcp.NewMetrics(),
+	}
+}
+
+func newTestIntegration(services *mcp.Services) *switchboardInt {
+	return &switchboardInt{services: services}
+}
+
+// --- Constructor tests ---
+
+func TestNew(t *testing.T) {
+	services := newTestServices()
+	i := New(services)
+	assert.Equal(t, "switchboard", i.Name())
+}
+
+func TestConfigure(t *testing.T) {
+	services := newTestServices()
+	i := New(services)
+	err := i.Configure(context.Background(), mcp.Credentials{})
+	assert.NoError(t, err)
+}
+
+func TestHealthy(t *testing.T) {
+	services := newTestServices()
+	i := New(services)
+	assert.True(t, i.Healthy(context.Background()))
+}
+
+func TestHealthy_NilServices(t *testing.T) {
+	s := &switchboardInt{}
+	assert.False(t, s.Healthy(context.Background()))
+}
+
+// --- Tools metadata tests ---
+
+func TestTools(t *testing.T) {
+	services := newTestServices()
+	i := New(services)
+	toolList := i.Tools()
+	assert.NotEmpty(t, toolList)
+
+	seen := make(map[mcp.ToolName]bool)
+	for _, tool := range toolList {
+		assert.True(t, strings.HasPrefix(string(tool.Name), "switchboard_"),
+			"tool %s missing switchboard_ prefix", tool.Name)
+		assert.NotEmpty(t, tool.Description, "tool %s has no description", tool.Name)
+		assert.False(t, seen[tool.Name], "duplicate tool: %s", tool.Name)
+		seen[tool.Name] = true
+	}
+}
+
+// --- Dispatch parity tests ---
+
+func TestDispatchMap_AllToolsCovered(t *testing.T) {
+	services := newTestServices()
+	i := New(services)
+	for _, tool := range i.Tools() {
+		_, ok := dispatch[tool.Name]
+		assert.True(t, ok, "tool %s has no dispatch handler", tool.Name)
+	}
+}
+
+func TestDispatchMap_NoOrphanHandlers(t *testing.T) {
+	services := newTestServices()
+	i := New(services)
+	toolNames := make(map[mcp.ToolName]bool)
+	for _, tool := range i.Tools() {
+		toolNames[tool.Name] = true
+	}
+	for name := range dispatch {
+		assert.True(t, toolNames[name], "dispatch handler %s has no tool definition", name)
+	}
+}
+
+// --- Execute unknown tool ---
+
+func TestExecute_UnknownTool(t *testing.T) {
+	services := newTestServices()
+	i := New(services)
+	res, err := i.Execute(context.Background(), "switchboard_nonexistent", nil)
+	require.NoError(t, err)
+	assert.True(t, res.IsError)
+	assert.Contains(t, res.Data, "unknown tool")
+}
+
+// --- Handler tests ---
+
+func TestListIntegrations(t *testing.T) {
+	fake := &fakeIntegration{name: "fake", healthy: true}
+	services := newTestServices(fake)
+	s := newTestIntegration(services)
+
+	res, err := listIntegrations(context.Background(), s, map[string]any{})
+	require.NoError(t, err)
+	assert.False(t, res.IsError)
+
+	var items []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(res.Data), &items))
+	assert.NotEmpty(t, items)
+	assert.Equal(t, "fake", items[0]["name"])
+}
+
+func TestListIntegrations_EnabledOnly(t *testing.T) {
+	fake := &fakeIntegration{name: "fake", healthy: true}
+	other := &fakeIntegration{name: "other", healthy: false}
+	services := newTestServices(fake, other)
+	s := newTestIntegration(services)
+
+	res, err := listIntegrations(context.Background(), s, map[string]any{"enabled_only": true})
+	require.NoError(t, err)
+	assert.False(t, res.IsError)
+
+	var items []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(res.Data), &items))
+	assert.Len(t, items, 1)
+	assert.Equal(t, "fake", items[0]["name"])
+}
+
+func TestGetIntegration_Found(t *testing.T) {
+	fake := &fakeIntegration{name: "fake", healthy: true}
+	services := newTestServices(fake)
+	s := newTestIntegration(services)
+
+	res, err := getIntegration(context.Background(), s, map[string]any{"name": "fake"})
+	require.NoError(t, err)
+	assert.False(t, res.IsError)
+
+	var detail map[string]any
+	require.NoError(t, json.Unmarshal([]byte(res.Data), &detail))
+	assert.Equal(t, "fake", detail["name"])
+	assert.Equal(t, float64(2), detail["tool_count"])
+}
+
+func TestGetIntegration_NotFound(t *testing.T) {
+	services := newTestServices()
+	s := newTestIntegration(services)
+
+	res, err := getIntegration(context.Background(), s, map[string]any{"name": "nonexistent"})
+	require.NoError(t, err)
+	assert.True(t, res.IsError)
+	assert.Contains(t, res.Data, "integration not found")
+}
+
+func TestGetIntegration_MissingName(t *testing.T) {
+	services := newTestServices()
+	s := newTestIntegration(services)
+
+	res, err := getIntegration(context.Background(), s, map[string]any{})
+	require.NoError(t, err)
+	assert.True(t, res.IsError)
+}
+
+func TestConfigureIntegration_Success(t *testing.T) {
+	fake := &fakeIntegration{name: "fake", healthy: true}
+	services := newTestServices(fake)
+	s := newTestIntegration(services)
+
+	res, err := configureIntegration(context.Background(), s, map[string]any{
+		"name":        "fake",
+		"credentials": map[string]any{"api_key": "new-key"},
+		"enabled":     true,
+	})
+	require.NoError(t, err)
+	assert.False(t, res.IsError)
+	assert.Contains(t, res.Data, "ok")
+
+	ic, _ := services.Config.GetIntegration("fake")
+	assert.Equal(t, "new-key", ic.Credentials["api_key"])
+	assert.True(t, ic.Enabled)
+}
+
+func TestConfigureIntegration_Disable(t *testing.T) {
+	fake := &fakeIntegration{name: "fake", healthy: true}
+	services := newTestServices(fake)
+	s := newTestIntegration(services)
+
+	res, err := configureIntegration(context.Background(), s, map[string]any{
+		"name":    "fake",
+		"enabled": false,
+	})
+	require.NoError(t, err)
+	assert.False(t, res.IsError)
+	assert.Contains(t, res.Data, "disabled")
+
+	ic, _ := services.Config.GetIntegration("fake")
+	assert.False(t, ic.Enabled)
+}
+
+func TestConfigureIntegration_NotFound(t *testing.T) {
+	services := newTestServices()
+	s := newTestIntegration(services)
+
+	res, err := configureIntegration(context.Background(), s, map[string]any{
+		"name": "nonexistent",
+	})
+	require.NoError(t, err)
+	assert.True(t, res.IsError)
+	assert.Contains(t, res.Data, "integration not found")
+}
+
+func TestConfigureIntegration_ConfigureFails(t *testing.T) {
+	fake := &fakeIntegration{
+		name:      "fake",
+		healthy:   true,
+		configErr: assert.AnError,
+	}
+	services := newTestServices(fake)
+	s := newTestIntegration(services)
+
+	res, err := configureIntegration(context.Background(), s, map[string]any{
+		"name":        "fake",
+		"credentials": map[string]any{"api_key": "bad-key"},
+	})
+	require.NoError(t, err)
+	assert.True(t, res.IsError)
+	assert.Contains(t, res.Data, "configure failed")
+}
+
+func TestCheckHealth_SingleIntegration(t *testing.T) {
+	fake := &fakeIntegration{name: "fake", healthy: true}
+	services := newTestServices(fake)
+	s := newTestIntegration(services)
+
+	res, err := checkHealth(context.Background(), s, map[string]any{"name": "fake"})
+	require.NoError(t, err)
+	assert.False(t, res.IsError)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal([]byte(res.Data), &result))
+	assert.Equal(t, "fake", result["name"])
+	assert.Equal(t, true, result["healthy"])
+}
+
+func TestCheckHealth_NotFound(t *testing.T) {
+	services := newTestServices()
+	s := newTestIntegration(services)
+
+	res, err := checkHealth(context.Background(), s, map[string]any{"name": "nonexistent"})
+	require.NoError(t, err)
+	assert.True(t, res.IsError)
+	assert.Contains(t, res.Data, "integration not found")
+}
+
+func TestCheckHealth_All(t *testing.T) {
+	fake := &fakeIntegration{name: "fake", healthy: true}
+	other := &fakeIntegration{name: "other", healthy: false}
+	services := newTestServices(fake, other)
+	s := newTestIntegration(services)
+
+	res, err := checkHealth(context.Background(), s, map[string]any{})
+	require.NoError(t, err)
+	assert.False(t, res.IsError)
+
+	var results []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(res.Data), &results))
+	assert.Len(t, results, 2)
+}
+
+func TestBrowsePlugins_NilMarketplace(t *testing.T) {
+	services := newTestServices()
+	s := newTestIntegration(services)
+
+	res, err := browsePlugins(context.Background(), s, map[string]any{})
+	require.NoError(t, err)
+	assert.True(t, res.IsError)
+	assert.Contains(t, res.Data, "marketplace is not configured")
+}
+
+func TestInstallPlugin_NilMarketplace(t *testing.T) {
+	services := newTestServices()
+	s := newTestIntegration(services)
+
+	res, err := installPlugin(context.Background(), s, map[string]any{"name": "foo"})
+	require.NoError(t, err)
+	assert.True(t, res.IsError)
+	assert.Contains(t, res.Data, "marketplace is not configured")
+}
+
+func TestInstallPlugin_MissingArgs(t *testing.T) {
+	services := newTestServices()
+	s := newTestIntegration(services)
+	s.marketplace = nil
+
+	res, err := installPlugin(context.Background(), s, map[string]any{})
+	require.NoError(t, err)
+	assert.True(t, res.IsError)
+}
+
+func TestUninstallPlugin_NilMarketplace(t *testing.T) {
+	services := newTestServices()
+	s := newTestIntegration(services)
+
+	res, err := uninstallPlugin(context.Background(), s, map[string]any{"name": "foo"})
+	require.NoError(t, err)
+	assert.True(t, res.IsError)
+	assert.Contains(t, res.Data, "marketplace is not configured")
+}
+
+func TestServerInfo(t *testing.T) {
+	fake := &fakeIntegration{name: "fake", healthy: true}
+	services := newTestServices(fake)
+	s := newTestIntegration(services)
+
+	res, err := serverInfo(context.Background(), s, map[string]any{})
+	require.NoError(t, err)
+	assert.False(t, res.IsError)
+
+	var info map[string]any
+	require.NoError(t, json.Unmarshal([]byte(res.Data), &info))
+	assert.Equal(t, float64(1), info["total_integrations"])
+	assert.Equal(t, float64(2), info["total_tools"])
+}
+
+// --- Compact specs tests ---
+
+func TestFieldCompactionSpecs_AllParse(t *testing.T) {
+	require.NotEmpty(t, fieldCompactionSpecs, "fieldCompactionSpecs should not be empty")
+}
+
+func TestFieldCompactionSpecs_NoDuplicateTools(t *testing.T) {
+	assert.Equal(t, len(rawFieldCompactionSpecs), len(fieldCompactionSpecs))
+}
+
+func TestFieldCompactionSpecs_NoOrphanSpecs(t *testing.T) {
+	for toolName := range fieldCompactionSpecs {
+		_, ok := dispatch[toolName]
+		assert.True(t, ok, "field compaction spec for %q has no dispatch handler", toolName)
+	}
+}
+
+func TestFieldCompactionSpec_ReturnsFields(t *testing.T) {
+	s := &switchboardInt{}
+	fields, ok := s.CompactSpec("switchboard_list_integrations")
+	require.True(t, ok, "switchboard_list_integrations should have field compaction spec")
+	assert.NotEmpty(t, fields)
+}
+
+func TestFieldCompactionSpec_ReturnsFalseForMutationTool(t *testing.T) {
+	s := &switchboardInt{}
+	_, ok := s.CompactSpec("switchboard_configure_integration")
+	assert.False(t, ok, "mutation tool should not have field compaction spec")
+}

--- a/integrations/switchboard/tools.go
+++ b/integrations/switchboard/tools.go
@@ -1,0 +1,79 @@
+package switchboard
+
+import mcp "github.com/daltoniam/switchboard"
+
+var tools = []mcp.ToolDefinition{
+	{
+		Name: "switchboard_list_integrations",
+		Description: "List all registered integrations with their enabled/healthy status, tool counts, and credential keys. " +
+			"Start here for Switchboard self-management, configuration, and integration setup. " +
+			"Shows which integrations are configured, which need credentials, and which are healthy.",
+		Parameters: map[string]string{
+			"enabled_only": "If true, only show enabled integrations (default: false).",
+		},
+	},
+	{
+		Name: "switchboard_get_integration",
+		Description: "Get detailed information about a specific integration including credential keys (not values), " +
+			"tool list, enabled/healthy status, and configuration hints. " +
+			"Use after list_integrations to inspect a single integration before configuring it.",
+		Parameters: map[string]string{
+			"name": "Integration name (e.g. \"github\", \"datadog\", \"slack\").",
+		},
+		Required: []string{"name"},
+	},
+	{
+		Name: "switchboard_configure_integration",
+		Description: "Configure an integration by setting credentials and enabling or disabling it. " +
+			"Credentials are merged with existing values — send only the keys you want to update. " +
+			"Set enabled=false to disable an integration without removing its credentials.",
+		Parameters: map[string]string{
+			"name":        "Integration name (e.g. \"github\", \"datadog\").",
+			"credentials": "JSON object of credential key-value pairs to set (merged with existing).",
+			"enabled":     "Whether to enable the integration after configuring (default: true).",
+		},
+		Required: []string{"name"},
+	},
+	{
+		Name: "switchboard_check_health",
+		Description: "Check connectivity health of one or all enabled integrations. " +
+			"Returns healthy/unhealthy status for each integration by calling its health endpoint. " +
+			"Use to verify credentials work and upstream APIs are reachable.",
+		Parameters: map[string]string{
+			"name": "Optional: specific integration to check. Omit to check all enabled integrations.",
+		},
+	},
+	{
+		Name: "switchboard_browse_plugins",
+		Description: "Browse available plugins from configured marketplace manifest sources. " +
+			"Shows plugin name, description, latest version, and whether it is already installed. " +
+			"Use before install_plugin to discover available extensions.",
+		Parameters: map[string]string{},
+	},
+	{
+		Name: "switchboard_install_plugin",
+		Description: "Install a plugin from the marketplace by name or from a direct URL. " +
+			"Downloads the WASM module, verifies its checksum, and registers it. " +
+			"Requires a server restart to load the plugin. Use after browse_plugins.",
+		Parameters: map[string]string{
+			"name": "Plugin name from the marketplace (mutually exclusive with url).",
+			"url":  "Direct URL to a .wasm file to install (mutually exclusive with name).",
+		},
+	},
+	{
+		Name: "switchboard_uninstall_plugin",
+		Description: "Uninstall a marketplace plugin by name. Removes the WASM file and " +
+			"deregisters it from config. Requires a server restart to take effect.",
+		Parameters: map[string]string{
+			"name": "Name of the installed plugin to remove.",
+		},
+		Required: []string{"name"},
+	},
+	{
+		Name: "switchboard_server_info",
+		Description: "Get Switchboard server information including version, enabled integration count, " +
+			"total tool count, marketplace status, and runtime metrics summary. " +
+			"Use for diagnostics, status checks, and understanding the current server state.",
+		Parameters: map[string]string{},
+	},
+}


### PR DESCRIPTION

## Summary

- Adds a `switchboard` integration with 8 tools that let LLMs manage Switchboard itself — list/get/configure integrations, check health, browse/install/uninstall marketplace plugins, and get server info
- Operates directly on the `Services` struct (no HTTP) with marketplace attached post-construction via `SetMarketplace()`
- Includes field compaction specs for list/read tools, 30 tests with full dispatch parity coverage, and config defaults wiring

## Test plan

- [x] `make ci` passes (build, vet, test-race, lint, gosec, govulncheck)
- [x] All 30 integration tests pass
- [x] Dispatch parity tests verify all tools have handlers and vice versa
- [x] Compact spec parity tests verify no orphan specs
- [x] Config test counts updated for new integration (33 → 34)


🐨 Generated with Crush