### PR TITLE
feat(rwx): upgrade integration for rwx CLI v3.13

### DIFF
--- a/integrations/rwx/compact_specs.go
+++ b/integrations/rwx/compact_specs.go
@@ -10,8 +10,8 @@ var rawFieldCompactionSpecs = map[mcp.ToolName][]string{
 	// ── Runs ────────────────────────────────────────────────────────
 	// Handler: jsonResult(map{ref, count, runs: [{run_id, status, commit_sha, title, definition_path, url}]})
 	mcp.ToolName("rwx_get_recent_runs"): {"ref", "count", "runs[].run_id", "runs[].status", "runs[].commit_sha", "runs[].title", "runs[].definition_path", "runs[].url"},
-	// Handler: jsonResult(map{run_id, url, status, execution, duration_seconds, summary, failed_tasks, tasks: [{key, status, duration_seconds, cache_hit}]})
-	mcp.ToolName("rwx_get_run_results"): {"run_id", "url", "status", "duration_seconds", "summary", "failed_tasks", "tasks[].key", "tasks[].status", "tasks[].duration_seconds", "tasks[].cache_hit"},
+	// Handler: jsonResult(map{run_id, url, status, completed, duration_seconds, title, branch, commit_sha, definition_path, failed_tasks: [{key, task_id, has_artifacts}], failed_tests, other_problems})
+	mcp.ToolName("rwx_get_run_results"): {"run_id", "url", "status", "completed", "duration_seconds", "title", "branch", "commit_sha", "definition_path", "failed_tasks[].key", "failed_tasks[].task_id", "failed_tasks[].has_artifacts", "failed_tests", "other_problems"},
 }
 
 var fieldCompactionSpecs = mustBuildFieldCompactionSpecs(rawFieldCompactionSpecs)

--- a/integrations/rwx/docs.go
+++ b/integrations/rwx/docs.go
@@ -1,0 +1,89 @@
+package rwx
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+func docsSearch(_ context.Context, r *rwx, args map[string]any) (*mcp.ToolResult, error) {
+	ra := mcp.NewArgs(args)
+	query := ra.Str("query")
+	limit := ra.Int("limit")
+	if err := ra.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if limit <= 0 {
+		limit = 5
+	}
+
+	cmdArgs := []string{"docs", "search", query, "--output", "json", "--limit", fmt.Sprintf("%d", limit)}
+	output, err := r.runRWXCommand(cmdArgs, 30000)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	var parsed struct {
+		Query     string `json:"Query"`
+		TotalHits int    `json:"TotalHits"`
+		Results   []struct {
+			URL   string `json:"url"`
+			Path  string `json:"path"`
+			Title string `json:"title"`
+			Body  string `json:"body"`
+		} `json:"Results"`
+	}
+	if err := json.Unmarshal([]byte(output), &parsed); err != nil {
+		return mcp.ErrResult(fmt.Errorf("parse docs search: %w", err))
+	}
+
+	var results []map[string]any
+	for _, doc := range parsed.Results {
+		entry := map[string]any{
+			"title": doc.Title,
+			"url":   doc.URL,
+			"path":  doc.Path,
+		}
+		if len(doc.Body) > 500 {
+			entry["snippet"] = doc.Body[:500] + "..."
+		} else {
+			entry["snippet"] = doc.Body
+		}
+		results = append(results, entry)
+	}
+
+	return mcp.JSONResult(map[string]any{
+		"query":      parsed.Query,
+		"total_hits": parsed.TotalHits,
+		"count":      len(results),
+		"results":    results,
+	})
+}
+
+func docsPull(_ context.Context, r *rwx, args map[string]any) (*mcp.ToolResult, error) {
+	urlOrPath, err := mcp.ArgStr(args, "url_or_path")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	cmdArgs := []string{"docs", "pull", urlOrPath, "--output", "json"}
+	output, err := r.runRWXCommand(cmdArgs, 30000)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	var parsed struct {
+		URL  string `json:"URL"`
+		Body string `json:"Body"`
+	}
+	if err := json.Unmarshal([]byte(output), &parsed); err != nil {
+		return mcp.ErrResult(fmt.Errorf("parse docs pull: %w", err))
+	}
+
+	return mcp.JSONResult(map[string]any{
+		"url":     parsed.URL,
+		"content": parsed.Body,
+	})
+}

