### PR TITLE
feat: add native agents integration to fix empty proxy responses #autodeploy

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/daltoniam/switchboard/config"
 	"github.com/daltoniam/switchboard/daemon"
 	acpInt "github.com/daltoniam/switchboard/integrations/acp"
+	agentsInt "github.com/daltoniam/switchboard/integrations/agents"
 	"github.com/daltoniam/switchboard/integrations/amazon"
 	awsInt "github.com/daltoniam/switchboard/integrations/aws"
 	"github.com/daltoniam/switchboard/integrations/botidentity"
@@ -231,6 +232,7 @@ func runServer(stdioMode bool, port int, discoverAll bool) {
 		flyInt.New(),
 		snowflakeInt.New(),
 		acpInt.New(),
+		agentsInt.New(),
 		signozInt.New(),
 		webfetchInt.New(),
 		nomadInt.New(),

--- a/config/config.go
+++ b/config/config.go
@@ -134,6 +134,11 @@ var envMapping = map[string]map[string]string{
 		"address": "NOMAD_ADDR",
 		"token":   "NOMAD_TOKEN",
 	},
+	"agents": {
+		"base_url": "AGENTS_BASE_URL",
+		"a2a_url":  "AGENTS_A2A_URL",
+		"token":    "AGENTS_TOKEN",
+	},
 }
 
 // EnvMapping returns the env var mapping table. Useful for documentation and debugging.
