### PR TITLE
feat(posthog): add posthog_query tool and expose insight result fields

### DIFF
--- a/integrations/posthog/compact_specs.go
+++ b/integrations/posthog/compact_specs.go
@@ -33,6 +33,12 @@ var rawFieldCompactionSpecs = map[mcp.ToolName][]string{
 	mcp.ToolName("posthog_list_insights"): {"results[].id", "results[].name", "results[].short_id", "results[].filters", "results[].query", "results[].result", "results[].hogql", "results[].is_cached", "results[].last_refresh", "results[].query_status", "results[].created_at", "results[].created_by.email", "results[].last_modified_at"},
 	mcp.ToolName("posthog_get_insight"):   {"id", "name", "short_id", "description", "filters", "query", "result", "hogql", "is_cached", "last_refresh", "query_status", "created_at", "created_by.email", "last_modified_at"},
 
+	// ── Query (HogQL) ───────────────────────────────────────────────
+	// /query/ responses include columns, results (2D row data), types, hogql,
+	// query (echo of the request), timings, and query_status. timings/types
+	// are rarely useful to the LLM and are dropped to save tokens.
+	mcp.ToolName("posthog_query"): {"columns", "results", "hogql", "query_status", "is_cached"},
+
 	// ── Persons ─────────────────────────────────────────────────────
 	mcp.ToolName("posthog_list_persons"): {"results[].id", "results[].distinct_ids", "results[].properties.email", "results[].properties.name", "results[].created_at"},
 	mcp.ToolName("posthog_get_person"):   {"id", "distinct_ids", "properties", "created_at"},

--- a/integrations/posthog/compact_specs.go
+++ b/integrations/posthog/compact_specs.go
@@ -27,8 +27,11 @@ var rawFieldCompactionSpecs = map[mcp.ToolName][]string{
 	mcp.ToolName("posthog_list_cohort_persons"): {"results[].id", "results[].distinct_ids", "results[].properties", "results[].created_at"},
 
 	// ── Insights ────────────────────────────────────────────────────
-	mcp.ToolName("posthog_list_insights"): {"results[].id", "results[].name", "results[].short_id", "results[].filters", "results[].created_at", "results[].created_by.email", "results[].last_modified_at"},
-	mcp.ToolName("posthog_get_insight"):   {"id", "name", "short_id", "description", "filters", "query", "result", "created_at", "created_by.email", "last_modified_at"},
+	// Note: result/hogql/is_cached/last_refresh/query_status expose the computed
+	// query output. PostHog computes results lazily, so freshly-created insights
+	// may have result: null until the first refresh (is_cached: true).
+	mcp.ToolName("posthog_list_insights"): {"results[].id", "results[].name", "results[].short_id", "results[].filters", "results[].query", "results[].result", "results[].hogql", "results[].is_cached", "results[].last_refresh", "results[].query_status", "results[].created_at", "results[].created_by.email", "results[].last_modified_at"},
+	mcp.ToolName("posthog_get_insight"):   {"id", "name", "short_id", "description", "filters", "query", "result", "hogql", "is_cached", "last_refresh", "query_status", "created_at", "created_by.email", "last_modified_at"},
 
 	// ── Persons ─────────────────────────────────────────────────────
 	mcp.ToolName("posthog_list_persons"): {"results[].id", "results[].distinct_ids", "results[].properties.email", "results[].properties.name", "results[].created_at"},

--- a/integrations/posthog/insights.go
+++ b/integrations/posthog/insights.go
@@ -135,3 +135,38 @@ func deleteInsight(ctx context.Context, p *posthog, args map[string]any) (*mcp.T
 	}
 	return mcp.RawResult(data)
 }
+
+func runQuery(ctx context.Context, p *posthog, args map[string]any) (*mcp.ToolResult, error) {
+	projID, err := p.proj(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	r := mcp.NewArgs(args)
+	hogql := r.Str("query")
+	clientQueryID := r.Str("client_query_id")
+	refresh := r.Str("refresh")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if hogql == "" {
+		return mcp.ErrResult(fmt.Errorf("query is required"))
+	}
+	body := map[string]any{
+		"query": map[string]any{
+			"kind":  "HogQLQuery",
+			"query": hogql,
+		},
+	}
+	if clientQueryID != "" {
+		body["client_query_id"] = clientQueryID
+	}
+	if refresh != "" {
+		body["refresh"] = refresh
+	}
+	path := fmt.Sprintf("/api/projects/%s/query/", projID)
+	data, err := p.post(ctx, path, body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}

--- a/integrations/posthog/posthog.go
+++ b/integrations/posthog/posthog.go
@@ -230,6 +230,7 @@ var dispatch = map[mcp.ToolName]handlerFunc{
 	mcp.ToolName("posthog_create_insight"): createInsight,
 	mcp.ToolName("posthog_update_insight"): updateInsight,
 	mcp.ToolName("posthog_delete_insight"): deleteInsight,
+	mcp.ToolName("posthog_query"):          runQuery,
 
 	// Persons
 	mcp.ToolName("posthog_list_persons"):           listPersons,

--- a/integrations/posthog/posthog_test.go
+++ b/integrations/posthog/posthog_test.go
@@ -432,3 +432,90 @@ func TestNoDefaultProject_WithArg(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, result.IsError)
 }
+
+func TestRunQuery(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/projects/1/query/", r.URL.Path)
+		assert.Equal(t, "Bearer token", r.Header.Get("Authorization"))
+
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+
+		q, ok := body["query"].(map[string]any)
+		require.True(t, ok, "query must be a nested object")
+		assert.Equal(t, "HogQLQuery", q["kind"])
+		assert.Equal(t, "SELECT count() FROM events", q["query"])
+
+		// Optional fields must be omitted when not provided.
+		_, hasClientID := body["client_query_id"]
+		_, hasRefresh := body["refresh"]
+		assert.False(t, hasClientID, "client_query_id should be omitted when empty")
+		assert.False(t, hasRefresh, "refresh should be omitted when empty")
+
+		_, _ = w.Write([]byte(`{"columns":["count"],"results":[[42]],"hogql":"SELECT count() FROM events"}`))
+	}))
+	defer ts.Close()
+
+	p := &posthog{apiKey: "token", projectID: "1", client: ts.Client(), baseURL: ts.URL}
+	result, err := p.Execute(context.Background(), "posthog_query", map[string]any{
+		"query": "SELECT count() FROM events",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, `"results"`)
+	assert.Contains(t, result.Data, "42")
+}
+
+func TestRunQuery_OptionalFields(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "trace-abc", body["client_query_id"])
+		assert.Equal(t, "blocking", body["refresh"])
+		_, _ = w.Write([]byte(`{"columns":[],"results":[]}`))
+	}))
+	defer ts.Close()
+
+	p := &posthog{apiKey: "token", projectID: "1", client: ts.Client(), baseURL: ts.URL}
+	result, err := p.Execute(context.Background(), "posthog_query", map[string]any{
+		"query":           "SELECT 1",
+		"client_query_id": "trace-abc",
+		"refresh":         "blocking",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+}
+
+func TestRunQuery_EmptyQuery(t *testing.T) {
+	// Server should never be called when query is empty.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("unexpected request to %s", r.URL.Path)
+	}))
+	defer ts.Close()
+
+	p := &posthog{apiKey: "token", projectID: "1", client: ts.Client(), baseURL: ts.URL}
+	result, err := p.Execute(context.Background(), "posthog_query", map[string]any{
+		"query": "",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "query is required")
+}
+
+func TestRunQuery_UsesProjectArg(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/projects/77/query/", r.URL.Path)
+		_, _ = w.Write([]byte(`{"results":[]}`))
+	}))
+	defer ts.Close()
+
+	// No default projectID configured — must come from args.
+	p := &posthog{apiKey: "token", client: ts.Client(), baseURL: ts.URL}
+	result, err := p.Execute(context.Background(), "posthog_query", map[string]any{
+		"project_id": "77",
+		"query":      "SELECT 1",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+}

--- a/integrations/posthog/tools.go
+++ b/integrations/posthog/tools.go
@@ -113,6 +113,11 @@ var tools = []mcp.ToolDefinition{
 		Parameters: map[string]string{"project_id": "Project ID (uses default if configured, otherwise required)", "insight_id": "Insight ID"},
 		Required:   []string{"insight_id"},
 	},
+	{
+		Name: mcp.ToolName("posthog_query"), Description: "Run a HogQL (SQL-like) query synchronously and return inline results. Use this for ad-hoc analytics without persisting an insight. Returns columns, results rows, and execution metadata.",
+		Parameters: map[string]string{"project_id": "Project ID (uses default if configured, otherwise required)", "query": "HogQL query text, e.g. SELECT count() FROM events WHERE timestamp > now() - INTERVAL 7 DAY", "client_query_id": "Optional client-supplied identifier to correlate the request in PostHog logs", "refresh": "Optional cache mode: 'blocking' (default-ish, wait for fresh result), 'force_blocking', 'lazy_async', 'force_cache'"},
+		Required:   []string{"query"},
+	},
 
 	// ── Persons ─────────────────────────────────────────────────────
 	{


### PR DESCRIPTION

## Summary

- Add `posthog_query` tool for synchronous HogQL execution via `/api/projects/{id}/query/`. Lets agents run ad-hoc analytics inline (no insight artifact, no async-cache wait, no cleanup cron needed).
- Expose `result`, `hogql`, `is_cached`, `last_refresh`, and `query_status` on `posthog_list_insights` and `posthog_get_insight`. These fields were silently stripped by the compaction spec, so cached insights returned only metadata.

## Why

An agent needs to answer ad-hoc analytics questions. The agent's only path today is `posthog_create_insight` + `posthog_get_insight`, which has two problems:

1. The compact specs drop the computed `result` field, so even when an insight is cached the agent can't see the data.
2. Freshly POSTed insights have `result: null` because PostHog computes lazily — there's no synchronous query path through the existing tools.

`posthog_query` hits the same `/query/` endpoint the PostHog UI uses for HogQL Editor, returning `columns`, `results`, and execution metadata inline. This is the proper primitive for ad-hoc analytics; insights remain the right tool for *persisting* charts.

## Test plan

- [x] `gofmt -w` + `go vet ./integrations/posthog/...`
- [x] `go build ./...`
- [x] `go test ./...` (all packages green; existing posthog spec tests still pass — they don't pin specific field names)
- [ ] CI: golangci-lint (not installed locally)