### PR TITLE
feat(wasm): add optional raw bytes support for plugin HTTP bodies

### DIFF
--- a/wasm/guest-rust/sdk/Cargo.toml
+++ b/wasm/guest-rust/sdk/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+base64 = "0.22"

--- a/wasm/guest-rust/sdk/src/lib.rs
+++ b/wasm/guest-rust/sdk/src/lib.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use base64::Engine as _;
 
 // ── Types matching the host ABI ─────────────────────────────────────────────
 
@@ -88,6 +89,8 @@ pub struct HttpRequest {
     pub headers: HashMap<String, String>,
     #[serde(skip_serializing_if = "String::is_empty")]
     pub body: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub body_base64: String,
 }
 
 #[derive(Deserialize)]
@@ -97,6 +100,8 @@ pub struct HttpResponse {
     pub headers: HashMap<String, String>,
     #[serde(default)]
     pub body: String,
+    #[serde(default)]
+    pub body_base64: String,
 }
 
 // ── Host imports ────────────────────────────────────────────────────────────
@@ -111,6 +116,35 @@ extern "C" {
 pub fn host_log(msg: &str) {
     unsafe {
         host_log_raw(msg.as_ptr() as u32, msg.len() as u32);
+    }
+}
+
+impl HttpRequest {
+    /// Create a request with a raw binary body. The bytes are base64-encoded
+    /// for transport over the JSON ABI.
+    pub fn with_body_bytes(method: &str, url: &str, headers: HashMap<String, String>, body: &[u8]) -> Self {
+        HttpRequest {
+            method: method.into(),
+            url: url.into(),
+            headers,
+            body: String::new(),
+            body_base64: base64::engine::general_purpose::STANDARD.encode(body),
+        }
+    }
+}
+
+impl HttpResponse {
+    /// Returns the response body as raw bytes. If the response was requested
+    /// with `X-Raw-Body`, decodes `body_base64`; otherwise returns the `body`
+    /// string as UTF-8 bytes.
+    pub fn body_bytes(&self) -> Result<Vec<u8>, String> {
+        if !self.body_base64.is_empty() {
+            base64::engine::general_purpose::STANDARD
+                .decode(&self.body_base64)
+                .map_err(|e| format!("decode body_base64: {e}"))
+        } else {
+            Ok(self.body.as_bytes().to_vec())
+        }
     }
 }
 
@@ -136,8 +170,26 @@ pub fn host_http_request_h2c(req: &HttpRequest) -> Result<HttpResponse, String> 
         url: req.url.clone(),
         headers: req.headers.clone(),
         body: req.body.clone(),
+        body_base64: req.body_base64.clone(),
     };
     patched.headers.insert("X-H2C".into(), "1".into());
+    do_host_http_request(&patched)
+}
+
+/// Execute an HTTP request and receive the response body as raw bytes.
+///
+/// Sets the `X-Raw-Body` header so the host returns the body as base64
+/// in `body_base64` instead of a UTF-8 string in `body`. Use
+/// [`HttpResponse::body_bytes`] to decode the result.
+pub fn host_http_request_raw(req: &HttpRequest) -> Result<HttpResponse, String> {
+    let mut patched = HttpRequest {
+        method: req.method.clone(),
+        url: req.url.clone(),
+        headers: req.headers.clone(),
+        body: req.body.clone(),
+        body_base64: req.body_base64.clone(),
+    };
+    patched.headers.insert("X-Raw-Body".into(), "1".into());
     do_host_http_request(&patched)
 }
 

--- a/wasm/host.go
+++ b/wasm/host.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -17,16 +18,18 @@ import (
 )
 
 type httpRequest struct {
-	Method  string            `json:"method"`
-	URL     string            `json:"url"`
-	Headers map[string]string `json:"headers,omitempty"`
-	Body    string            `json:"body,omitempty"`
+	Method     string            `json:"method"`
+	URL        string            `json:"url"`
+	Headers    map[string]string `json:"headers,omitempty"`
+	Body       string            `json:"body,omitempty"`
+	BodyBase64 string            `json:"body_base64,omitempty"`
 }
 
 type httpResponse struct {
-	Status  int               `json:"status"`
-	Headers map[string]string `json:"headers,omitempty"`
-	Body    string            `json:"body"`
+	Status     int               `json:"status"`
+	Headers    map[string]string `json:"headers,omitempty"`
+	Body       string            `json:"body"`
+	BodyBase64 string            `json:"body_base64,omitempty"`
 }
 
 const maxHostResponseSize = 10 * 1024 * 1024