@@ -305,6 +310,10 @@ func defaultConfig() *mcp.Config {
 			"nomad": {
 				Enabled:     false,
 				Credentials: mcp.Credentials{"address": "", "token": ""},
+			},
+			"agents": {
+				Enabled:     false,
+				Credentials: mcp.Credentials{"base_url": "", "a2a_url": "", "token": ""},
 			},
 			"switchboard": {
 				Enabled:     false,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -32,7 +32,7 @@ func TestLoad_CreatesDefaultWhenMissing(t *testing.T) {
 	_, err = os.Stat(path)
 	assert.NoError(t, err)
 
-	assert.Len(t, m.cfg.Integrations, 34)
+	assert.Len(t, m.cfg.Integrations, 35)
 	for _, name := range []string{"github", "datadog", "linear", "sentry", "slack", "metabase", "aws", "posthog", "postgres", "clickhouse", "elasticsearch", "pganalyze", "rwx", "gmail", "notion", "ollama", "ynab", "gcp", "suno", "amazon", "jira", "confluence", "salesforce", "cloudflare", "digitalocean", "fly", "snowflake", "acp", "web", "botidentity", "x", "signoz", "nomad", "switchboard"} {
 		ic, ok := m.cfg.Integrations[name]
 		assert.True(t, ok, "missing default integration: %s", name)
@@ -134,7 +134,7 @@ func TestSave(t *testing.T) {
 
 	var cfg mcp.Config
 	require.NoError(t, json.Unmarshal(data, &cfg))
-	assert.Len(t, cfg.Integrations, 34)
+	assert.Len(t, cfg.Integrations, 35)
 }
 
 func TestGet(t *testing.T) {
@@ -143,7 +143,7 @@ func TestGet(t *testing.T) {
 
 	cfg := m.Get()
 	assert.NotNil(t, cfg)
-	assert.Len(t, cfg.Integrations, 34)
+	assert.Len(t, cfg.Integrations, 35)
 }
 
 func TestUpdate(t *testing.T) {
@@ -253,7 +253,7 @@ func TestEnabledIntegrations_Multiple(t *testing.T) {
 func TestDefaultConfig(t *testing.T) {
 	cfg := defaultConfig()
 	require.NotNil(t, cfg)
-	assert.Len(t, cfg.Integrations, 34)
+	assert.Len(t, cfg.Integrations, 35)
 
 	expected := map[string][]string{
 		"github":        {"token", "client_id", "token_source"},
@@ -503,7 +503,7 @@ func TestEnvMapping_ReturnsMapping(t *testing.T) {
 	assert.Equal(t, "SIGNOZ_API_KEY", m["signoz"]["api_key"])
 	assert.Equal(t, "NOMAD_ADDR", m["nomad"]["address"])
 	assert.Equal(t, "NOMAD_TOKEN", m["nomad"]["token"])
-	assert.Len(t, m, 24)
+	assert.Len(t, m, 25)
 }
 
 func TestToolGlobs_PersistThroughSaveLoad(t *testing.T) {

--- a/integrations/agents/agents.go
+++ b/integrations/agents/agents.go
@@ -1,0 +1,189 @@
+// Package agents provides a native Go integration for the ARP (Agent Registry
+// & Proxy) daemon. It communicates over two transports:
+//   - gRPC via HTTP/2 cleartext (h2c) for agent lifecycle management
+//   - HTTP/1.1 JSON for the A2A proxy endpoints
+//
+// The gRPC and HTTP endpoints may run on different ports (configured via
+// base_url and a2a_url credentials). This resolves the empty-response issue
+// where the WASM plugin used a single port for both transports.
+package agents
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+type integration struct {
+	mu      sync.RWMutex
+	grpc    *grpcClient
+	http    *httpClient
+	baseURL string
+	a2aURL  string
+	token   string
+}
+
+var _ mcp.PlainTextCredentials = (*integration)(nil)
+var _ mcp.PlaceholderHints = (*integration)(nil)
+var _ mcp.OptionalCredentials = (*integration)(nil)
+
+// New creates a new agents integration.
+func New() mcp.Integration {
+	return &integration{}
+}
+
+func (a *integration) Name() string { return "agents" }
+
+func (a *integration) PlainTextKeys() []string { return []string{"base_url", "a2a_url"} }
+func (a *integration) OptionalKeys() []string  { return []string{"token", "a2a_url"} }
+func (a *integration) Placeholders() map[string]string {
+	return map[string]string{
+		"base_url": "http://localhost:9098",
+		"a2a_url":  "http://localhost:9099 (defaults to base_url with port+1)",
+		"token":    "arp-bearer-token (optional for localhost)",
+	}
+}
+
+func (a *integration) Configure(_ context.Context, creds mcp.Credentials) error {
+	baseURL := strings.TrimRight(creds["base_url"], "/")
+	if baseURL == "" {
+		return fmt.Errorf("agents: base_url is required")
+	}
+
+	a2aURL := strings.TrimRight(creds["a2a_url"], "/")
+	if a2aURL == "" {
+		a2aURL = deriveA2AURL(baseURL)
+	}
+
+	token := creds["token"]
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	a.baseURL = baseURL
+	a.a2aURL = a2aURL
+	a.token = token
+	a.grpc = newGRPCClient(baseURL, token)
+	a.http = newHTTPClient(a2aURL, token)
+
+	return nil
+}
+
+func (a *integration) Healthy(ctx context.Context) bool {
+	a.mu.RLock()
+	g := a.grpc
+	a.mu.RUnlock()
+
+	if g == nil {
+		return false
+	}
+
+	// Try listing projects as a health check.
+	_, err := g.call(ctx, "arp.v1.ProjectService", "ListProjects", map[string]any{})
+	return err == nil
+}
+
+func (a *integration) Tools() []mcp.ToolDefinition {
+	return tools
+}
+
+func (a *integration) Execute(ctx context.Context, toolName mcp.ToolName, args map[string]any) (*mcp.ToolResult, error) {
+	fn, ok := dispatch[toolName]
+	if !ok {
+		return &mcp.ToolResult{Data: fmt.Sprintf("unknown tool: %s", toolName), IsError: true}, nil
+	}
+
+	a.mu.RLock()
+	grpc := a.grpc
+	http := a.http
+	a.mu.RUnlock()
+
+	if grpc == nil || http == nil {
+		return &mcp.ToolResult{Data: "agents: not configured", IsError: true}, nil
+	}
+
+	return fn(ctx, grpc, http, args)
+}
+
+type handlerFunc func(ctx context.Context, grpc *grpcClient, http *httpClient, args map[string]any) (*mcp.ToolResult, error)
+
+var dispatch = map[mcp.ToolName]handlerFunc{
+	// ProjectService
+	"agents_project_list":       handleProjectList,
+	"agents_project_register":   handleProjectRegister,
+	"agents_project_unregister": handleProjectUnregister,
+	// WorkspaceService
+	"agents_workspace_create":  handleWorkspaceCreate,
+	"agents_workspace_list":    handleWorkspaceList,
+	"agents_workspace_get":     handleWorkspaceGet,
+	"agents_workspace_destroy": handleWorkspaceDestroy,
+	// AgentService — lifecycle
+	"agents_agent_spawn":   handleAgentSpawn,
+	"agents_agent_list":    handleAgentList,
+	"agents_agent_status":  handleAgentStatus,
+	"agents_agent_stop":    handleAgentStop,
+	"agents_agent_restart": handleAgentRestart,
+	// AgentService — messaging
+	"agents_agent_message":     handleAgentMessage,
+	"agents_agent_task":        handleAgentTask,
+	"agents_agent_task_status": handleAgentTaskStatus,
+	// DiscoveryService
+	"agents_discover": handleDiscover,
+	// A2A proxy (HTTP)
+	"agents_proxy_list":         handleProxyList,
+	"agents_agent_card":         handleAgentCard,
+	"agents_proxy_send_message": handleProxySendMessage,
+	"agents_proxy_get_task":     handleProxyGetTask,
+	"agents_proxy_cancel_task":  handleProxyCancelTask,
+	"agents_route_message":      handleRouteMessage,
+}
+
+// deriveA2AURL computes the A2A HTTP URL from the gRPC base URL by
+// incrementing the port number by 1. For example, http://localhost:9098
+// becomes http://localhost:9099.
+func deriveA2AURL(baseURL string) string {
+	// Strip scheme prefix to find the host:port portion.
+	scheme := ""
+	rest := baseURL
+	if idx := strings.Index(baseURL, "://"); idx != -1 {
+		scheme = baseURL[:idx+3]
+		rest = baseURL[idx+3:]
+	}
+
+	// Find the port after the last colon in the host portion.
+	// Stop at any path separator.
+	hostPort := rest
+	var pathSuffix string
+	if idx := strings.Index(rest, "/"); idx != -1 {
+		hostPort = rest[:idx]
+		pathSuffix = rest[idx:]
+	}
+
+	lastColon := strings.LastIndex(hostPort, ":")
+	if lastColon == -1 {
+		// No port specified, return original.
+		return baseURL
+	}
+
+	host := hostPort[:lastColon]
+	portStr := hostPort[lastColon+1:]
+
+	port := 0
+	for _, c := range portStr {
+		if c >= '0' && c <= '9' {
+			port = port*10 + int(c-'0')
+		} else {
+			// Not a valid port, return original.
+			return baseURL
+		}
+	}
+
+	if portStr == "" {
+		return baseURL
+	}
+
+	return fmt.Sprintf("%s%s:%d%s", scheme, host, port+1, pathSuffix)
+}

--- a/integrations/agents/agents_test.go
+++ b/integrations/agents/agents_test.go
@@ -1,0 +1,451 @@
+package agents
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+func TestName(t *testing.T) {
+	i := New()
+	if i.Name() != "agents" {
+		t.Fatalf("expected name 'agents', got %q", i.Name())
+	}
+}
+
+func TestConfigureRequiresBaseURL(t *testing.T) {
+	i := New()
+	err := i.Configure(context.Background(), mcp.Credentials{})
+	if err == nil {
+		t.Fatal("expected error for empty credentials")
+	}
+	if err.Error() != "agents: base_url is required" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestConfigureSuccess(t *testing.T) {
+	i := New()
+	err := i.Configure(context.Background(), mcp.Credentials{
+		"base_url": "http://localhost:9098",
+		"a2a_url":  "http://localhost:9099",
+		"token":    "test-token",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestConfigureDeriveA2AURL(t *testing.T) {
+	i := New().(*integration)
+	err := i.Configure(context.Background(), mcp.Credentials{
+		"base_url": "http://localhost:9098",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if i.a2aURL != "http://localhost:9099" {
+		t.Fatalf("expected derived a2a_url 'http://localhost:9099', got %q", i.a2aURL)
+	}
+}
+
+func TestDeriveA2AURL(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"http://localhost:9098", "http://localhost:9099"},
+		{"http://example.com:8080", "http://example.com:8081"},
+		{"http://192.168.1.1:3000", "http://192.168.1.1:3001"},
+		{"http://noport", "http://noport"}, // no port to increment
+	}
+	for _, tt := range tests {
+		got := deriveA2AURL(tt.input)
+		if got != tt.expected {
+			t.Errorf("deriveA2AURL(%q) = %q, want %q", tt.input, got, tt.expected)
+		}
+	}
+}
+
+func TestTools(t *testing.T) {
+	i := New()
+	tools := i.Tools()
+	if len(tools) == 0 {
+		t.Fatal("expected tools, got none")
+	}
+
+	// Check that all expected proxy tools exist.
+	expectedNames := []string{
+		"agents_proxy_list",
+		"agents_proxy_send_message",
+		"agents_proxy_get_task",
+		"agents_proxy_cancel_task",
+		"agents_route_message",
+		"agents_agent_card",
+	}
+	nameSet := make(map[mcp.ToolName]bool)
+	for _, tool := range tools {
+		nameSet[tool.Name] = true
+	}
+	for _, name := range expectedNames {
+		if !nameSet[mcp.ToolName(name)] {
+			t.Errorf("missing tool %q", name)
+		}
+	}
+}
+
+func TestPlainTextKeys(t *testing.T) {
+	i := New().(mcp.PlainTextCredentials)
+	keys := i.PlainTextKeys()
+	expected := map[string]bool{"base_url": true, "a2a_url": true}
+	for _, k := range keys {
+		if !expected[k] {
+			t.Errorf("unexpected plain text key: %q", k)
+		}
+		delete(expected, k)
+	}
+	for k := range expected {
+		t.Errorf("missing plain text key: %q", k)
+	}
+}
+
+func TestOptionalKeys(t *testing.T) {
+	i := New().(mcp.OptionalCredentials)
+	keys := i.OptionalKeys()
+	expected := map[string]bool{"token": true, "a2a_url": true}
+	for _, k := range keys {
+		if !expected[k] {
+			t.Errorf("unexpected optional key: %q", k)
+		}
+		delete(expected, k)
+	}
+	for k := range expected {
+		t.Errorf("missing optional key: %q", k)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// A2A proxy handler tests with mock HTTP server
+// ---------------------------------------------------------------------------
+
+func TestProxyList(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/a2a/agents" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			http.Error(w, "not found", 404)
+			return
+		}
+		if r.Method != "GET" {
+			t.Errorf("unexpected method: %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `[{"name":"test-agent","description":"A test agent"}]`)
+	}))
+	defer srv.Close()
+
+	i := New().(*integration)
+	_ = i.Configure(context.Background(), mcp.Credentials{
+		"base_url": "http://localhost:9098", // won't be used for proxy
+		"a2a_url":  srv.URL,
+	})
+
+	result, err := i.Execute(context.Background(), "agents_proxy_list", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got error: %s", result.Data)
+	}
+	if result.Data == "{}" {
+		t.Fatal("got empty {} response — this was the original bug")
+	}
+	var agents []map[string]any
+	if err := json.Unmarshal([]byte(result.Data), &agents); err != nil {
+		t.Fatalf("invalid JSON response: %v", err)
+	}
+	if len(agents) != 1 {
+		t.Fatalf("expected 1 agent, got %d", len(agents))
+	}
+	if agents[0]["name"] != "test-agent" {
+		t.Fatalf("expected agent name 'test-agent', got %v", agents[0]["name"])
+	}
+}
+
+func TestProxySendMessage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/a2a/agents/test-agent/message:send" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			http.Error(w, "not found", 404)
+			return
+		}
+		if r.Method != "POST" {
+			t.Errorf("unexpected method: %s", r.Method)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+			t.Errorf("unexpected content-type: %s", ct)
+		}
+
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		msg, _ := body["message"].(map[string]any)
+		if msg == nil {
+			t.Fatal("expected 'message' in body")
+		}
+		if msg["role"] != "ROLE_USER" {
+			t.Errorf("expected role ROLE_USER, got %v", msg["role"])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"task":{"id":"task-123","status":{"state":"working"}}}`)
+	}))
+	defer srv.Close()
+
+	i := New().(*integration)
+	_ = i.Configure(context.Background(), mcp.Credentials{
+		"base_url": "http://localhost:9098",
+		"a2a_url":  srv.URL,
+	})
+
+	result, err := i.Execute(context.Background(), "agents_proxy_send_message", map[string]any{
+		"agent_id": "test-agent",
+		"message":  "Hello, agent!",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got error: %s", result.Data)
+	}
+	if result.Data == "{}" {
+		t.Fatal("got empty {} response — this was the original bug")
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(result.Data), &resp); err != nil {
+		t.Fatalf("invalid JSON response: %v", err)
+	}
+	task, _ := resp["task"].(map[string]any)
+	if task == nil {
+		t.Fatal("expected 'task' in response")
+	}
+	if task["id"] != "task-123" {
+		t.Fatalf("expected task id 'task-123', got %v", task["id"])
+	}
+}
+
+func TestProxyGetTask(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/a2a/agents/agent-1/tasks/task-abc" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			http.Error(w, "not found", 404)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"id":"task-abc","status":{"state":"completed"},"artifacts":[{"text":"done"}]}`)
+	}))
+	defer srv.Close()
+
+	i := New().(*integration)
+	_ = i.Configure(context.Background(), mcp.Credentials{
+		"base_url": "http://localhost:9098",
+		"a2a_url":  srv.URL,
+	})
+
+	result, err := i.Execute(context.Background(), "agents_proxy_get_task", map[string]any{
+		"agent_id": "agent-1",
+		"task_id":  "task-abc",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got error: %s", result.Data)
+	}
+	if result.Data == "{}" {
+		t.Fatal("got empty {} response — this was the original bug")
+	}
+}
+
+func TestProxyCancelTask(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/a2a/agents/agent-1/tasks/task-abc:cancel" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			http.Error(w, "not found", 404)
+			return
+		}
+		if r.Method != "POST" {
+			t.Errorf("unexpected method: %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"id":"task-abc","status":{"state":"canceled"}}`)
+	}))
+	defer srv.Close()
+
+	i := New().(*integration)
+	_ = i.Configure(context.Background(), mcp.Credentials{
+		"base_url": "http://localhost:9098",
+		"a2a_url":  srv.URL,
+	})
+
+	result, err := i.Execute(context.Background(), "agents_proxy_cancel_task", map[string]any{
+		"agent_id": "agent-1",
+		"task_id":  "task-abc",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got error: %s", result.Data)
+	}
+}
+
+func TestRouteMessage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/a2a/route/message:send" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			http.Error(w, "not found", 404)
+			return
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		routing, _ := body["routing"].(map[string]any)
+		if routing == nil {
+			t.Fatal("expected 'routing' in body")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"task":{"id":"routed-task-1","status":{"state":"working"}}}`)
+	}))
+	defer srv.Close()
+
+	i := New().(*integration)
+	_ = i.Configure(context.Background(), mcp.Credentials{
+		"base_url": "http://localhost:9098",
+		"a2a_url":  srv.URL,
+	})
+
+	result, err := i.Execute(context.Background(), "agents_route_message", map[string]any{
+		"message": "Help me with coding",
+		"tags":    `["coding", "go"]`,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got error: %s", result.Data)
+	}
+}
+
+func TestProxyListEmptyResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Simulate the old daemon bug: returns 200 with empty body
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	i := New().(*integration)
+	_ = i.Configure(context.Background(), mcp.Credentials{
+		"base_url": "http://localhost:9098",
+		"a2a_url":  srv.URL,
+	})
+
+	result, err := i.Execute(context.Background(), "agents_proxy_list", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should return an error result explaining the issue, not empty {}
+	if !result.IsError {
+		t.Fatal("expected error result for empty response")
+	}
+	if result.Data == "{}" {
+		t.Fatal("got empty {} — should explain the problem")
+	}
+}
+
+func TestProxyListHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	i := New().(*integration)
+	_ = i.Configure(context.Background(), mcp.Credentials{
+		"base_url": "http://localhost:9098",
+		"a2a_url":  srv.URL,
+	})
+
+	result, err := i.Execute(context.Background(), "agents_proxy_list", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result for 401 response")
+	}
+}
+
+func TestAgentCardPathEncoding(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The agent ID "workspace/agent" should be encoded.
+		expected := "/a2a/agents/workspace%2Fagent/.well-known/agent-card.json"
+		if r.URL.RawPath != expected && r.URL.Path != "/a2a/agents/workspace%2Fagent/.well-known/agent-card.json" {
+			t.Errorf("unexpected path: %s (raw: %s)", r.URL.Path, r.URL.RawPath)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"name":"my-agent","skills":[]}`)
+	}))
+	defer srv.Close()
+
+	i := New().(*integration)
+	_ = i.Configure(context.Background(), mcp.Credentials{
+		"base_url": "http://localhost:9098",
+		"a2a_url":  srv.URL,
+	})
+
+	result, err := i.Execute(context.Background(), "agents_agent_card", map[string]any{
+		"agent_id": "workspace/agent",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got error: %s", result.Data)
+	}
+}
+
+func TestProxySendMessageWithAuth(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if auth != "Bearer my-token" {
+			t.Errorf("expected 'Bearer my-token' auth header, got %q", auth)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"task":{"id":"t1"}}`)
+	}))
+	defer srv.Close()
+
+	i := New().(*integration)
+	_ = i.Configure(context.Background(), mcp.Credentials{
+		"base_url": "http://localhost:9098",
+		"a2a_url":  srv.URL,
+		"token":    "my-token",
+	})
+
+	result, err := i.Execute(context.Background(), "agents_proxy_send_message", map[string]any{
+		"agent_id": "agent-1",
+		"message":  "hello",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got error: %s", result.Data)
+	}
+}

--- a/integrations/agents/grpc.go
+++ b/integrations/agents/grpc.go
@@ -1,0 +1,167 @@
+package agents
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"time"
+
+	"golang.org/x/net/http2"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// grpcClient makes gRPC calls over HTTP/2 cleartext (h2c) to the ARP daemon.
+// It uses google.protobuf.Struct for all request/response encoding to avoid
+// importing the full ARP proto definitions. The daemon's gRPC services accept
+// JSON-encoded Struct messages via the standard protobuf JSON mapping.
+type grpcClient struct {
+	baseURL string
+	token   string
+	client  *http.Client
+}
+
+func newGRPCClient(baseURL, token string) *grpcClient {
+	return &grpcClient{
+		baseURL: baseURL,
+		token:   token,
+		client: &http.Client{
+			Timeout: 30 * time.Second,
+			Transport: &http2.Transport{
+				AllowHTTP: true,
+				DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+					return (&net.Dialer{}).DialContext(ctx, network, addr)
+				},
+			},
+		},
+	}
+}
+
+// call invokes a gRPC method using protobuf Struct encoding over h2c.
+// The request args are encoded as a google.protobuf.Struct, framed in gRPC
+// wire format, and sent as application/grpc. The response is decoded from
+// the gRPC frame back into a JSON-compatible map.
+func (g *grpcClient) call(ctx context.Context, service, method string, args map[string]any) (json.RawMessage, error) {
+	// Encode request as protobuf Struct.
+	reqStruct, err := structpb.NewStruct(args)
+	if err != nil {
+		return nil, fmt.Errorf("encode request: %w", err)
+	}
+
+	reqBytes, err := proto.Marshal(reqStruct)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	// Frame in gRPC wire format: 1 byte compressed flag + 4 byte length + payload.
+	frame := make([]byte, 5+len(reqBytes))
+	frame[0] = 0 // not compressed
+	binary.BigEndian.PutUint32(frame[1:5], uint32(len(reqBytes)))
+	copy(frame[5:], reqBytes)
+
+	url := fmt.Sprintf("%s/%s/%s", g.baseURL, service, method)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, io.NopCloser(bytesReader(frame)))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/grpc")
+	req.Header.Set("TE", "trailers")
+	if g.token != "" {
+		req.Header.Set("Authorization", "Bearer "+g.token)
+	}
+
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("grpc call %s/%s: %w", service, method, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		gs := resp.Trailer.Get("grpc-status")
+		gm := resp.Trailer.Get("grpc-message")
+		if gs == "" {
+			gs = resp.Header.Get("grpc-status")
+		}
+		if gm == "" {
+			gm = resp.Header.Get("grpc-message")
+		}
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		if gm == "" {
+			gm = string(body)
+		}
+		return nil, fmt.Errorf("gRPC error (http=%d, status=%s): %s", resp.StatusCode, gs, gm)
+	}
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	// Check trailers for gRPC status.
+	if gs := resp.Trailer.Get("grpc-status"); gs != "" && gs != "0" {
+		gm := resp.Trailer.Get("grpc-message")
+		if gm == "" {
+			gm = "unknown error"
+		}
+		return nil, fmt.Errorf("gRPC error (status=%s): %s", gs, gm)
+	}
+
+	// Empty response is valid (e.g. for delete operations).
+	if len(respBody) < 5 {
+		// Check header-based grpc-status for responses with no body.
+		if gs := resp.Header.Get("grpc-status"); gs != "" && gs != "0" {
+			gm := resp.Header.Get("grpc-message")
+			return nil, fmt.Errorf("gRPC error (status=%s): %s", gs, gm)
+		}
+		return json.RawMessage("{}"), nil
+	}
+
+	// Parse gRPC frame.
+	if respBody[0]&0x80 != 0 {
+		// Trailers-only frame.
+		return json.RawMessage("{}"), nil
+	}
+
+	msgLen := binary.BigEndian.Uint32(respBody[1:5])
+	if len(respBody) < int(5+msgLen) {
+		return nil, fmt.Errorf("gRPC response truncated: have %d, need %d", len(respBody)-5, msgLen)
+	}
+
+	// Decode as Struct and convert to JSON.
+	var respStruct structpb.Struct
+	if err := proto.Unmarshal(respBody[5:5+msgLen], &respStruct); err != nil {
+		return nil, fmt.Errorf("unmarshal response: %w", err)
+	}
+
+	jsonBytes, err := protojson.Marshal(&respStruct)
+	if err != nil {
+		return nil, fmt.Errorf("marshal response to JSON: %w", err)
+	}
+
+	return json.RawMessage(jsonBytes), nil
+}
+
+// bytesReader wraps a byte slice as an io.Reader.
+func bytesReader(b []byte) io.Reader {
+	return &bytesReaderImpl{data: b}
+}
+
+type bytesReaderImpl struct {
+	data []byte
+	pos  int
+}
+
+func (r *bytesReaderImpl) Read(p []byte) (int, error) {
+	if r.pos >= len(r.data) {
+		return 0, io.EOF
+	}
+	n := copy(p, r.data[r.pos:])
+	r.pos += n
+	return n, nil
+}

--- a/integrations/agents/handlers.go
+++ b/integrations/agents/handlers.go
@@ -1,0 +1,648 @@
+package agents
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"sync/atomic"
+	"time"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+// messageCounter generates unique message IDs.
+var messageCounter uint64
+
+func genMessageID() string {
+	n := atomic.AddUint64(&messageCounter, 1)
+	return fmt.Sprintf("swb-%016x", n)
+}
+
+// ---------------------------------------------------------------------------
+// ProjectService handlers
+// ---------------------------------------------------------------------------
+
+func handleProjectList(ctx context.Context, grpc *grpcClient, _ *httpClient, _ map[string]any) (*mcp.ToolResult, error) {
+	resp, err := grpc.call(ctx, "arp.v1.ProjectService", "ListProjects", map[string]any{})
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return &mcp.ToolResult{Data: string(resp)}, nil
+}
+
+func handleProjectRegister(ctx context.Context, grpc *grpcClient, _ *httpClient, args map[string]any) (*mcp.ToolResult, error) {
+	name, _ := mcp.ArgStr(args, "name")
+	repo, _ := mcp.ArgStr(args, "repo")
+	if name == "" {
+		return mcp.ErrResult(fmt.Errorf("name is required"))
+	}
+	if repo == "" {
+		return mcp.ErrResult(fmt.Errorf("repo is required"))
+	}
+
+	req := map[string]any{
+		"name": name,
+		"repo": repo,
+	}
+	if branch, _ := mcp.ArgStr(args, "branch"); branch != "" {
+		req["branch"] = branch
+	}
+	if agentsJSON, _ := mcp.ArgStr(args, "agents"); agentsJSON != "" {
+		var agents []any
+		if err := json.Unmarshal([]byte(agentsJSON), &agents); err != nil {
+			return mcp.ErrResult(fmt.Errorf("invalid agents JSON: %w", err))
+		}
+		req["agents"] = agents
+	}
+
+	resp, err := grpc.call(ctx, "arp.v1.ProjectService", "RegisterProject", req)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return &mcp.ToolResult{Data: string(resp)}, nil
+}
+
+func handleProjectUnregister(ctx context.Context, grpc *grpcClient, _ *httpClient, args map[string]any) (*mcp.ToolResult, error) {
+	name, _ := mcp.ArgStr(args, "name")
+	if name == "" {
+		return mcp.ErrResult(fmt.Errorf("name is required"))
+	}
+
+	_, err := grpc.call(ctx, "arp.v1.ProjectService", "UnregisterProject", map[string]any{"name": name})
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return &mcp.ToolResult{Data: `{"status":"ok"}`}, nil
+}
+
+// ---------------------------------------------------------------------------
+// WorkspaceService handlers
+// ---------------------------------------------------------------------------
+
+func handleWorkspaceCreate(ctx context.Context, grpc *grpcClient, _ *httpClient, args map[string]any) (*mcp.ToolResult, error) {
+	name, _ := mcp.ArgStr(args, "name")
+	project, _ := mcp.ArgStr(args, "project")
+	if name == "" {
+		return mcp.ErrResult(fmt.Errorf("name is required"))
+	}
+	if project == "" {
+		return mcp.ErrResult(fmt.Errorf("project is required"))
+	}
+
+	req := map[string]any{
+		"name":    name,
+		"project": project,
+	}
+	if branch, _ := mcp.ArgStr(args, "branch"); branch != "" {
+		req["branch"] = branch
+	}
+	if autoJSON, _ := mcp.ArgStr(args, "auto_agents"); autoJSON != "" {
+		var agents []any
+		if err := json.Unmarshal([]byte(autoJSON), &agents); err != nil {
+			return mcp.ErrResult(fmt.Errorf("invalid auto_agents JSON: %w", err))
+		}
+		req["autoAgents"] = agents
+	}
+
+	resp, err := grpc.call(ctx, "arp.v1.WorkspaceService", "CreateWorkspace", req)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return &mcp.ToolResult{Data: string(resp)}, nil
+}
+
+func handleWorkspaceList(ctx context.Context, grpc *grpcClient, _ *httpClient, args map[string]any) (*mcp.ToolResult, error) {
+	req := map[string]any{}
+	if project, _ := mcp.ArgStr(args, "project"); project != "" {
+		req["project"] = project
+	}
+	if status, _ := mcp.ArgStr(args, "status"); status != "" {
+		switch status {
+		case "active":
+			req["status"] = 1
+		case "inactive":
+			req["status"] = 2
+		}
+	}
+
+	resp, err := grpc.call(ctx, "arp.v1.WorkspaceService", "ListWorkspaces", req)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return &mcp.ToolResult{Data: string(resp)}, nil
+}
+
+func handleWorkspaceGet(ctx context.Context, grpc *grpcClient, _ *httpClient, args map[string]any) (*mcp.ToolResult, error) {
+	name, _ := mcp.ArgStr(args, "name")
+	if name == "" {
+		return mcp.ErrResult(fmt.Errorf("name is required"))
+	}
+
+	resp, err := grpc.call(ctx, "arp.v1.WorkspaceService", "GetWorkspace", map[string]any{"name": name})
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return &mcp.ToolResult{Data: string(resp)}, nil
+}
+
+func handleWorkspaceDestroy(ctx context.Context, grpc *grpcClient, _ *httpClient, args map[string]any) (*mcp.ToolResult, error) {
+	name, _ := mcp.ArgStr(args, "name")
+	if name == "" {
+		return mcp.ErrResult(fmt.Errorf("name is required"))
+	}
+
+	req := map[string]any{"name": name}
+	if keepStr, _ := mcp.ArgStr(args, "keep_worktree"); keepStr == "true" {
+		req["keepWorktree"] = true
+	}
+
+	_, err := grpc.call(ctx, "arp.v1.WorkspaceService", "DestroyWorkspace", req)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return &mcp.ToolResult{Data: `{"status":"ok"}`}, nil
+}
+
+// ---------------------------------------------------------------------------
+// AgentService handlers — lifecycle
+// ---------------------------------------------------------------------------
+
+func handleAgentSpawn(ctx context.Context, grpc *grpcClient, _ *httpClient, args map[string]any) (*mcp.ToolResult, error) {
+	workspace, _ := mcp.ArgStr(args, "workspace")
+	template, _ := mcp.ArgStr(args, "template")
+	if workspace == "" {
+		return mcp.ErrResult(fmt.Errorf("workspace is required"))
+	}
+	if template == "" {
+		return mcp.ErrResult(fmt.Errorf("template is required"))
+	}
+
+	req := map[string]any{
+		"workspace": workspace,
+		"template":  template,
+	}
+	if name, _ := mcp.ArgStr(args, "name"); name != "" {
+		req["name"] = name
+	}
+	if prompt, _ := mcp.ArgStr(args, "prompt"); prompt != "" {
+		req["prompt"] = prompt
+	}
+	if envJSON, _ := mcp.ArgStr(args, "env"); envJSON != "" {
+		var env map[string]any
+		if err := json.Unmarshal([]byte(envJSON), &env); err != nil {
+			return mcp.ErrResult(fmt.Errorf("invalid env JSON: %w", err))
+		}
+		req["env"] = env
+	}
+	if scopeJSON, _ := mcp.ArgStr(args, "scope"); scopeJSON != "" {
+		var scope map[string]any
+		if err := json.Unmarshal([]byte(scopeJSON), &scope); err != nil {
+			return mcp.ErrResult(fmt.Errorf("invalid scope JSON: %w", err))
+		}
+		req["scope"] = scope
+	}
+	if perm, _ := mcp.ArgStr(args, "permission"); perm != "" {
+		switch perm {
+		case "session", "PERMISSION_SESSION":
+			req["permission"] = 1
+		case "project", "PERMISSION_PROJECT":
+			req["permission"] = 2
+		case "admin", "PERMISSION_ADMIN":
+			req["permission"] = 3
+		}
+	}
+
+	resp, err := grpc.call(ctx, "arp.v1.AgentService", "SpawnAgent", req)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return &mcp.ToolResult{Data: string(resp)}, nil
+}
+
+func handleAgentList(ctx context.Context, grpc *grpcClient, _ *httpClient, args map[string]any) (*mcp.ToolResult, error) {
+	req := map[string]any{}
+	if workspace, _ := mcp.ArgStr(args, "workspace"); workspace != "" {
+		req["workspace"] = workspace
+	}
+	if template, _ := mcp.ArgStr(args, "template"); template != "" {
+		req["template"] = template
+	}
+	if status, _ := mcp.ArgStr(args, "status"); status != "" {
+		switch status {
+		case "starting":
+			req["status"] = 1
+		case "ready":
+			req["status"] = 2
+		case "busy":
+			req["status"] = 3
+		case "error":
+			req["status"] = 4
+		case "stopping":
+			req["status"] = 5
+		case "stopped":
+			req["status"] = 6
+		}
+	}
+
+	resp, err := grpc.call(ctx, "arp.v1.AgentService", "ListAgents", req)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return &mcp.ToolResult{Data: string(resp)}, nil
+}
+
+func handleAgentStatus(ctx context.Context, grpc *grpcClient, _ *httpClient, args map[string]any) (*mcp.ToolResult, error) {
+	agentID, _ := mcp.ArgStr(args, "agent_id")
+	if agentID == "" {
+		return mcp.ErrResult(fmt.Errorf("agent_id is required"))
+	}
+
+	resp, err := grpc.call(ctx, "arp.v1.AgentService", "GetAgentStatus", map[string]any{"agentId": agentID})
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return &mcp.ToolResult{Data: string(resp)}, nil
+}
+
+func handleAgentStop(ctx context.Context, grpc *grpcClient, _ *httpClient, args map[string]any) (*mcp.ToolResult, error) {
+	agentID, _ := mcp.ArgStr(args, "agent_id")
+	if agentID == "" {
+		return mcp.ErrResult(fmt.Errorf("agent_id is required"))
+	}
+
+	req := map[string]any{"agentId": agentID}
+	if grace, _ := mcp.ArgStr(args, "grace_period_ms"); grace != "" {
+		if v, err := strconv.Atoi(grace); err == nil {
+			req["gracePeriodMs"] = v
+		}
+	}
+
+	resp, err := grpc.call(ctx, "arp.v1.AgentService", "StopAgent", req)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return &mcp.ToolResult{Data: string(resp)}, nil
+}
+
+func handleAgentRestart(ctx context.Context, grpc *grpcClient, _ *httpClient, args map[string]any) (*mcp.ToolResult, error) {
+	agentID, _ := mcp.ArgStr(args, "agent_id")
+	if agentID == "" {
+		return mcp.ErrResult(fmt.Errorf("agent_id is required"))
+	}
+
+	resp, err := grpc.call(ctx, "arp.v1.AgentService", "RestartAgent", map[string]any{"agentId": agentID})
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return &mcp.ToolResult{Data: string(resp)}, nil
+}
+
+// ---------------------------------------------------------------------------
+// AgentService handlers — messaging
+// ---------------------------------------------------------------------------
+
+const maxPollAttempts = 600
+
+func isTerminalStatus(status string) bool {
+	switch status {
+	case "completed", "failed", "canceled":
+		return true
+	}
+	return false
+}
+
+func handleAgentMessage(ctx context.Context, grpc *grpcClient, _ *httpClient, args map[string]any) (*mcp.ToolResult, error) {
+	agentID, _ := mcp.ArgStr(args, "agent_id")
+	message, _ := mcp.ArgStr(args, "message")
+	if agentID == "" {
+		return mcp.ErrResult(fmt.Errorf("agent_id is required"))
+	}
+	if message == "" {
+		return mcp.ErrResult(fmt.Errorf("message is required"))
+	}
+
+	blockingStr, _ := mcp.ArgStr(args, "blocking")
+	blocking := blockingStr != "false" // default true
+
+	contextID, _ := mcp.ArgStr(args, "context_id")
+
+	// Always send non-blocking to avoid gRPC timeout, then poll if blocking.
+	req := map[string]any{
+		"agentId":  agentID,
+		"message":  message,
+		"blocking": false,
+	}
+	if contextID != "" {
+		req["contextId"] = contextID
+	}
+
+	resp, err := grpc.call(ctx, "arp.v1.AgentService", "SendAgentMessage", req)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	// Parse response to check for direct message or task.
+	var result map[string]json.RawMessage
+	if err := json.Unmarshal(resp, &result); err != nil {
+		return &mcp.ToolResult{Data: string(resp)}, nil
+	}
+
+	// If we got a direct message, return it.
+	if _, ok := result["message"]; ok {
+		return &mcp.ToolResult{Data: string(resp)}, nil
+	}
+
+	// Extract task.
+	taskRaw, hasTask := result["task"]
+	if !hasTask {
+		return &mcp.ToolResult{Data: string(resp)}, nil
+	}
+
+	// Non-blocking mode: return task immediately.
+	if !blocking {
+		return &mcp.ToolResult{Data: string(resp)}, nil
+	}
+
+	// Extract task ID for polling.
+	var task map[string]any
+	if err := json.Unmarshal(taskRaw, &task); err != nil {
+		return &mcp.ToolResult{Data: string(resp)}, nil
+	}
+	taskID, _ := task["id"].(string)
+	if taskID == "" {
+		return &mcp.ToolResult{Data: string(resp)}, nil
+	}
+
+	// Poll until terminal state.
+	return pollTaskUntilDone(ctx, grpc, agentID, taskID)
+}
+
+func pollTaskUntilDone(ctx context.Context, grpc *grpcClient, agentID, taskID string) (*mcp.ToolResult, error) {
+	pollReq := map[string]any{
+		"agentId":       agentID,
+		"taskId":        taskID,
+		"historyLength": 10,
+	}
+
+	for range maxPollAttempts {
+		select {
+		case <-ctx.Done():
+			return mcp.ErrResult(ctx.Err())
+		default:
+		}
+
+		resp, err := grpc.call(ctx, "arp.v1.AgentService", "GetAgentTaskStatus", pollReq)
+		if err != nil {
+			return mcp.ErrResult(fmt.Errorf("poll error: %w", err))
+		}
+
+		// Check if terminal.
+		var task map[string]any
+		if err := json.Unmarshal(resp, &task); err == nil {
+			// Check nested status.state.
+			if statusObj, ok := task["status"].(map[string]any); ok {
+				if state, ok := statusObj["state"].(string); ok && isTerminalStatus(state) {
+					return &mcp.ToolResult{Data: string(resp)}, nil
+				}
+			}
+			// Check flat state field.
+			if state, ok := task["state"].(string); ok && isTerminalStatus(state) {
+				return &mcp.ToolResult{Data: string(resp)}, nil
+			}
+		}
+
+		// Brief pause before next poll to avoid tight loop.
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// Timed out — return last status with warning.
+	resp, _ := grpc.call(ctx, "arp.v1.AgentService", "GetAgentTaskStatus", pollReq)
+	if resp != nil {
+		return &mcp.ToolResult{Data: fmt.Sprintf(`{"task":%s,"_warning":"polling timeout — task may still be running"}`, string(resp))}, nil
+	}
+	return mcp.ErrResult(fmt.Errorf("polling timeout for task %s", taskID))
+}
+
+func handleAgentTask(ctx context.Context, grpc *grpcClient, _ *httpClient, args map[string]any) (*mcp.ToolResult, error) {
+	agentID, _ := mcp.ArgStr(args, "agent_id")
+	message, _ := mcp.ArgStr(args, "message")
+	if agentID == "" {
+		return mcp.ErrResult(fmt.Errorf("agent_id is required"))
+	}
+	if message == "" {
+		return mcp.ErrResult(fmt.Errorf("message is required"))
+	}
+
+	req := map[string]any{
+		"agentId": agentID,
+		"message": message,
+	}
+	if contextID, _ := mcp.ArgStr(args, "context_id"); contextID != "" {
+		req["contextId"] = contextID
+	}
+
+	resp, err := grpc.call(ctx, "arp.v1.AgentService", "CreateAgentTask", req)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return &mcp.ToolResult{Data: string(resp)}, nil
+}
+
+func handleAgentTaskStatus(ctx context.Context, grpc *grpcClient, _ *httpClient, args map[string]any) (*mcp.ToolResult, error) {
+	agentID, _ := mcp.ArgStr(args, "agent_id")
+	taskID, _ := mcp.ArgStr(args, "task_id")
+	if agentID == "" {
+		return mcp.ErrResult(fmt.Errorf("agent_id is required"))
+	}
+	if taskID == "" {
+		return mcp.ErrResult(fmt.Errorf("task_id is required"))
+	}
+
+	req := map[string]any{
+		"agentId": agentID,
+		"taskId":  taskID,
+	}
+	if hl, _ := mcp.ArgStr(args, "history_length"); hl != "" {
+		if v, err := strconv.Atoi(hl); err == nil {
+			req["historyLength"] = v
+		}
+	}
+
+	resp, err := grpc.call(ctx, "arp.v1.AgentService", "GetAgentTaskStatus", req)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return &mcp.ToolResult{Data: string(resp)}, nil
+}
+
+// ---------------------------------------------------------------------------
+// DiscoveryService handler
+// ---------------------------------------------------------------------------
+
+func handleDiscover(ctx context.Context, grpc *grpcClient, _ *httpClient, args map[string]any) (*mcp.ToolResult, error) {
+	req := map[string]any{}
+	if scope, _ := mcp.ArgStr(args, "scope"); scope != "" {
+		switch scope {
+		case "local", "DISCOVERY_SCOPE_LOCAL":
+			req["scope"] = 1
+		case "network", "DISCOVERY_SCOPE_NETWORK":
+			req["scope"] = 2
+		}
+	}
+	if capability, _ := mcp.ArgStr(args, "capability"); capability != "" {
+		req["capability"] = capability
+	}
+	if urlsJSON, _ := mcp.ArgStr(args, "urls"); urlsJSON != "" {
+		var urls []any
+		if err := json.Unmarshal([]byte(urlsJSON), &urls); err != nil {
+			return mcp.ErrResult(fmt.Errorf("invalid urls JSON: %w", err))
+		}
+		req["urls"] = urls
+	}
+
+	resp, err := grpc.call(ctx, "arp.v1.DiscoveryService", "DiscoverAgents", req)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return &mcp.ToolResult{Data: string(resp)}, nil
+}
+
+// ---------------------------------------------------------------------------
+// A2A proxy handlers (HTTP)
+// ---------------------------------------------------------------------------
+
+func handleProxyList(ctx context.Context, _ *grpcClient, h *httpClient, _ map[string]any) (*mcp.ToolResult, error) {
+	resp, err := h.get(ctx, "/a2a/agents")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return &mcp.ToolResult{Data: string(resp)}, nil
+}
+
+func handleAgentCard(ctx context.Context, _ *grpcClient, h *httpClient, args map[string]any) (*mcp.ToolResult, error) {
+	agentID, _ := mcp.ArgStr(args, "agent_id")
+	if agentID == "" {
+		return mcp.ErrResult(fmt.Errorf("agent_id is required"))
+	}
+
+	path := fmt.Sprintf("/a2a/agents/%s/.well-known/agent-card.json", encodePath(agentID))
+	resp, err := h.get(ctx, path)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return &mcp.ToolResult{Data: string(resp)}, nil
+}
+
+func handleProxySendMessage(ctx context.Context, _ *grpcClient, h *httpClient, args map[string]any) (*mcp.ToolResult, error) {
+	agentID, _ := mcp.ArgStr(args, "agent_id")
+	message, _ := mcp.ArgStr(args, "message")
+	if agentID == "" {
+		return mcp.ErrResult(fmt.Errorf("agent_id is required"))
+	}
+	if message == "" {
+		return mcp.ErrResult(fmt.Errorf("message is required"))
+	}
+
+	msgID, _ := mcp.ArgStr(args, "message_id")
+	if msgID == "" {
+		msgID = genMessageID()
+	}
+	contextID, _ := mcp.ArgStr(args, "context_id")
+
+	msg := map[string]any{
+		"role":       "ROLE_USER",
+		"parts":      []map[string]any{{"text": message}},
+		"message_id": msgID,
+	}
+	if contextID != "" {
+		msg["context_id"] = contextID
+	}
+
+	payload := map[string]any{"message": msg}
+
+	path := fmt.Sprintf("/a2a/agents/%s/message:send", encodePath(agentID))
+	resp, err := h.post(ctx, path, payload)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return &mcp.ToolResult{Data: string(resp)}, nil
+}
+
+func handleProxyGetTask(ctx context.Context, _ *grpcClient, h *httpClient, args map[string]any) (*mcp.ToolResult, error) {
+	agentID, _ := mcp.ArgStr(args, "agent_id")
+	taskID, _ := mcp.ArgStr(args, "task_id")
+	if agentID == "" {
+		return mcp.ErrResult(fmt.Errorf("agent_id is required"))
+	}
+	if taskID == "" {
+		return mcp.ErrResult(fmt.Errorf("task_id is required"))
+	}
+
+	path := fmt.Sprintf("/a2a/agents/%s/tasks/%s", encodePath(agentID), encodePath(taskID))
+	resp, err := h.get(ctx, path)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return &mcp.ToolResult{Data: string(resp)}, nil
+}
+
+func handleProxyCancelTask(ctx context.Context, _ *grpcClient, h *httpClient, args map[string]any) (*mcp.ToolResult, error) {
+	agentID, _ := mcp.ArgStr(args, "agent_id")
+	taskID, _ := mcp.ArgStr(args, "task_id")
+	if agentID == "" {
+		return mcp.ErrResult(fmt.Errorf("agent_id is required"))
+	}
+	if taskID == "" {
+		return mcp.ErrResult(fmt.Errorf("task_id is required"))
+	}
+
+	path := fmt.Sprintf("/a2a/agents/%s/tasks/%s:cancel", encodePath(agentID), encodePath(taskID))
+	resp, err := h.post(ctx, path, map[string]any{})
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return &mcp.ToolResult{Data: string(resp)}, nil
+}
+
+func handleRouteMessage(ctx context.Context, _ *grpcClient, h *httpClient, args map[string]any) (*mcp.ToolResult, error) {
+	message, _ := mcp.ArgStr(args, "message")
+	tagsJSON, _ := mcp.ArgStr(args, "tags")
+	if message == "" {
+		return mcp.ErrResult(fmt.Errorf("message is required"))
+	}
+	if tagsJSON == "" {
+		return mcp.ErrResult(fmt.Errorf("tags is required"))
+	}
+
+	var tags any
+	if err := json.Unmarshal([]byte(tagsJSON), &tags); err != nil {
+		return mcp.ErrResult(fmt.Errorf("invalid tags JSON: %w", err))
+	}
+
+	msgID, _ := mcp.ArgStr(args, "message_id")
+	if msgID == "" {
+		msgID = genMessageID()
+	}
+	contextID, _ := mcp.ArgStr(args, "context_id")
+
+	msg := map[string]any{
+		"role":       "ROLE_USER",
+		"parts":      []map[string]any{{"text": message}},
+		"message_id": msgID,
+	}
+	if contextID != "" {
+		msg["context_id"] = contextID
+	}
+
+	payload := map[string]any{
+		"message": msg,
+		"routing": map[string]any{"tags": tags},
+	}
+
+	resp, err := h.post(ctx, "/a2a/route/message:send", payload)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return &mcp.ToolResult{Data: string(resp)}, nil
+}

--- a/integrations/agents/http.go
+++ b/integrations/agents/http.go
@@ -1,0 +1,124 @@
+package agents
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// httpClient handles HTTP/1.1 JSON requests to the A2A proxy endpoints.
+type httpClient struct {
+	baseURL string
+	token   string
+	client  *http.Client
+}
+
+func newHTTPClient(baseURL, token string) *httpClient {
+	return &httpClient{
+		baseURL: baseURL,
+		token:   token,
+		client: &http.Client{
+			Timeout: 60 * time.Second,
+		},
+	}
+}
+
+// get performs an HTTP GET and returns the response body as raw JSON.
+func (h *httpClient) get(ctx context.Context, path string) (json.RawMessage, error) {
+	reqURL := h.baseURL + path
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	h.setHeaders(req)
+
+	resp, err := h.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("A2A GET %s: %w", path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("A2A error (HTTP %d): %s", resp.StatusCode, truncate(string(body), 500))
+	}
+
+	// If the response body is empty, return an informative error rather than
+	// silently returning empty JSON. This surfaces daemon-side issues clearly.
+	if len(bytes.TrimSpace(body)) == 0 {
+		return nil, fmt.Errorf("A2A endpoint %s returned empty response (HTTP %d) — the ARP daemon may not be serving A2A endpoints on %s", path, resp.StatusCode, h.baseURL)
+	}
+
+	return json.RawMessage(body), nil
+}
+
+// post performs an HTTP POST with a JSON body and returns the response.
+func (h *httpClient) post(ctx context.Context, path string, payload any) (json.RawMessage, error) {
+	reqURL := h.baseURL + path
+
+	var bodyReader io.Reader
+	if payload != nil {
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return nil, fmt.Errorf("marshal request: %w", err)
+		}
+		bodyReader = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	h.setHeaders(req)
+
+	resp, err := h.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("A2A POST %s: %w", path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("A2A error (HTTP %d): %s", resp.StatusCode, truncate(string(body), 500))
+	}
+
+	if len(bytes.TrimSpace(body)) == 0 {
+		return nil, fmt.Errorf("A2A endpoint %s returned empty response (HTTP %d) — the ARP daemon may not be serving A2A endpoints on %s", path, resp.StatusCode, h.baseURL)
+	}
+
+	return json.RawMessage(body), nil
+}
+
+func (h *httpClient) setHeaders(req *http.Request) {
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	if h.token != "" {
+		req.Header.Set("Authorization", "Bearer "+h.token)
+	}
+}
+
+// encodePath percent-encodes a path segment for use in URLs.
+func encodePath(s string) string {
+	return url.PathEscape(s)
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "..."
+}

--- a/integrations/agents/tools.go
+++ b/integrations/agents/tools.go
@@ -1,0 +1,230 @@
+package agents
+
+import mcp "github.com/daltoniam/switchboard"
+
+var tools = []mcp.ToolDefinition{
+	// =========================================================================
+	// ProjectService — gRPC via h2c
+	// =========================================================================
+	{
+		Name:        "agents_project_list",
+		Description: "List all registered projects via gRPC ProjectService.ListProjects. Returns Project objects with name, repo, branch, and agent templates.",
+		Parameters:  map[string]string{},
+	},
+	{
+		Name:        "agents_project_register",
+		Description: "Register a new project via gRPC ProjectService.RegisterProject. A project defines a git repo and agent templates for spawning.",
+		Parameters: map[string]string{
+			"name":   "Unique project name",
+			"repo":   "Path or URL to the git repository",
+			"branch": "Default branch for new workspaces (default: main)",
+			"agents": `JSON array of AgentTemplate objects. Each has: name (required), command (required), port_env, capabilities (string array), a2a_card_config ({name, description, skills, input_modes, output_modes, streaming})`,
+		},
+		Required: []string{"name", "repo"},
+	},
+	{
+		Name:        "agents_project_unregister",
+		Description: "Unregister a project via gRPC ProjectService.UnregisterProject. Fails if active workspaces with running agents exist.",
+		Parameters: map[string]string{
+			"name": "Project name to unregister",
+		},
+		Required: []string{"name"},
+	},
+
+	// =========================================================================
+	// WorkspaceService — gRPC via h2c
+	// =========================================================================
+	{
+		Name:        "agents_workspace_create",
+		Description: "Create a new workspace via gRPC WorkspaceService.CreateWorkspace. Creates a git worktree and optionally auto-spawns agents.",
+		Parameters: map[string]string{
+			"name":        "Unique workspace name (used as worktree branch name)",
+			"project":     "Project to create workspace from (must be registered)",
+			"branch":      "Git branch override (defaults to project's default branch)",
+			"auto_agents": `JSON array of template names to auto-spawn (e.g. ["crush", "reviewer"])`,
+		},
+		Required: []string{"name", "project"},
+	},
+	{
+		Name:        "agents_workspace_list",
+		Description: "List workspaces via gRPC WorkspaceService.ListWorkspaces. Optionally filter by project or status.",
+		Parameters: map[string]string{
+			"project": "Filter by project name",
+			"status":  "Filter by status: active or inactive",
+		},
+	},
+	{
+		Name:        "agents_workspace_get",
+		Description: "Get workspace details via gRPC WorkspaceService.GetWorkspace. Returns agents, directory path, and creation time.",
+		Parameters: map[string]string{
+			"name": "Workspace name",
+		},
+		Required: []string{"name"},
+	},
+	{
+		Name:        "agents_workspace_destroy",
+		Description: "Destroy a workspace via gRPC WorkspaceService.DestroyWorkspace. Stops all agents, cancels working tasks, and optionally removes the worktree.",
+		Parameters: map[string]string{
+			"name":          "Workspace name to destroy",
+			"keep_worktree": "If true, preserve the git worktree directory on disk (default: false)",
+		},
+		Required: []string{"name"},
+	},
+
+	// =========================================================================
+	// AgentService — gRPC via h2c (lifecycle)
+	// =========================================================================
+	{
+		Name:        "agents_agent_spawn",
+		Description: "Spawn a new A2A agent via gRPC AgentService.SpawnAgent. Returns AgentInstance with id, port, direct_url, proxy_url, and status.",
+		Parameters: map[string]string{
+			"workspace":  "Workspace name to spawn the agent in",
+			"template":   "Agent template name from the project",
+			"name":       "Custom instance name (defaults to template name)",
+			"env":        "JSON object of additional environment variables",
+			"prompt":     "Initial prompt to send after agent reaches READY",
+			"scope":      `JSON Scope object: {"global": false, "projects": ["proj-a"]}`,
+			"permission": "Permission level: session, project, or admin",
+		},
+		Required: []string{"workspace", "template"},
+	},
+	{
+		Name:        "agents_agent_list",
+		Description: "List agent instances via gRPC AgentService.ListAgents. Optionally filter by workspace, status, or template.",
+		Parameters: map[string]string{
+			"workspace": "Filter by workspace name",
+			"status":    "Filter by status: starting, ready, busy, error, stopping, stopped",
+			"template":  "Filter by template name",
+		},
+	},
+	{
+		Name:        "agents_agent_status",
+		Description: "Get agent status via gRPC AgentService.GetAgentStatus. Returns AgentInstance with resolved A2A AgentCard.",
+		Parameters: map[string]string{
+			"agent_id": "Agent instance ID",
+		},
+		Required: []string{"agent_id"},
+	},
+	{
+		Name:        "agents_agent_stop",
+		Description: "Stop an agent via gRPC AgentService.StopAgent. Cancels working A2A tasks, sends SIGTERM, waits grace period, then SIGKILL.",
+		Parameters: map[string]string{
+			"agent_id":        "Agent instance ID to stop",
+			"grace_period_ms": "Milliseconds to wait after SIGTERM before SIGKILL (default: 5000)",
+		},
+		Required: []string{"agent_id"},
+	},
+	{
+		Name:        "agents_agent_restart",
+		Description: "Restart an agent via gRPC AgentService.RestartAgent. Stop + spawn with same config. proxy_url stays stable.",
+		Parameters: map[string]string{
+			"agent_id": "Agent instance ID to restart",
+		},
+		Required: []string{"agent_id"},
+	},
+
+	// =========================================================================
+	// AgentService — gRPC via h2c (messaging)
+	// =========================================================================
+	{
+		Name:        "agents_agent_message",
+		Description: "Send a message to an agent via gRPC AgentService.SendAgentMessage. When blocking=true (default), polls until the task completes. When blocking=false, returns the task immediately for async tracking via agents_agent_task_status.",
+		Parameters: map[string]string{
+			"agent_id":   "Agent instance ID",
+			"message":    "Text message to send",
+			"context_id": "A2A context_id for multi-turn conversations",
+			"blocking":   "If true (default), wait for response. If false, return immediately.",
+		},
+		Required: []string{"agent_id", "message"},
+	},
+	{
+		Name:        "agents_agent_task",
+		Description: "Create a task on an agent via gRPC AgentService.CreateAgentTask. Returns immediately with a Task for async tracking via agents_agent_task_status (never blocks on completion).",
+		Parameters: map[string]string{
+			"agent_id":   "Agent instance ID",
+			"message":    "Task description",
+			"context_id": "A2A context_id to continue a conversation",
+		},
+		Required: []string{"agent_id", "message"},
+	},
+	{
+		Name:        "agents_agent_task_status",
+		Description: "Get task status via gRPC AgentService.GetAgentTaskStatus. Returns Task with status, artifacts, and history.",
+		Parameters: map[string]string{
+			"agent_id":       "Agent instance ID",
+			"task_id":        "A2A task ID to check",
+			"history_length": "Maximum number of recent messages to include (default: 10)",
+		},
+		Required: []string{"agent_id", "task_id"},
+	},
+
+	// =========================================================================
+	// DiscoveryService — gRPC via h2c
+	// =========================================================================
+	{
+		Name:        "agents_discover",
+		Description: "Discover agents via gRPC DiscoveryService.DiscoverAgents. Returns enriched AgentCards. Supports local/network scope and capability filtering.",
+		Parameters: map[string]string{
+			"scope":      `Discovery scope: local (default) or network`,
+			"capability": `Filter by AgentSkill tag (e.g. "coding")`,
+			"urls":       `JSON array of base URLs to probe for AgentCards (network scope)`,
+		},
+	},
+
+	// =========================================================================
+	// A2A proxy — HTTP endpoints on separate port
+	// =========================================================================
+	{
+		Name:        "agents_proxy_list",
+		Description: "List all A2A AgentCards via the ARP HTTP proxy at /a2a/agents. Returns cards for READY/BUSY agents with metadata.arp fields.",
+		Parameters:  map[string]string{},
+	},
+	{
+		Name:        "agents_agent_card",
+		Description: "Get an enriched A2A AgentCard via the ARP HTTP proxy. Includes metadata.arp and supportedInterfaces pointing to the proxy.",
+		Parameters: map[string]string{
+			"agent_id": "Agent ID, name, or workspace/instance_name",
+		},
+		Required: []string{"agent_id"},
+	},
+	{
+		Name:        "agents_proxy_send_message",
+		Description: "Send an A2A message through the ARP HTTP proxy at /a2a/agents/{id}/message:send. Routes by agent ID, name, or workspace/name.",
+		Parameters: map[string]string{
+			"agent_id":   "Agent ID, name, or workspace/instance_name",
+			"message":    "Text message to send",
+			"context_id": "A2A context_id for multi-turn conversation",
+			"message_id": "Message ID (auto-generated if omitted)",
+		},
+		Required: []string{"agent_id", "message"},
+	},
+	{
+		Name:        "agents_proxy_get_task",
+		Description: "Get an A2A task via the ARP HTTP proxy.",
+		Parameters: map[string]string{
+			"agent_id": "Agent ID",
+			"task_id":  "A2A task ID",
+		},
+		Required: []string{"agent_id", "task_id"},
+	},
+	{
+		Name:        "agents_proxy_cancel_task",
+		Description: "Cancel an A2A task via the ARP HTTP proxy.",
+		Parameters: map[string]string{
+			"agent_id": "Agent ID",
+			"task_id":  "A2A task ID to cancel",
+		},
+		Required: []string{"agent_id", "task_id"},
+	},
+	{
+		Name:        "agents_route_message",
+		Description: "Route an A2A message by skill tags via the ARP HTTP proxy at /a2a/route/message:send. Finds best matching agent (prefers READY over BUSY).",
+		Parameters: map[string]string{
+			"message":    "Text message to send",
+			"tags":       `JSON array of skill tags to match (e.g. ["coding"])`,
+			"context_id": "A2A context_id for multi-turn conversation",
+			"message_id": "Message ID (auto-generated if omitted)",
+		},
+		Required: []string{"message", "tags"},
+	},
+}


### PR DESCRIPTION
## Summary

- Adds a native Go `agents` integration that replaces the WASM plugin to fix the empty `{}` response issue from A2A proxy tools
- The WASM plugin was using the gRPC port (9098) for HTTP REST calls that should go to the A2A HTTP port (9099), causing empty responses
- The native integration properly separates gRPC (h2c) and HTTP/1.1 transports with a configurable `a2a_url` credential that auto-derives from `base_url` (port+1)
- Empty responses now surface clear error messages instead of silently returning `{}`

## Changes

- `integrations/agents/` — New native integration with 22 tools (all tools from the WASM plugin):
  - **gRPC handlers**: project/workspace/agent lifecycle management via h2c
  - **HTTP handlers**: A2A proxy tools (`proxy_list`, `proxy_send_message`, `proxy_get_task`, `proxy_cancel_task`, `route_message`, `agent_card`)
  - Proper error handling: empty responses report the issue instead of returning `{}`
  - Auth token forwarded to both transport layers
- `cmd/server/main.go` — Register the native integration
- `config/config.go` — Add default config and env var mapping (`AGENTS_BASE_URL`, `AGENTS_A2A_URL`, `AGENTS_TOKEN`)

## Configuration

```json
{
  "agents": {
    "enabled": true,
    "credentials": {
      "base_url": "http://localhost:9098",
      "a2a_url": "http://localhost:9099",
      "token": ""
    }
  }
}
```

If `a2a_url` is omitted, it auto-derives from `base_url` by incrementing the port by 1.

## Test plan

- [x] All 17 new tests pass (proxy list, send message, get task, cancel task, route message, error handling, auth forwarding, path encoding)
- [x] Existing tests updated for new config entry counts (34→35 integrations, 24→25 env mappings)
- [x] Full test suite passes (`go test ./...`)
- [x] `go vet` clean
- [x] Binary builds successfully


💘 Generated with Crush