### PR TITLE
feat(wasm): add h2c support for HTTP/2 cleartext in plugins

### DIFF
--- a/wasm/guest-rust/sdk/src/lib.rs
+++ b/wasm/guest-rust/sdk/src/lib.rs
@@ -114,7 +114,34 @@ pub fn host_log(msg: &str) {
     }
 }
 
+/// Execute an HTTP request via the host. For standard HTTP/1.1 or
+/// auto-negotiated HTTP/2 over TLS, use this directly.
+///
+/// To force HTTP/2 cleartext (h2c) — required for plaintext gRPC endpoints —
+/// use [`host_http_request_h2c`] instead.
 pub fn host_http_request(req: &HttpRequest) -> Result<HttpResponse, String> {
+    do_host_http_request(req)
+}
+
+/// Execute an HTTP request using HTTP/2 cleartext (h2c) transport.
+///
+/// This is required for talking to gRPC servers or other HTTP/2 services
+/// that listen on plain `http://` without TLS.
+///
+/// Internally this sets the `X-H2C` header which tells the host to use
+/// an h2c-capable HTTP/2 transport instead of the default HTTP/1.1 client.
+pub fn host_http_request_h2c(req: &HttpRequest) -> Result<HttpResponse, String> {
+    let mut patched = HttpRequest {
+        method: req.method.clone(),
+        url: req.url.clone(),
+        headers: req.headers.clone(),
+        body: req.body.clone(),
+    };
+    patched.headers.insert("X-H2C".into(), "1".into());
+    do_host_http_request(&patched)
+}
+
+fn do_host_http_request(req: &HttpRequest) -> Result<HttpResponse, String> {
     let req_json = serde_json::to_vec(req).map_err(|e| e.to_string())?;
     let ptr_size = pack_ptr_size(req_json.as_ptr() as u32, req_json.len() as u32);
     let result = unsafe { host_http_request_raw(ptr_size) };

--- a/wasm/host.go
+++ b/wasm/host.go
@@ -3,14 +3,17 @@ package wasm
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"time"
 
 	"github.com/tetratelabs/wazero/api"
+	"golang.org/x/net/http2"
 )
 
 type httpRequest struct {
@@ -28,7 +31,25 @@ type httpResponse struct {
 
 const maxHostResponseSize = 10 * 1024 * 1024
 
-var hostHTTPClient = &http.Client{Timeout: 30 * time.Second}
+// h2cHeaderKey is the header plugins set to request HTTP/2 cleartext (h2c)
+// transport. Any non-empty value enables h2c for that request.
+const h2cHeaderKey = "X-H2C"
+
+var (
+	hostHTTPClient = &http.Client{Timeout: 30 * time.Second}
+
+	// h2cClient uses an http2.Transport configured for cleartext (no TLS)
+	// connections. Plugins opt in by setting the X-H2C header.
+	h2cClient = &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http2.Transport{
+			AllowHTTP: true,
+			DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+				return (&net.Dialer{}).DialContext(ctx, network, addr)
+			},
+		},
+	}
+)
 
 func hostHTTPRequest(ctx context.Context, mod api.Module, ptrSize uint64) uint64 {
 	ptr, size := unpackPtrSize(ptrSize)
@@ -43,40 +64,11 @@ func hostHTTPRequest(ctx context.Context, mod api.Module, ptrSize uint64) uint64
 		return writeErrorResponse(ctx, mod, fmt.Sprintf("parse request: %v", err))
 	}
 
-	var bodyReader io.Reader
-	if req.Body != "" {
-		bodyReader = bytes.NewBufferString(req.Body)
-	}
-
-	httpReq, err := http.NewRequestWithContext(ctx, req.Method, req.URL, bodyReader)
-	if err != nil {
-		return writeErrorResponse(ctx, mod, fmt.Sprintf("create request: %v", err))
-	}
-	for k, v := range req.Headers {
-		httpReq.Header.Set(k, v)
-	}
-
-	resp, err := hostHTTPClient.Do(httpReq)
+	result, err := doHostHTTP(ctx, &req)
 	if err != nil {
 		return writeErrorResponse(ctx, mod, fmt.Sprintf("http error: %v", err))
 	}
-	defer func() { _ = resp.Body.Close() }()
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxHostResponseSize))
-	if err != nil {
-		return writeErrorResponse(ctx, mod, fmt.Sprintf("read response: %v", err))
-	}
-
-	headers := make(map[string]string)
-	for k := range resp.Header {
-		headers[k] = resp.Header.Get(k)
-	}
-
-	result := httpResponse{
-		Status:  resp.StatusCode,
-		Headers: headers,
-		Body:    string(body),
-	}
 	resultData, err := json.Marshal(result)
 	if err != nil {
 		return writeErrorResponse(ctx, mod, fmt.Sprintf("marshal response: %v", err))
@@ -87,6 +79,57 @@ func hostHTTPRequest(ctx context.Context, mod api.Module, ptrSize uint64) uint64
 		return writeErrorResponse(ctx, mod, fmt.Sprintf("write response: %v", err))
 	}
 	return packPtrSize(rPtr, rSize)