--- a/integrations/rwx/logs.go
+++ b/integrations/rwx/logs.go
@@ -58,35 +58,44 @@ func (c *logCache) set(id, logs string) {
 
 // --- Log download ---
 
-func downloadLogs(ctx context.Context, r *rwx, id string) (string, error) {
-	if cached, ok := r.logCache.get(id); ok {
+func downloadLogs(ctx context.Context, r *rwx, id string, taskKey ...string) (string, error) {
+	cacheKey := id
+	if len(taskKey) > 0 && taskKey[0] != "" {
+		cacheKey = id + ":" + taskKey[0]
+	}
+	if cached, ok := r.logCache.get(cacheKey); ok {
 		return cached, nil
 	}
 
-	logs, err := r.downloadLogsFromRWX(id)
+	logs, err := r.downloadLogsFromRWX(id, taskKey...)
 	if err != nil {
 		return "", err
 	}
 
 	go func() {
-		status, isComplete, err := fetchRunStatus(ctx, r, id)
+		bgCtx := context.WithoutCancel(ctx)
+		status, isComplete, err := fetchRunStatus(bgCtx, r, id)
 		_ = status
 		if err == nil && isComplete {
-			r.logCache.set(id, logs)
+			r.logCache.set(cacheKey, logs)
 		}
 	}()
 
 	return logs, nil
 }
 
-func (r *rwx) downloadLogsFromRWX(id string) (string, error) {
+func (r *rwx) downloadLogsFromRWX(id string, taskKey ...string) (string, error) {
 	outputDir, err := os.MkdirTemp("", fmt.Sprintf("rwx-logs-%s-", id))
 	if err != nil {
 		return "", fmt.Errorf("create temp dir: %w", err)
 	}
 	defer func() { _ = os.RemoveAll(outputDir) }()
 
-	_, err = r.runRWXCommand([]string{"logs", id, "--output-dir", outputDir, "--auto-extract", "--output", "json"}, 0)
+	cmdArgs := []string{"logs", id, "--output-dir", outputDir, "--auto-extract", "--output", "json"}
+	if len(taskKey) > 0 && taskKey[0] != "" {
+		cmdArgs = append(cmdArgs, "--task", taskKey[0])
+	}
+	_, err = r.runRWXCommand(cmdArgs, 0)
 	if err != nil {
 		return "", err
 	}
@@ -140,12 +149,26 @@ func findLogFiles(dir string) ([]string, error) {
 // --- Log tool handlers ---
 
 func getTaskLogs(ctx context.Context, r *rwx, args map[string]any) (*mcp.ToolResult, error) {
-	taskIDRaw, err := mcp.ArgStr(args, "task_id")
-	if err != nil {
+	ra := mcp.NewArgs(args)
+	taskIDRaw := ra.Str("task_id")
+	runIDRaw := ra.Str("run_id")
+	taskKey := ra.Str("task_key")
+	if err := ra.Err(); err != nil {
 		return mcp.ErrResult(err)
 	}
-	id := extractRunID(taskIDRaw)
-	logs, err := downloadLogs(ctx, r, id)
+
+	var id string
+	var logTaskKey string
+	if taskKey != "" && runIDRaw != "" {
+		id = extractRunID(runIDRaw)
+		logTaskKey = taskKey
+	} else if taskIDRaw != "" {
+		id = extractRunID(taskIDRaw)
+	} else {
+		return mcp.ErrResult(fmt.Errorf("either task_id or run_id+task_key is required"))
+	}
+
+	logs, err := downloadLogs(ctx, r, id, logTaskKey)
 	if err != nil {
 		return mcp.ErrResult(err)
 	}
@@ -186,6 +209,7 @@ func headLogs(ctx context.Context, r *rwx, args map[string]any) (*mcp.ToolResult
 	idRaw := ra.Str("id")
 	numLines := ra.Int("lines")
 	offset := ra.Int("offset")
+	taskKey := ra.Str("task_key")
 	if err := ra.Err(); err != nil {
 		return mcp.ErrResult(err)
 	}
@@ -194,7 +218,7 @@ func headLogs(ctx context.Context, r *rwx, args map[string]any) (*mcp.ToolResult
 		numLines = maxLinesPerPage
 	}
 
-	logs, err := downloadLogs(ctx, r, id)
+	logs, err := downloadLogs(ctx, r, id, taskKey)
 	if err != nil {
 		return mcp.ErrResult(err)
 	}
@@ -232,6 +256,7 @@ func tailLogs(ctx context.Context, r *rwx, args map[string]any) (*mcp.ToolResult
 	idRaw := ra.Str("id")
 	numLines := ra.Int("lines")
 	offset := ra.Int("offset")
+	taskKey := ra.Str("task_key")
 	if err := ra.Err(); err != nil {
 		return mcp.ErrResult(err)
 	}
@@ -240,7 +265,7 @@ func tailLogs(ctx context.Context, r *rwx, args map[string]any) (*mcp.ToolResult
 		numLines = maxLinesPerPage
 	}
 
-	logs, err := downloadLogs(ctx, r, id)
+	logs, err := downloadLogs(ctx, r, id, taskKey)
 	if err != nil {
 		return mcp.ErrResult(err)
 	}
@@ -281,6 +306,7 @@ func grepLogs(ctx context.Context, r *rwx, args map[string]any) (*mcp.ToolResult
 	pattern := ra.Str("pattern")
 	contextLines := ra.Int("context")
 	page := ra.Int("page")
+	taskKey := ra.Str("task_key")
 	if err := ra.Err(); err != nil {
 		return mcp.ErrResult(err)
 	}
@@ -292,7 +318,7 @@ func grepLogs(ctx context.Context, r *rwx, args map[string]any) (*mcp.ToolResult
 		page = 1
 	}
 
-	logs, err := downloadLogs(ctx, r, id)
+	logs, err := downloadLogs(ctx, r, id, taskKey)
 	if err != nil {
 		return mcp.ErrResult(err)
 	}

--- a/integrations/rwx/proxy.go
+++ b/integrations/rwx/proxy.go
@@ -23,10 +23,12 @@ var cliToMCPReplacements = []struct {
 	{regexp.MustCompile("`rwx logs[^`]*`"), "the log tools (rwx_get_task_logs, rwx_head_logs, rwx_tail_logs, rwx_grep_logs)"},
 	{regexp.MustCompile("`rwx results[^`]*`"), "the rwx_get_run_results tool"},
 	{regexp.MustCompile("`rwx artifacts[^`]*`"), "the rwx_get_artifacts tool"},
+	{regexp.MustCompile("`rwx dispatch[^`]*`"), "the rwx_dispatch_run tool"},
 	{regexp.MustCompile("`rwx run[^`]*`"), "the rwx_launch_ci_run tool"},
 	{regexp.MustCompile(`(?i)\brwx logs\b`), "the log tools (rwx_get_task_logs, rwx_head_logs, rwx_tail_logs, rwx_grep_logs)"},
 	{regexp.MustCompile(`(?i)\brwx results\b`), "the rwx_get_run_results tool"},
 	{regexp.MustCompile(`(?i)\brwx artifacts\b`), "the rwx_get_artifacts tool"},
+	{regexp.MustCompile(`(?i)\brwx dispatch\b`), "the rwx_dispatch_run tool"},
 	{regexp.MustCompile(`(?i)\brwx run\b`), "the rwx_launch_ci_run tool"},
 }
 

--- a/integrations/rwx/runs.go
+++ b/integrations/rwx/runs.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 
@@ -13,8 +14,11 @@ import (
 )
 
 func launchCIRun(_ context.Context, r *rwx, args map[string]any) (*mcp.ToolResult, error) {
-	workflow, err := mcp.ArgStr(args, "workflow")
-	if err != nil {
+	ra := mcp.NewArgs(args)
+	workflow := ra.Str("workflow")
+	wait := ra.Bool("wait")
+	title := ra.Str("title")
+	if err := ra.Err(); err != nil {
 		return mcp.ErrResult(err)
 	}
 	if workflow == "" {
@@ -22,12 +26,8 @@ func launchCIRun(_ context.Context, r *rwx, args map[string]any) (*mcp.ToolResul
 	}
 	cmdArgs := []string{"run", workflow, "--output", "json"}
 
-	wait, err := mcp.ArgBool(args, "wait")
-	if err != nil {
-		return mcp.ErrResult(err)
-	}
 	if wait {
-		cmdArgs = append(cmdArgs, "--wait")
+		cmdArgs = append(cmdArgs, "--wait", "--fail-fast")
 	}
 
 	targets, err := mcp.ArgStrSlice(args, "targets")
@@ -36,6 +36,18 @@ func launchCIRun(_ context.Context, r *rwx, args map[string]any) (*mcp.ToolResul
 	}
 	for _, t := range targets {
 		cmdArgs = append(cmdArgs, "--target", t)
+	}
+
+	if title != "" {
+		cmdArgs = append(cmdArgs, "--title", title)
+	}
+
+	initParams, err := mcp.ArgMap(args, "init")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	for k, v := range initParams {
+		cmdArgs = append(cmdArgs, "--init", fmt.Sprintf("%s=%v", k, v))
 	}
 
 	var timeoutMs int
@@ -89,6 +101,89 @@ func launchCIRun(_ context.Context, r *rwx, args map[string]any) (*mcp.ToolResul
 		"status":    "launched",
 		"url":       runURL,
 		"next_step": "Use rwx_wait_for_ci_run to wait for completion, or launch with wait=true",
+	})
+}
+
+func dispatchRun(_ context.Context, r *rwx, args map[string]any) (*mcp.ToolResult, error) {
+	ra := mcp.NewArgs(args)
+	dispatchKey := ra.Str("dispatch_key")
+	ref := ra.Str("ref")
+	wait := ra.Bool("wait")
+	title := ra.Str("title")
+	if err := ra.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	cmdArgs := []string{"dispatch", dispatchKey, "--output", "json"}
+	if ref != "" {
+		cmdArgs = append(cmdArgs, "--ref", ref)
+	}
+	if wait {
+		cmdArgs = append(cmdArgs, "--wait", "--fail-fast")
+	}
+	if title != "" {
+		cmdArgs = append(cmdArgs, "--title", title)
+	}
+
+	params, err := mcp.ArgMap(args, "params")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	for k, v := range params {
+		cmdArgs = append(cmdArgs, "--param", fmt.Sprintf("%s=%v", k, v))
+	}
+
+	var timeoutMs int
+	if wait {
+		timeoutMs = 30 * 60 * 1000
+	}
+
+	output, err := r.runRWXCommand(cmdArgs, timeoutMs)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	var parsed struct {
+		RunID     string `json:"run_id"`
+		RunURL    string `json:"run_url"`
+		Result    string `json:"result"`
+		Execution string `json:"execution"`
+	}
+	if err := json.Unmarshal([]byte(output), &parsed); err != nil {
+		return mcp.ErrResult(fmt.Errorf("parse dispatch output: %w", err))
+	}
+
+	runURL := parsed.RunURL
+	if runURL == "" {
+		runURL = fmt.Sprintf("%s/mint/%s/runs/%s", r.baseURL, r.org, parsed.RunID)
+	}
+
+	if wait {
+		status := normalizeStatus(parsed.Result)
+		resp := map[string]any{
+			"completed": true,
+			"run_id":    parsed.RunID,
+			"status":    status,
+			"url":       runURL,
+		}
+		if status == "failure" {
+			resp["next_step"] = "Use rwx_get_run_results to see task failures, or rwx_grep_logs to search for errors"
+		} else {
+			resp["next_step"] = "Run completed successfully"
+		}
+		result, _ := mcp.JSONResult(resp)
+		if status == "failure" {
+			result.IsError = true
+		}
+		return result, nil
+	}
+
+	return mcp.JSONResult(map[string]any{
+		"completed": false,
+		"run_id":    parsed.RunID,
+		"status":    "launched",
+		"url":       runURL,
+		"next_step": "Use rwx_wait_for_ci_run to wait for completion, or dispatch with wait=true",
 	})
 }
 
@@ -245,68 +340,106 @@ func getRecentRuns(ctx context.Context, r *rwx, args map[string]any) (*mcp.ToolR
 	})
 }
 
-func getRunResults(_ context.Context, r *rwx, args map[string]any) (*mcp.ToolResult, error) {
-	runIDRaw, err := mcp.ArgStr(args, "run_id")
-	if err != nil {
+func getRunResults(ctx context.Context, r *rwx, args map[string]any) (*mcp.ToolResult, error) {
+	ra := mcp.NewArgs(args)
+	runIDRaw := ra.Str("run_id")
+	taskKey := ra.Str("task_key")
+	branch := ra.Str("branch")
+	commit := ra.Str("commit")
+	repo := ra.Str("repo")
+	definition := ra.Str("definition")
+	if err := ra.Err(); err != nil {
 		return mcp.ErrResult(err)
 	}
-	id := extractRunID(runIDRaw)
-	output, err := r.runRWXCommand([]string{"results", id, "--output", "json"}, 0)
+
+	var cmdArgs []string
+	if runIDRaw != "" {
+		id := extractRunID(runIDRaw)
+		cmdArgs = []string{"results", id, "--output", "json"}
+	} else if branch != "" || commit != "" {
+		cmdArgs = []string{"results", "--output", "json"}
+		if branch != "" {
+			cmdArgs = append(cmdArgs, "--branch", branch)
+		}
+		if commit != "" {
+			cmdArgs = append(cmdArgs, "--commit", commit)
+		}
+		if repo != "" {
+			cmdArgs = append(cmdArgs, "--repo", repo)
+		}
+		if definition != "" {
+			cmdArgs = append(cmdArgs, "--definition", definition)
+		}
+	} else {
+		return mcp.ErrResult(fmt.Errorf("either run_id or branch/commit is required"))
+	}
+	if taskKey != "" {
+		cmdArgs = append(cmdArgs, "--task", taskKey)
+	}
+
+	output, err := r.runRWXCommand(cmdArgs, 0)
 	if err != nil {
 		return mcp.ErrResult(err)
 	}
 
 	var parsed struct {
-		RunID     string `json:"run_id"`
-		Result    string `json:"result"`
-		Execution string `json:"execution"`
-		Duration  int    `json:"duration_seconds"`
-		Tasks     []struct {
-			Key      string `json:"key"`
-			Status   string `json:"status"`
-			Duration int    `json:"duration_seconds"`
-			CacheHit bool   `json:"cache_hit"`
-		} `json:"tasks"`
+		RunID        string `json:"RunID"`
+		TaskID       string `json:"TaskID"`
+		ResultStatus string `json:"ResultStatus"`
+		Completed    bool   `json:"Completed"`
+		Prompt       string `json:"Prompt"`
 	}
 	if err := json.Unmarshal([]byte(output), &parsed); err != nil {
 		return mcp.ErrResult(fmt.Errorf("parse results: %w", err))
 	}
 
+	id := parsed.RunID
 	runURL := fmt.Sprintf("%s/mint/%s/runs/%s", r.baseURL, r.org, id)
-	status := normalizeStatus(parsed.Result)
+	status := normalizeStatus(parsed.ResultStatus)
 
-	var failedKeys []string
-	succeeded, failed, skipped, cached := 0, 0, 0, 0
-	for _, t := range parsed.Tasks {
-		switch strings.ToLower(t.Status) {
-		case "succeeded":
-			succeeded++
-		case "failed":
-			failed++
-			failedKeys = append(failedKeys, t.Key)
-		case "skipped":
-			skipped++
+	failedTasks, failedTests, otherProblems := parseResultsPrompt(parsed.Prompt)
+
+	resp := map[string]any{
+		"run_id":    id,
+		"url":       runURL,
+		"status":    status,
+		"completed": parsed.Completed,
+	}
+
+	if parsed.TaskID != "" {
+		resp["task_id"] = parsed.TaskID
+	}
+	if taskKey != "" {
+		resp["task_key"] = taskKey
+	}
+
+	runDetail, detailErr := fetchRunDetail(ctx, r, id)
+	if detailErr == nil {
+		if v, ok := runDetail["completed_runtime_seconds"]; ok {
+			resp["duration_seconds"] = v
 		}
-		if t.CacheHit {
-			cached++
+		if v, ok := runDetail["title"]; ok {
+			resp["title"] = v
+		}
+		if v, ok := runDetail["branch"]; ok {
+			resp["branch"] = v
+		}
+		if v, ok := runDetail["commit_sha"]; ok {
+			resp["commit_sha"] = v
+		}
+		if v, ok := runDetail["definition_path"]; ok {
+			resp["definition_path"] = v
 		}
 	}
 
-	resp := map[string]any{
-		"run_id":           id,
-		"url":              runURL,
-		"status":           status,
-		"execution":        parsed.Execution,
-		"duration_seconds": parsed.Duration,
-		"summary": map[string]int{
-			"total":     len(parsed.Tasks),
-			"succeeded": succeeded,
-			"failed":    failed,
-			"skipped":   skipped,
-			"cached":    cached,
-		},
-		"failed_tasks": failedKeys,
-		"tasks":        parsed.Tasks,
+	if len(failedTasks) > 0 {
+		resp["failed_tasks"] = failedTasks
+	}
+	if len(failedTests) > 0 {
+		resp["failed_tests"] = failedTests
+	}
+	if len(otherProblems) > 0 {
+		resp["other_problems"] = otherProblems
 	}
 
 	result, _ := mcp.JSONResult(resp)
@@ -314,6 +447,90 @@ func getRunResults(_ context.Context, r *rwx, args map[string]any) (*mcp.ToolRes
 		result.IsError = true
 	}
 	return result, nil
+}
+
+func fetchRunDetail(ctx context.Context, r *rwx, runID string) (map[string]any, error) {
+	apiURL := fmt.Sprintf("%s/mint/api/runs/%s", r.baseURL, runID)
+	req, err := http.NewRequestWithContext(ctx, "GET", apiURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+r.accessToken)
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("API error: %d", resp.StatusCode)
+	}
+
+	var data map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+type failedTask struct {
+	Key          string `json:"key"`
+	TaskID       string `json:"task_id"`
+	HasArtifacts bool   `json:"has_artifacts,omitempty"`
+}
+
+func parseResultsPrompt(prompt string) (tasks []failedTask, failedTests []string, otherProblems []string) {
+	if prompt == "" {
+		return nil, nil, nil
+	}
+
+	lines := strings.Split(prompt, "\n")
+	var section string
+	taskRe := regexp.MustCompile(`^- (.+?) \(task-id: ([a-f0-9]+)\)(.*)`)
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		if strings.HasPrefix(trimmed, "# Failed tests:") {
+			section = "tests"
+			continue
+		}
+		if strings.HasPrefix(trimmed, "# Failed tasks:") {
+			section = "tasks"
+			continue
+		}
+		if strings.HasPrefix(trimmed, "# Other problems:") {
+			section = "problems"
+			continue
+		}
+		if strings.HasPrefix(trimmed, "For more documentation") {
+			section = ""
+			continue
+		}
+		if strings.HasPrefix(trimmed, "You can pull the logs") {
+			continue
+		}
+		if trimmed == "" {
+			continue
+		}
+
+		switch section {
+		case "tests":
+			failedTests = append(failedTests, trimmed)
+		case "tasks":
+			if m := taskRe.FindStringSubmatch(trimmed); m != nil {
+				ft := failedTask{Key: m[1], TaskID: m[2]}
+				if strings.Contains(m[3], "has artifacts") {
+					ft.HasArtifacts = true
+				}
+				tasks = append(tasks, ft)
+			}
+		case "problems":
+			otherProblems = append(otherProblems, trimmed)
+		}
+	}
+	return tasks, failedTests, otherProblems
 }
 
 // --- helpers ---

--- a/integrations/rwx/rwx.go
+++ b/integrations/rwx/rwx.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	minRWXVersion     = "3.0.0"
+	minRWXVersion     = "3.13.0"
 	defaultRWXAPIBase = "https://cloud.rwx.com"
 	maxResponseSize   = 10 * 1024 * 1024 // 10 MB
 )
@@ -175,6 +175,7 @@ type handlerFunc func(ctx context.Context, r *rwx, args map[string]any) (*mcp.To
 var dispatch = map[mcp.ToolName]handlerFunc{
 	// Runs
 	mcp.ToolName("rwx_launch_ci_run"):   launchCIRun,
+	mcp.ToolName("rwx_dispatch_run"):    dispatchRun,
 	mcp.ToolName("rwx_wait_for_ci_run"): waitForCIRun,
 	mcp.ToolName("rwx_get_recent_runs"): getRecentRuns,
 	mcp.ToolName("rwx_get_run_results"): getRunResults,
@@ -190,6 +191,17 @@ var dispatch = map[mcp.ToolName]handlerFunc{
 
 	// Workflow
 	mcp.ToolName("rwx_validate_workflow"): validateWorkflow,
+
+	// Docs
+	mcp.ToolName("rwx_docs_search"): docsSearch,
+	mcp.ToolName("rwx_docs_pull"):   docsPull,
+
+	// Vaults
+	mcp.ToolName("rwx_vaults_var_show"):      vaultsVarShow,
+	mcp.ToolName("rwx_vaults_var_set"):       vaultsVarSet,
+	mcp.ToolName("rwx_vaults_var_delete"):    vaultsVarDelete,
+	mcp.ToolName("rwx_vaults_secret_set"):    vaultsSecretSet,
+	mcp.ToolName("rwx_vaults_secret_delete"): vaultsSecretDelete,
 
 	// CLI
 	mcp.ToolName("rwx_verify_cli"): verifyCLI,

--- a/integrations/rwx/rwx_test.go
+++ b/integrations/rwx/rwx_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	mcp "github.com/daltoniam/switchboard"
@@ -168,9 +169,11 @@ func TestTransformCLIReferences(t *testing.T) {
 		{"`rwx logs abc`", "rwx_get_task_logs"},
 		{"`rwx results abc`", "rwx_get_run_results"},
 		{"`rwx artifacts abc`", "rwx_get_artifacts"},
+		{"`rwx dispatch my-workflow`", "rwx_dispatch_run"},
 		{"`rwx run .rwx/ci.yml`", "rwx_launch_ci_run"},
 		{"Use rwx logs to see output", "rwx_get_task_logs"},
 		{"Use rwx results to check", "rwx_get_run_results"},
+		{"Use rwx dispatch to trigger", "rwx_dispatch_run"},
 	}
 	for _, tc := range tests {
 		result := transformCLIReferences(tc.input)
@@ -339,6 +342,78 @@ func TestJSONResult_Complex(t *testing.T) {
 	assert.Equal(t, float64(3), parsed["count"])
 }
 
+// --- parseResultsPrompt tests ---
+
+func TestParseResultsPrompt_Empty(t *testing.T) {
+	tasks, tests, problems := parseResultsPrompt("")
+	assert.Nil(t, tasks)
+	assert.Nil(t, tests)
+	assert.Nil(t, problems)
+}
+
+func TestParseResultsPrompt_FailedTasksWithArtifacts(t *testing.T) {
+	prompt := `# Failed tests:
+
+- packages/curri-db/src/models/Orders/tests/OrderQuotes.integration.test.ts
+  - OrderQuotes > OrderQuotesCrud.findById (numeric) > finds existing order quote by numeric id
+  - OrderQuotes > OrderQuotesCrud.findById (string external_id) > finds existing order quote by string external id
+
+# Failed tasks:
+
+You can pull the logs for these tasks using ` + "`rwx logs <task-id>`" + ` and see available artifacts using ` + "`rwx artifacts list <task-id>`" + `
+
+- jest-integration-tests.jest-integration-tests-0 (task-id: 191a345d35d42c0e9b9c7a6150cf7d32) (has artifacts)
+- jest-integration-tests.jest-integration-tests-2 (task-id: 0b5fe5a97b7ede3068820c00653e8666) (has artifacts)
+
+For more documentation on the RWX CLI, see ` + "`rwx --help`" + `
+`
+	tasks, tests, problems := parseResultsPrompt(prompt)
+
+	require.Len(t, tasks, 2)
+	assert.Equal(t, "jest-integration-tests.jest-integration-tests-0", tasks[0].Key)
+	assert.Equal(t, "191a345d35d42c0e9b9c7a6150cf7d32", tasks[0].TaskID)
+	assert.True(t, tasks[0].HasArtifacts)
+	assert.Equal(t, "jest-integration-tests.jest-integration-tests-2", tasks[1].Key)
+	assert.Equal(t, "0b5fe5a97b7ede3068820c00653e8666", tasks[1].TaskID)
+	assert.True(t, tasks[1].HasArtifacts)
+
+	require.Len(t, tests, 3)
+	assert.Contains(t, tests[0], "OrderQuotes.integration.test.ts")
+	assert.Contains(t, tests[1], "findById (numeric)")
+	assert.Contains(t, tests[2], "findById (string external_id)")
+
+	assert.Empty(t, problems)
+}
+
+func TestParseResultsPrompt_OtherProblems(t *testing.T) {
+	prompt := `# Other problems:
+
+- [build:tsgo] src/graphql/resolvers/DriverResolver.ts
+  - [Error] Type assignment mismatch [tsc - 2322] (line 337:9)
+
+# Failed tasks:
+
+You can pull the logs for these tasks using ` + "`rwx logs <task-id>`" + `
+
+- build (task-id: 06ca539c77d27a637433e81110bddb97)
+- db-and-api-build (task-id: a72aafdaf5f759c3c1fe3ba16c5137d5)
+
+For more documentation on the RWX CLI, see ` + "`rwx --help`" + `
+`
+	tasks, tests, problems := parseResultsPrompt(prompt)
+
+	require.Len(t, tasks, 2)
+	assert.Equal(t, "build", tasks[0].Key)
+	assert.Equal(t, "06ca539c77d27a637433e81110bddb97", tasks[0].TaskID)
+	assert.False(t, tasks[0].HasArtifacts)
+
+	assert.Empty(t, tests)
+
+	require.Len(t, problems, 2)
+	assert.Contains(t, problems[0], "DriverResolver.ts")
+	assert.Contains(t, problems[1], "tsc - 2322")
+}
+
 // --- resolveRWXBinary tests ---
 
 func TestResolveRWXBinary_ExplicitPath(t *testing.T) {
@@ -456,4 +531,344 @@ func TestRunRWXCommand_FailureWithStdoutReturnsStdout(t *testing.T) {
 	out, err := r.runRWXCommand(nil, 0)
 	require.NoError(t, err, "should return stdout on failure when stdout has content")
 	assert.Contains(t, out, "{\"partial\":true}")
+}
+
+// --- Dispatch handler tests ---
+
+func fakeBin(t *testing.T, script string) string {
+	t.Helper()
+	tmp := t.TempDir()
+	bin := filepath.Join(tmp, "rwx")
+	require.NoError(t, os.WriteFile(bin, []byte("#!/bin/sh\n"+script), 0o755))
+	return bin
+}
+
+func TestDispatchRun_Launched(t *testing.T) {
+	bin := fakeBin(t, `echo '{"run_id":"dispatch-123","run_url":"https://cloud.rwx.com/mint/org/runs/dispatch-123"}'`)
+	r := &rwx{cliPath: bin, org: "org", baseURL: "https://cloud.rwx.com", logCache: newLogCache()}
+
+	result, err := dispatchRun(context.Background(), r, map[string]any{
+		"dispatch_key": "deploy-staging",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.Data), &parsed))
+	assert.Equal(t, "dispatch-123", parsed["run_id"])
+	assert.Equal(t, "launched", parsed["status"])
+	assert.Equal(t, false, parsed["completed"])
+}
+
+func TestDispatchRun_WaitFailure(t *testing.T) {
+	bin := fakeBin(t, `echo '{"run_id":"dispatch-456","result":"failed"}'`)
+	r := &rwx{cliPath: bin, org: "org", baseURL: "https://cloud.rwx.com", logCache: newLogCache()}
+
+	result, err := dispatchRun(context.Background(), r, map[string]any{
+		"dispatch_key": "deploy-staging",
+		"wait":         true,
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.Data), &parsed))
+	assert.Equal(t, "failure", parsed["status"])
+	assert.Equal(t, true, parsed["completed"])
+}
+
+func TestDispatchRun_WaitSuccess(t *testing.T) {
+	bin := fakeBin(t, `echo '{"run_id":"dispatch-ok","result":"succeeded"}'`)
+	r := &rwx{cliPath: bin, org: "org", baseURL: "https://cloud.rwx.com", logCache: newLogCache()}
+
+	result, err := dispatchRun(context.Background(), r, map[string]any{
+		"dispatch_key": "deploy-staging",
+		"wait":         true,
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.Data), &parsed))
+	assert.Equal(t, "success", parsed["status"])
+	assert.Equal(t, "Run completed successfully", parsed["next_step"])
+}
+
+func TestDispatchRun_URLFallback(t *testing.T) {
+	bin := fakeBin(t, `echo '{"run_id":"dispatch-789"}'`)
+	r := &rwx{cliPath: bin, org: "my-org", baseURL: "https://cloud.rwx.com", logCache: newLogCache()}
+
+	result, err := dispatchRun(context.Background(), r, map[string]any{
+		"dispatch_key": "test",
+	})
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.Data), &parsed))
+	assert.Equal(t, "https://cloud.rwx.com/mint/my-org/runs/dispatch-789", parsed["url"])
+}
+
+// --- Docs handler tests ---
+
+func TestDocsSearch(t *testing.T) {
+	jsonOut := `{"Query":"caching","TotalHits":2,"Results":[{"url":"https://www.rwx.com/docs/caching","path":"/docs/caching","title":"Caching","body":"Short body here."}]}`
+	bin := fakeBin(t, fmt.Sprintf(`echo '%s'`, jsonOut))
+	r := &rwx{cliPath: bin, logCache: newLogCache()}
+
+	result, err := docsSearch(context.Background(), r, map[string]any{"query": "caching"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.Data), &parsed))
+	assert.Equal(t, "caching", parsed["query"])
+	assert.Equal(t, float64(2), parsed["total_hits"])
+	assert.Equal(t, float64(1), parsed["count"])
+
+	results := parsed["results"].([]any)
+	first := results[0].(map[string]any)
+	assert.Equal(t, "Caching", first["title"])
+	assert.Equal(t, "Short body here.", first["snippet"])
+}
+
+func TestDocsSearch_SnippetTruncation(t *testing.T) {
+	longBody := ""
+	for i := 0; i < 600; i++ {
+		longBody += "x"
+	}
+	jsonOut := fmt.Sprintf(`{"Query":"test","TotalHits":1,"Results":[{"url":"u","path":"p","title":"T","body":"%s"}]}`, longBody)
+	bin := fakeBin(t, fmt.Sprintf(`echo '%s'`, jsonOut))
+	r := &rwx{cliPath: bin, logCache: newLogCache()}
+
+	result, err := docsSearch(context.Background(), r, map[string]any{"query": "test"})
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.Data), &parsed))
+	results := parsed["results"].([]any)
+	first := results[0].(map[string]any)
+	snippet := first["snippet"].(string)
+	assert.True(t, len(snippet) <= 504, "snippet should be truncated to ~500+...")
+	assert.True(t, strings.HasSuffix(snippet, "..."))
+}
+
+func TestDocsPull(t *testing.T) {
+	tmp := t.TempDir()
+	bin := filepath.Join(tmp, "rwx")
+	script := "#!/bin/sh\nprintf '{\"URL\":\"https://www.rwx.com/docs/caching\",\"Body\":\"Caching content here.\"}'\n"
+	require.NoError(t, os.WriteFile(bin, []byte(script), 0o755))
+	r := &rwx{cliPath: bin, logCache: newLogCache()}
+
+	result, err := docsPull(context.Background(), r, map[string]any{"url_or_path": "/docs/caching"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.Data), &parsed))
+	assert.Equal(t, "https://www.rwx.com/docs/caching", parsed["url"])
+	assert.Contains(t, parsed["content"], "Caching content here.")
+}
+
+// --- LaunchCIRun handler tests ---
+
+func TestLaunchCIRun_WaitAddsFailFast(t *testing.T) {
+	bin := fakeBin(t, `echo '{"run_id":"run-1","result":"succeeded"}'`)
+	r := &rwx{cliPath: bin, org: "org", baseURL: "https://cloud.rwx.com", logCache: newLogCache()}
+
+	result, err := launchCIRun(context.Background(), r, map[string]any{
+		"wait": true,
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.Data), &parsed))
+	assert.Equal(t, "success", parsed["status"])
+	assert.Equal(t, true, parsed["completed"])
+}
+
+func TestLaunchCIRun_TitleAndInit(t *testing.T) {
+	bin := fakeBin(t, `echo '{"run_id":"run-2"}'`)
+	r := &rwx{cliPath: bin, org: "org", baseURL: "https://cloud.rwx.com", logCache: newLogCache()}
+
+	result, err := launchCIRun(context.Background(), r, map[string]any{
+		"title": "Deploy v2",
+		"init":  map[string]any{"env": "staging"},
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.Data), &parsed))
+	assert.Equal(t, "run-2", parsed["run_id"])
+	assert.Equal(t, "launched", parsed["status"])
+}
+
+// --- GetTaskLogs handler tests ---
+
+func TestGetTaskLogs_MissingArgs(t *testing.T) {
+	r := &rwx{cliPath: "rwx", logCache: newLogCache()}
+
+	result, err := getTaskLogs(context.Background(), r, map[string]any{})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "either task_id or run_id+task_key is required")
+}
+
+func TestGetTaskLogs_RunIDAndTaskKey(t *testing.T) {
+	tmp := t.TempDir()
+	bin := filepath.Join(tmp, "rwx")
+	script := `#!/bin/sh
+for arg in "$@"; do
+  case "$prev" in
+    --output-dir) echo "log output for task" > "$arg/task.log" ;;
+  esac
+  prev="$arg"
+done
+echo '{}'
+`
+	require.NoError(t, os.WriteFile(bin, []byte(script), 0o755))
+	r := &rwx{cliPath: bin, logCache: newLogCache(), client: &http.Client{}, baseURL: "http://localhost:0", org: "test"}
+
+	result, err := getTaskLogs(context.Background(), r, map[string]any{
+		"run_id":   "run-abc123",
+		"task_key": "ci.checks.lint",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "log output for task")
+}
+
+// --- GetRunResults handler tests ---
+
+func TestGetRunResults_MissingArgs(t *testing.T) {
+	r := &rwx{cliPath: "rwx", org: "org", baseURL: "https://cloud.rwx.com", logCache: newLogCache()}
+
+	result, err := getRunResults(context.Background(), r, map[string]any{})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "either run_id or branch/commit is required")
+}
+
+func TestGetRunResults_BranchLookup(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"id":"run-abc","completed_runtime_seconds":120,"title":"CI","branch":"main","commit_sha":"abc123","definition_path":".rwx/ci.yml"}`))
+	}))
+	defer ts.Close()
+
+	bin := fakeBin(t, `echo '{"RunID":"run-abc","ResultStatus":"succeeded","Completed":true}'`)
+	r := &rwx{cliPath: bin, org: "org", baseURL: ts.URL, client: ts.Client(), logCache: newLogCache()}
+
+	result, err := getRunResults(context.Background(), r, map[string]any{
+		"branch": "main",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.Data), &parsed))
+	assert.Equal(t, "run-abc", parsed["run_id"])
+	assert.Equal(t, "success", parsed["status"])
+	assert.Equal(t, "main", parsed["branch"])
+}
+
+// --- Vault handler tests ---
+
+func TestVaultsVarShow(t *testing.T) {
+	bin := fakeBin(t, `echo '{"name":"MY_VAR","value":"hello","vault":"default"}'`)
+	r := &rwx{cliPath: bin, logCache: newLogCache()}
+
+	result, err := vaultsVarShow(context.Background(), r, map[string]any{"name": "MY_VAR"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "MY_VAR")
+}
+
+func TestVaultsVarShow_EmptyOutput(t *testing.T) {
+	bin := fakeBin(t, `true`)
+	r := &rwx{cliPath: bin, logCache: newLogCache()}
+
+	result, err := vaultsVarShow(context.Background(), r, map[string]any{"name": "MISSING"})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "no output from CLI")
+}
+
+func TestVaultsVarSet_WithOutput(t *testing.T) {
+	bin := fakeBin(t, `echo '{"ok":true}'`)
+	r := &rwx{cliPath: bin, logCache: newLogCache()}
+
+	result, err := vaultsVarSet(context.Background(), r, map[string]any{"name": "K", "value": "V"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "ok")
+}
+
+func TestVaultsVarSet_EmptyOutput(t *testing.T) {
+	bin := fakeBin(t, `true`)
+	r := &rwx{cliPath: bin, logCache: newLogCache()}
+
+	result, err := vaultsVarSet(context.Background(), r, map[string]any{"name": "K", "value": "V"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.Data), &parsed))
+	assert.Equal(t, "set", parsed["status"])
+	assert.Equal(t, "K", parsed["name"])
+	assert.Equal(t, "default", parsed["vault"])
+}
+
+func TestVaultsVarDelete_EmptyOutput(t *testing.T) {
+	bin := fakeBin(t, `true`)
+	r := &rwx{cliPath: bin, logCache: newLogCache()}
+
+	result, err := vaultsVarDelete(context.Background(), r, map[string]any{"name": "K"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.Data), &parsed))
+	assert.Equal(t, "deleted", parsed["status"])
+	assert.Equal(t, "K", parsed["name"])
+}
+
+func TestVaultsSecretSet_EmptyOutput(t *testing.T) {
+	bin := fakeBin(t, `true`)
+	r := &rwx{cliPath: bin, logCache: newLogCache()}
+
+	result, err := vaultsSecretSet(context.Background(), r, map[string]any{"name": "S", "value": "secret"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.Data), &parsed))
+	assert.Equal(t, "set", parsed["status"])
+	assert.Equal(t, "S", parsed["name"])
+}
+
+func TestVaultsSecretDelete_EmptyOutput(t *testing.T) {
+	bin := fakeBin(t, `true`)
+	r := &rwx{cliPath: bin, logCache: newLogCache()}
+
+	result, err := vaultsSecretDelete(context.Background(), r, map[string]any{"name": "S"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.Data), &parsed))
+	assert.Equal(t, "deleted", parsed["status"])
+	assert.Equal(t, "S", parsed["name"])
+}
+
+func TestVaultsVarSet_CustomVault(t *testing.T) {
+	bin := fakeBin(t, `true`)
+	r := &rwx{cliPath: bin, logCache: newLogCache()}
+
+	result, err := vaultsVarSet(context.Background(), r, map[string]any{"name": "K", "value": "V", "vault": "staging"})
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.Data), &parsed))
+	assert.Equal(t, "staging", parsed["vault"])
 }

--- a/integrations/rwx/tools.go
+++ b/integrations/rwx/tools.go
@@ -11,7 +11,21 @@ var tools = []mcp.ToolDefinition{
 			"workflow": "Path to the RWX workflow YAML file to run (default: .rwx/ci.yml, e.g. .rwx/auto-deploy.yml)",
 			"targets":  "JSON array of specific task keys to target (optional)",
 			"wait":     "Wait for the run to complete before returning (true/false, default: false)",
+			"title":    "Display title for the run in the RWX UI (optional)",
+			"init":     "JSON object of init parameters available in the init context (optional, e.g. {\"deploy_env\": \"staging\"})",
 		},
+	},
+	{
+		Name:        mcp.ToolName("rwx_dispatch_run"),
+		Description: "Launch a run from a pre-configured RWX dispatch workflow by key. Use instead of rwx_launch_ci_run when triggering remote/pre-configured workflows without local files.",
+		Parameters: map[string]string{
+			"dispatch_key": "The dispatch key identifying the pre-configured workflow",
+			"ref":          "Git ref (branch/tag/SHA) to use for the run (optional)",
+			"params":       "JSON object of dispatch params available in event.dispatch.params context (optional)",
+			"wait":         "Wait for the run to complete before returning (true/false, default: false)",
+			"title":        "Display title for the run in the RWX UI (optional)",
+		},
+		Required: []string{"dispatch_key"},
 	},
 	{
 		Name:        mcp.ToolName("rwx_wait_for_ci_run"),
@@ -35,11 +49,15 @@ var tools = []mcp.ToolDefinition{
 	},
 	{
 		Name:        mcp.ToolName("rwx_get_run_results"),
-		Description: "Get structured CI/CD pipeline results for a completed run, including per-task pass/fail status and build summary",
+		Description: "Get structured CI/CD pipeline results including per-task pass/fail status, failed tests, and build errors. Accepts a run ID or branch/commit lookup.",
 		Parameters: map[string]string{
-			"run_id": "RWX run ID or full URL to get results for",
+			"run_id":     "RWX run ID or full URL (required unless branch is provided)",
+			"task_key":   "Get results for a specific task by key (e.g. ci.checks.lint) instead of the full run",
+			"branch":     "Look up results by branch name instead of run ID (uses current repo unless repo is set)",
+			"commit":     "Look up results by commit SHA instead of run ID",
+			"repo":       "Repository name for branch/commit lookup (default: current git repo)",
+			"definition": "Definition path for branch/commit lookup (e.g. .rwx/ci.yml)",
 		},
-		Required: []string{"run_id"},
 	},
 
 	// ── Logs ────────────────────────────────────────────────────────
@@ -47,17 +65,19 @@ var tools = []mcp.ToolDefinition{
 		Name:        mcp.ToolName("rwx_get_task_logs"),
 		Description: "Download and return full CI/CD task logs with build failure and test failure highlights",
 		Parameters: map[string]string{
-			"task_id": "RWX task ID (32-char hex) or task URL",
+			"task_id":  "RWX task ID (32-char hex) or task URL",
+			"run_id":   "RWX run ID — use with task_key to resolve by key instead of ID (optional)",
+			"task_key": "Task key (e.g. ci.checks.lint) — requires run_id. Use instead of task_id.",
 		},
-		Required: []string{"task_id"},
 	},
 	{
 		Name:        mcp.ToolName("rwx_head_logs"),
 		Description: "Return the first N lines of logs for a run or task. Supports pagination via offset.",
 		Parameters: map[string]string{
-			"id":     "RWX run ID or task ID",
-			"lines":  "Number of lines to return from the beginning (default: 50, max: 50)",
-			"offset": "Line offset to start from (default: 0). Use for pagination.",
+			"id":       "RWX run ID or task ID",
+			"lines":    "Number of lines to return from the beginning (default: 50, max: 50)",
+			"offset":   "Line offset to start from (default: 0). Use for pagination.",
+			"task_key": "Task key (e.g. ci.checks.lint) — when set, id is treated as run ID and task is resolved by key",
 		},
 		Required: []string{"id"},
 	},
@@ -65,9 +85,10 @@ var tools = []mcp.ToolDefinition{
 		Name:        mcp.ToolName("rwx_tail_logs"),
 		Description: "Return the last N lines of logs for a run or task. Supports pagination via offset.",
 		Parameters: map[string]string{
-			"id":     "RWX run ID or task ID",
-			"lines":  "Number of lines to return from the end (default: 50, max: 50)",
-			"offset": "Line offset from the end (default: 0). Use for pagination to see earlier lines.",
+			"id":       "RWX run ID or task ID",
+			"lines":    "Number of lines to return from the end (default: 50, max: 50)",
+			"offset":   "Line offset from the end (default: 0). Use for pagination to see earlier lines.",
+			"task_key": "Task key (e.g. ci.checks.lint) — when set, id is treated as run ID and task is resolved by key",
 		},
 		Required: []string{"id"},
 	},
@@ -75,10 +96,11 @@ var tools = []mcp.ToolDefinition{
 		Name:        mcp.ToolName("rwx_grep_logs"),
 		Description: "Search CI/CD build and test logs for a pattern with context lines. Results are paginated (50 lines per page).",
 		Parameters: map[string]string{
-			"id":      "RWX run ID or task ID",
-			"pattern": "Pattern to search for in the logs (case-insensitive)",
-			"context": "Number of context lines before and after matches (default: 3)",
-			"page":    "Page number (default: 1). Each page returns up to 50 lines of output.",
+			"id":       "RWX run ID or task ID",
+			"pattern":  "Pattern to search for in the logs (case-insensitive)",
+			"context":  "Number of context lines before and after matches (default: 3)",
+			"page":     "Page number (default: 1). Each page returns up to 50 lines of output.",
+			"task_key": "Task key (e.g. ci.checks.lint) — when set, id is treated as run ID and task is resolved by key",
 		},
 		Required: []string{"id", "pattern"},
 	},
@@ -102,6 +124,74 @@ var tools = []mcp.ToolDefinition{
 		Parameters: map[string]string{
 			"file_path": "Path to the RWX workflow YAML file to validate (default: .rwx/ci.yml)",
 		},
+	},
+
+	// ── Docs ────────────────────────────────────────────────────────
+	{
+		Name:        mcp.ToolName("rwx_docs_search"),
+		Description: "Search RWX documentation. Use to find docs on caching, parallelism, configuration, and other RWX features.",
+		Parameters: map[string]string{
+			"query": "Search query (e.g. 'caching', 'parallelism', 'filtering files')",
+			"limit": "Maximum number of results (default: 5)",
+		},
+		Required: []string{"query"},
+	},
+	{
+		Name:        mcp.ToolName("rwx_docs_pull"),
+		Description: "Fetch an RWX documentation article as markdown. Use a URL from rwx_docs_search results or a docs path like /docs/caching.",
+		Parameters: map[string]string{
+			"url_or_path": "Full URL (https://www.rwx.com/docs/...) or path (/docs/caching) of the article to fetch",
+		},
+		Required: []string{"url_or_path"},
+	},
+
+	// ── Vaults ──────────────────────────────────────────────────────
+	{
+		Name:        mcp.ToolName("rwx_vaults_var_show"),
+		Description: "Show a variable value from an RWX vault",
+		Parameters: map[string]string{
+			"name":  "Variable name to show",
+			"vault": "Vault name (default: 'default')",
+		},
+		Required: []string{"name"},
+	},
+	{
+		Name:        mcp.ToolName("rwx_vaults_var_set"),
+		Description: "Set a variable in an RWX vault",
+		Parameters: map[string]string{
+			"name":  "Variable name",
+			"value": "Variable value",
+			"vault": "Vault name (default: 'default')",
+		},
+		Required: []string{"name", "value"},
+	},
+	{
+		Name:        mcp.ToolName("rwx_vaults_var_delete"),
+		Description: "Delete a variable from an RWX vault",
+		Parameters: map[string]string{
+			"name":  "Variable name to delete",
+			"vault": "Vault name (default: 'default')",
+		},
+		Required: []string{"name"},
+	},
+	{
+		Name:        mcp.ToolName("rwx_vaults_secret_set"),
+		Description: "Set a secret in an RWX vault. The value is stored encrypted and cannot be read back.",
+		Parameters: map[string]string{
+			"name":  "Secret name",
+			"value": "Secret value",
+			"vault": "Vault name (default: 'default')",
+		},
+		Required: []string{"name", "value"},
+	},
+	{
+		Name:        mcp.ToolName("rwx_vaults_secret_delete"),
+		Description: "Delete a secret from an RWX vault",
+		Parameters: map[string]string{
+			"name":  "Secret name to delete",
+			"vault": "Vault name (default: 'default')",
+		},
+		Required: []string{"name"},
 	},
 
 	// ── CLI ─────────────────────────────────────────────────────────

--- a/integrations/rwx/vaults.go
+++ b/integrations/rwx/vaults.go
@@ -1,0 +1,193 @@
+package rwx
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+func vaultsVarShow(_ context.Context, r *rwx, args map[string]any) (*mcp.ToolResult, error) {
+	ra := mcp.NewArgs(args)
+	name := ra.Str("name")
+	vault := ra.Str("vault")
+	if err := ra.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if vault == "" {
+		vault = "default"
+	}
+
+	cmdArgs := []string{"vaults", "vars", "show", name, "--vault", vault, "--output", "json"}
+	output, err := r.runRWXCommand(cmdArgs, 30000)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	var parsed any
+	if err := json.Unmarshal([]byte(output), &parsed); err != nil {
+		if output == "" {
+			return mcp.ErrResult(fmt.Errorf("vault var show: no output from CLI"))
+		}
+		return &mcp.ToolResult{Data: output}, nil
+	}
+	return mcp.JSONResult(parsed)
+}
+
+func vaultsVarSet(_ context.Context, r *rwx, args map[string]any) (*mcp.ToolResult, error) {
+	ra := mcp.NewArgs(args)
+	name := ra.Str("name")
+	value := ra.Str("value")
+	vault := ra.Str("vault")
+	if err := ra.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if vault == "" {
+		vault = "default"
+	}
+
+	envFile, err := writeEnvFile(name, value)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	defer func() { _ = os.Remove(envFile) }()
+
+	cmdArgs := []string{"vaults", "vars", "set", "--file", envFile, "--vault", vault, "--output", "json"}
+	output, err := r.runRWXCommand(cmdArgs, 30000)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	if output == "" {
+		return mcp.JSONResult(map[string]any{
+			"status": "set",
+			"name":   name,
+			"vault":  vault,
+		})
+	}
+	var parsed any
+	if err := json.Unmarshal([]byte(output), &parsed); err != nil {
+		return &mcp.ToolResult{Data: output}, nil
+	}
+	return mcp.JSONResult(parsed)
+}
+
+func vaultsVarDelete(_ context.Context, r *rwx, args map[string]any) (*mcp.ToolResult, error) {
+	ra := mcp.NewArgs(args)
+	name := ra.Str("name")
+	vault := ra.Str("vault")
+	if err := ra.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if vault == "" {
+		vault = "default"
+	}
+
+	cmdArgs := []string{"vaults", "vars", "delete", name, "--vault", vault, "--yes", "--output", "json"}
+	output, err := r.runRWXCommand(cmdArgs, 30000)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	if output == "" {
+		return mcp.JSONResult(map[string]any{
+			"status": "deleted",
+			"name":   name,
+			"vault":  vault,
+		})
+	}
+	var parsed any
+	if err := json.Unmarshal([]byte(output), &parsed); err != nil {
+		return &mcp.ToolResult{Data: output}, nil
+	}
+	return mcp.JSONResult(parsed)
+}
+
+func vaultsSecretSet(_ context.Context, r *rwx, args map[string]any) (*mcp.ToolResult, error) {
+	ra := mcp.NewArgs(args)
+	name := ra.Str("name")
+	value := ra.Str("value")
+	vault := ra.Str("vault")
+	if err := ra.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if vault == "" {
+		vault = "default"
+	}
+
+	envFile, err := writeEnvFile(name, value)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	defer func() { _ = os.Remove(envFile) }()
+
+	cmdArgs := []string{"vaults", "secrets", "set", "--file", envFile, "--vault", vault, "--output", "json"}
+	output, err := r.runRWXCommand(cmdArgs, 30000)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	if output == "" {
+		return mcp.JSONResult(map[string]any{
+			"status": "set",
+			"name":   name,
+			"vault":  vault,
+		})
+	}
+	var parsed any
+	if err := json.Unmarshal([]byte(output), &parsed); err != nil {
+		return &mcp.ToolResult{Data: output}, nil
+	}
+	return mcp.JSONResult(parsed)
+}
+
+func vaultsSecretDelete(_ context.Context, r *rwx, args map[string]any) (*mcp.ToolResult, error) {
+	ra := mcp.NewArgs(args)
+	name := ra.Str("name")
+	vault := ra.Str("vault")
+	if err := ra.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if vault == "" {
+		vault = "default"
+	}
+
+	cmdArgs := []string{"vaults", "secrets", "delete", name, "--vault", vault, "--yes", "--output", "json"}
+	output, err := r.runRWXCommand(cmdArgs, 30000)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	if output == "" {
+		return mcp.JSONResult(map[string]any{
+			"status": "deleted",
+			"name":   name,
+			"vault":  vault,
+		})
+	}
+	var parsed any
+	if err := json.Unmarshal([]byte(output), &parsed); err != nil {
+		return &mcp.ToolResult{Data: output}, nil
+	}
+	return mcp.JSONResult(parsed)
+}
+
+func writeEnvFile(name, value string) (string, error) {
+	f, err := os.CreateTemp("", "rwx-vault-*.env")
+	if err != nil {
+		return "", fmt.Errorf("create temp env file: %w", err)
+	}
+	_, err = fmt.Fprintf(f, "%s=%s\n", name, value)
+	closeErr := f.Close()
+	if err != nil {
+		_ = os.Remove(f.Name())
+		return "", fmt.Errorf("write env file: %w", err)
+	}
+	if closeErr != nil {
+		_ = os.Remove(f.Name())
+		return "", fmt.Errorf("close env file: %w", closeErr)
+	}
+	return f.Name(), nil
+}


### PR DESCRIPTION

## Summary

- **Fix `rwx_get_run_results`**: parse actual CLI JSON output (`RunID`, `ResultStatus`, `Completed`, `Prompt`) — the old handler expected fields (`tasks`, `result`, `execution`, `duration_seconds`) that the CLI never returned
- **8 new tools**: `rwx_dispatch_run`, `rwx_docs_search`, `rwx_docs_pull`, `rwx_vaults_var_show/set/delete`, `rwx_vaults_secret_set/delete`
- **Enhanced existing tools**: branch/commit lookup for results, `--task` key resolution across all log and results tools, `--title`/`--init`/`--fail-fast` for launches
- **Min CLI version**: bumped to 3.13.0

## Test plan

- [x] `make ci` passes (build, vet, test-race, lint, security)
- [x] `parseResultsPrompt` tested with empty, failed-tasks-with-artifacts, and build-error prompts
- [x] Dispatch parity tests pass (`TestDispatchMap_AllToolsCovered`, `TestDispatchMap_NoOrphanHandlers`)
- [x] Compaction spec parity tests pass
- [ ] Manual smoke test with live RWX runs


🐾 Generated with Crush