@@ -34,6 +37,11 @@ const maxHostResponseSize = 10 * 1024 * 1024
 // h2cHeaderKey is the header plugins set to request HTTP/2 cleartext (h2c)
 // transport. Any non-empty value enables h2c for that request.
 const h2cHeaderKey = "X-H2C"
+
+// rawBodyHeaderKey is the header plugins set to request the response body
+// as raw base64-encoded bytes in the body_base64 field instead of a UTF-8
+// string in the body field. Required for binary payloads (protobuf, images, etc.).
+const rawBodyHeaderKey = "X-Raw-Body"
 
 var (
 	hostHTTPClient = &http.Client{Timeout: 30 * time.Second}
@@ -86,7 +94,13 @@ func hostHTTPRequest(ctx context.Context, mod api.Module, ptrSize uint64) uint64
 // is used instead of the default HTTP/1.1 client.
 func doHostHTTP(ctx context.Context, req *httpRequest) (*httpResponse, error) {
 	var bodyReader io.Reader
-	if req.Body != "" {
+	if req.BodyBase64 != "" {
+		decoded, err := base64.StdEncoding.DecodeString(req.BodyBase64)
+		if err != nil {
+			return nil, fmt.Errorf("decode body_base64: %w", err)
+		}
+		bodyReader = bytes.NewReader(decoded)
+	} else if req.Body != "" {
 		bodyReader = bytes.NewBufferString(req.Body)
 	}
 
@@ -95,10 +109,11 @@ func doHostHTTP(ctx context.Context, req *httpRequest) (*httpResponse, error) {
 		return nil, fmt.Errorf("create request: %w", err)
 	}
 
-	// Check for h2c header before copying headers to the outgoing request.
+	// Check for control headers before copying to the outgoing request.
 	useH2C := req.Headers[h2cHeaderKey] != ""
+	rawBody := req.Headers[rawBodyHeaderKey] != ""
 	for k, v := range req.Headers {
-		if k == h2cHeaderKey {
+		if k == h2cHeaderKey || k == rawBodyHeaderKey {
 			continue
 		}
 		httpReq.Header.Set(k, v)
@@ -125,11 +140,16 @@ func doHostHTTP(ctx context.Context, req *httpRequest) (*httpResponse, error) {
 		headers[k] = resp.Header.Get(k)
 	}
 
-	return &httpResponse{
+	result := &httpResponse{
 		Status:  resp.StatusCode,
 		Headers: headers,
-		Body:    string(body),
-	}, nil
+	}
+	if rawBody {
+		result.BodyBase64 = base64.StdEncoding.EncodeToString(body)
+	} else {
+		result.Body = string(body)
+	}
+	return result, nil
 }
 
 func writeErrorResponse(ctx context.Context, mod api.Module, msg string) uint64 {

--- a/wasm/host_test.go
+++ b/wasm/host_test.go
@@ -2,7 +2,9 @@ package wasm
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"testing"
@@ -123,5 +125,121 @@ func TestDoHostHTTP_H2C_POST(t *testing.T) {
 	}
 	if gotBody != `{"method":"ping"}` {
 		t.Errorf("server got body = %q", gotBody)
+	}
+}
+
+func TestDoHostHTTP_RawBody_Response(t *testing.T) {
+	binaryPayload := []byte{0x00, 0x01, 0x02, 0xff, 0xfe, 0x80, 0x90}
+	base := newH2CServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write(binaryPayload)
+	}))
+
+	resp, err := doHostHTTP(context.Background(), &httpRequest{
+		Method:  "GET",
+		URL:     base + "/binary",
+		Headers: map[string]string{rawBodyHeaderKey: "1"},
+	})
+	if err != nil {
+		t.Fatalf("doHostHTTP: %v", err)
+	}
+	if resp.Status != 200 {
+		t.Errorf("status = %d, want 200", resp.Status)
+	}
+	if resp.Body != "" {
+		t.Errorf("body should be empty when raw body requested, got %q", resp.Body)
+	}
+	if resp.BodyBase64 == "" {
+		t.Fatal("body_base64 should be populated")
+	}
+	decoded, err := base64.StdEncoding.DecodeString(resp.BodyBase64)
+	if err != nil {
+		t.Fatalf("decode body_base64: %v", err)
+	}
+	if len(decoded) != len(binaryPayload) {
+		t.Fatalf("decoded len = %d, want %d", len(decoded), len(binaryPayload))
+	}
+	for i, b := range decoded {
+		if b != binaryPayload[i] {
+			t.Errorf("byte %d: got %#x, want %#x", i, b, binaryPayload[i])
+		}
+	}
+}
+
+func TestDoHostHTTP_RawBody_HeaderNotForwarded(t *testing.T) {
+	base := newH2CServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if v := r.Header.Get(rawBodyHeaderKey); v != "" {
+			t.Errorf("X-Raw-Body header leaked to upstream: %q", v)
+		}
+		_, _ = w.Write([]byte("ok"))
+	}))
+
+	_, err := doHostHTTP(context.Background(), &httpRequest{
+		Method:  "GET",
+		URL:     base + "/test",
+		Headers: map[string]string{rawBodyHeaderKey: "1"},
+	})
+	if err != nil {
+		t.Fatalf("doHostHTTP: %v", err)
+	}
+}
+
+func TestDoHostHTTP_RawBody_NotRequestedReturnsString(t *testing.T) {
+	base := newH2CServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("hello text"))
+	}))
+
+	resp, err := doHostHTTP(context.Background(), &httpRequest{
+		Method: "GET",
+		URL:    base + "/text",
+	})
+	if err != nil {
+		t.Fatalf("doHostHTTP: %v", err)
+	}
+	if resp.Body != "hello text" {
+		t.Errorf("body = %q, want %q", resp.Body, "hello text")
+	}
+	if resp.BodyBase64 != "" {
+		t.Errorf("body_base64 should be empty when raw body not requested, got %q", resp.BodyBase64)
+	}
+}
+
+func TestDoHostHTTP_BodyBase64_Request(t *testing.T) {
+	binaryPayload := []byte{0x00, 0x01, 0x02, 0xff}
+	var gotBody []byte
+	base := newH2CServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		_, _ = w.Write([]byte("ok"))
+	}))
+
+	resp, err := doHostHTTP(context.Background(), &httpRequest{
+		Method:     "POST",
+		URL:        base + "/upload",
+		BodyBase64: base64.StdEncoding.EncodeToString(binaryPayload),
+	})
+	if err != nil {
+		t.Fatalf("doHostHTTP: %v", err)
+	}
+	if resp.Status != 200 {
+		t.Errorf("status = %d, want 200", resp.Status)
+	}
+	if len(gotBody) != len(binaryPayload) {
+		t.Fatalf("server got %d bytes, want %d", len(gotBody), len(binaryPayload))
+	}
+	for i, b := range gotBody {
+		if b != binaryPayload[i] {
+			t.Errorf("byte %d: got %#x, want %#x", i, b, binaryPayload[i])
+		}
+	}
+}
+
+func TestDoHostHTTP_BodyBase64_InvalidEncoding(t *testing.T) {
+	_, err := doHostHTTP(context.Background(), &httpRequest{
+		Method:     "POST",
+		URL:        "http://localhost:1/unused",
+		BodyBase64: "not-valid-base64!!!",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid base64")
 	}
 }


### PR DESCRIPTION

## Summary

- Adds `body_base64` field to the WASM plugin HTTP ABI for binary payloads (protobuf, images, gRPC, etc.)
- Plugins opt in per-request via `X-Raw-Body` header (same pattern as existing `X-H2C`); response body returned as base64 in `body_base64` instead of UTF-8 string in `body`
- Request bodies can also be sent as base64 via the `body_base64` field on `HttpRequest`
- Fully backward-compatible — existing plugins that only use the `body` string field are unaffected

## Test plan

- [x] `make ci` passes
- [x] Binary response round-trip (bytes → base64 → decode)
- [x] `X-Raw-Body` header not leaked to upstream
- [x] Normal requests still return string body (no base64)
- [x] Binary request body via `body_base64`
- [x] Invalid base64 error handling


🐾 Generated with Crush