+}
+
+// doHostHTTP executes an HTTP request on behalf of a WASM guest.
+// If the request includes an X-H2C header, the h2c (HTTP/2 cleartext) client
+// is used instead of the default HTTP/1.1 client.
+func doHostHTTP(ctx context.Context, req *httpRequest) (*httpResponse, error) {
+	var bodyReader io.Reader
+	if req.Body != "" {
+		bodyReader = bytes.NewBufferString(req.Body)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, req.Method, req.URL, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	// Check for h2c header before copying headers to the outgoing request.
+	useH2C := req.Headers[h2cHeaderKey] != ""
+	for k, v := range req.Headers {
+		if k == h2cHeaderKey {
+			continue
+		}
+		httpReq.Header.Set(k, v)
+	}
+
+	client := hostHTTPClient
+	if useH2C {
+		client = h2cClient
+	}
+
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxHostResponseSize))
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	headers := make(map[string]string)
+	for k := range resp.Header {
+		headers[k] = resp.Header.Get(k)
+	}
+
+	return &httpResponse{
+		Status:  resp.StatusCode,
+		Headers: headers,
+		Body:    string(body),
+	}, nil
 }
 
 func writeErrorResponse(ctx context.Context, mod api.Module, msg string) uint64 {

--- a/wasm/host_test.go
+++ b/wasm/host_test.go
@@ -1,0 +1,127 @@
+package wasm
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+)
+
+// newH2CServer starts an HTTP/2 cleartext server on a random port.
+// Returns the base URL (http://127.0.0.1:<port>) and a cleanup function.
+func newH2CServer(t *testing.T, handler http.Handler) string {
+	t.Helper()
+	h2s := &http2.Server{}
+	srv := &http.Server{Handler: h2c.NewHandler(handler, h2s)}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { srv.Close() })
+
+	return fmt.Sprintf("http://%s", ln.Addr().String())
+}
+
+func TestDoHostHTTP_H2C(t *testing.T) {
+	var gotProto string
+	base := newH2CServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotProto = r.Proto
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+
+	resp, err := doHostHTTP(context.Background(), &httpRequest{
+		Method:  "GET",
+		URL:     base + "/test",
+		Headers: map[string]string{h2cHeaderKey: "1"},
+	})
+	if err != nil {
+		t.Fatalf("doHostHTTP: %v", err)
+	}
+	if resp.Status != 200 {
+		t.Errorf("status = %d, want 200", resp.Status)
+	}
+	if resp.Body != `{"ok":true}` {
+		t.Errorf("body = %q", resp.Body)
+	}
+	if gotProto != "HTTP/2.0" {
+		t.Errorf("server saw proto = %q, want HTTP/2.0", gotProto)
+	}
+}
+
+func TestDoHostHTTP_H2C_HeaderNotForwarded(t *testing.T) {
+	base := newH2CServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if v := r.Header.Get(h2cHeaderKey); v != "" {
+			t.Errorf("X-H2C header leaked to upstream: %q", v)
+		}
+		_, _ = w.Write([]byte("ok"))
+	}))
+
+	_, err := doHostHTTP(context.Background(), &httpRequest{
+		Method:  "GET",
+		URL:     base + "/test",
+		Headers: map[string]string{h2cHeaderKey: "1", "Authorization": "Bearer tok"},
+	})
+	if err != nil {
+		t.Fatalf("doHostHTTP: %v", err)
+	}
+}
+
+func TestDoHostHTTP_HTTP1_Default(t *testing.T) {
+	var gotProto string
+	base := newH2CServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotProto = r.Proto
+		_, _ = w.Write([]byte("ok"))
+	}))
+
+	resp, err := doHostHTTP(context.Background(), &httpRequest{
+		Method: "GET",
+		URL:    base + "/test",
+	})
+	if err != nil {
+		t.Fatalf("doHostHTTP: %v", err)
+	}
+	if resp.Status != 200 {
+		t.Errorf("status = %d, want 200", resp.Status)
+	}
+	// Without the h2c header, the default client uses HTTP/1.1.
+	if gotProto != "HTTP/1.1" {
+		t.Errorf("server saw proto = %q, want HTTP/1.1", gotProto)
+	}
+}
+
+func TestDoHostHTTP_H2C_POST(t *testing.T) {
+	var gotProto, gotBody string
+	base := newH2CServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotProto = r.Proto
+		b := make([]byte, 1024)
+		n, _ := r.Body.Read(b)
+		gotBody = string(b[:n])
+		_, _ = w.Write([]byte(`{"received":true}`))
+	}))
+
+	resp, err := doHostHTTP(context.Background(), &httpRequest{
+		Method:  "POST",
+		URL:     base + "/rpc",
+		Headers: map[string]string{h2cHeaderKey: "1", "Content-Type": "application/json"},
+		Body:    `{"method":"ping"}`,
+	})
+	if err != nil {
+		t.Fatalf("doHostHTTP: %v", err)
+	}
+	if resp.Status != 200 {
+		t.Errorf("status = %d, want 200", resp.Status)
+	}
+	if gotProto != "HTTP/2.0" {
+		t.Errorf("server saw proto = %q, want HTTP/2.0", gotProto)
+	}
+	if gotBody != `{"method":"ping"}` {
+		t.Errorf("server got body = %q", gotBody)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds an h2c (HTTP/2 cleartext) transport to the WASM host HTTP proxy, enabling plugins to talk to plaintext HTTP/2 endpoints like gRPC servers
- Plugins opt in per-request by setting `X-H2C` header — the host strips it before forwarding and routes through `http2.Transport` with `AllowHTTP` + plaintext dialer
- Adds `host_http_request_h2c()` convenience wrapper to the Rust guest SDK

## Test plan

- [x] `TestDoHostHTTP_H2C` — verifies HTTP/2.0 protocol negotiation over h2c
- [x] `TestDoHostHTTP_H2C_HeaderNotForwarded` — verifies X-H2C stripped from upstream request
- [x] `TestDoHostHTTP_HTTP1_Default` — verifies default path stays HTTP/1.1
- [x] `TestDoHostHTTP_H2C_POST` — verifies request body works over h2c
- [x] `make ci` passes (build, vet, test-race, lint, gosec, govulncheck)


🐶 Generated with Crush