### PR TITLE
Fix postgres web UI: JSON tag round-trip and slow setup page load

### DIFF
--- a/web/templates/pages/postgres_setup.templ
+++ b/web/templates/pages/postgres_setup.templ
@@ -7,15 +7,15 @@ import (
 )
 
 type PostgresConnection struct {
-	Alias            string
-	ConnectionString string
-	Host             string
-	Port             string
-	User             string
-	Password         string
-	Database         string
-	SSLMode          string
-	ReadOnly         string
+	Alias            string `json:"alias"`
+	ConnectionString string `json:"connection_string"`
+	Host             string `json:"host"`
+	Port             string `json:"port"`
+	User             string `json:"user"`
+	Password         string `json:"password"`
+	Database         string `json:"database"`
+	SSLMode          string `json:"sslmode"`
+	ReadOnly         string `json:"read_only"`
 }
 
 type PostgresSetupData struct {

--- a/web/templates/pages/postgres_setup_templ.go
+++ b/web/templates/pages/postgres_setup_templ.go
@@ -15,15 +15,15 @@ import (
 )
 
 type PostgresConnection struct {
-	Alias            string
-	ConnectionString string
-	Host             string
-	Port             string
-	User             string
-	Password         string
-	Database         string
-	SSLMode          string
-	ReadOnly         string
+	Alias            string `json:"alias"`
+	ConnectionString string `json:"connection_string"`
+	Host             string `json:"host"`
+	Port             string `json:"port"`
+	User             string `json:"user"`
+	Password         string `json:"password"`
+	Database         string `json:"database"`
+	SSLMode          string `json:"sslmode"`
+	ReadOnly         string `json:"read_only"`
 }
 
 type PostgresSetupData struct {

--- a/web/web.go
+++ b/web/web.go
@@ -1156,13 +1156,17 @@ func (w *WebServer) handlePostgresSetup(rw http.ResponseWriter, r *http.Request)
 	ic, exists := w.services.Config.GetIntegration("postgres")
 	enabled := exists && ic.Enabled
 
+	// Avoid calling Configure() on every page load — with multi-postgres each
+	// invocation re-opens connections to all configured databases and pings them
+	// (5s timeout each), which can hang the setup page noticeably. The integration
+	// is already configured at startup; just probe the existing connection's health.
 	var healthy bool
 	if enabled {
 		integration, ok := w.services.Registry.Get("postgres")
 		if ok {
-			if err := integration.Configure(r.Context(), ic.Credentials); err == nil {
-				healthy = integration.Healthy(r.Context())
-			}
+			ctx, cancel := context.WithTimeout(r.Context(), 1*time.Second)
+			healthy = integration.Healthy(ctx)
+			cancel()
 		}
 	}
 

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	mcp "github.com/daltoniam/switchboard"
+	"github.com/daltoniam/switchboard/web/templates/pages"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -839,4 +840,65 @@ func TestUpdateCredentials(t *testing.T) {
 		assert.Equal(t, http.StatusInternalServerError, rr.Code)
 		assert.Contains(t, rr.Body.String(), "bad token")
 	})
+}
+
+// TestPostgresConnection_JSONRoundTrip verifies that the PostgresConnection
+// struct used by the postgres setup page can round-trip through JSON without
+// losing any field. The web UI serializes additional connections to JSON on
+// save and unmarshals them on the next page load — without snake_case JSON
+// tags, fields like connection_string and read_only would silently come back
+// blank, and the user would lose the connection data on the next save.
+func TestPostgresConnection_JSONRoundTrip(t *testing.T) {
+	original := pages.PostgresConnection{
+		Alias:            "analytics",
+		ConnectionString: "postgres://user:pass@host:5432/db",
+		Host:             "analytics.example.com",
+		Port:             "5432",
+		User:             "readonly",
+		Password:         "secret",
+		Database:         "analytics",
+		SSLMode:          "require",
+		ReadOnly:         "true",
+	}
+
+	// Round-trip as a slice — this matches how postgres_setup.templ JS gathers
+	// connections and how handlePostgresSetup unmarshals them.
+	encoded, err := json.Marshal([]pages.PostgresConnection{original})
+	require.NoError(t, err)
+
+	// JS produces snake_case keys; the encoded form must match that contract.
+	assert.Contains(t, string(encoded), `"connection_string"`)
+	assert.Contains(t, string(encoded), `"read_only"`)
+
+	var decoded []pages.PostgresConnection
+	require.NoError(t, json.Unmarshal(encoded, &decoded))
+	require.Len(t, decoded, 1)
+	assert.Equal(t, original, decoded[0])
+}
+
+// TestPostgresConnection_DecodesSnakeCase guards the specific failure mode
+// the latest PR 109 review caught: without JSON tags, snake_case keys from
+// the browser-side JSON do not bind to CamelCase struct fields and the
+// fields come back blank.
+func TestPostgresConnection_DecodesSnakeCase(t *testing.T) {
+	raw := `[{
+		"alias": "warehouse",
+		"connection_string": "postgres://x",
+		"host": "warehouse.example.com",
+		"port": "5432",
+		"user": "u",
+		"password": "p",
+		"database": "wh",
+		"sslmode": "require",
+		"read_only": "false"
+	}]`
+
+	var conns []pages.PostgresConnection
+	require.NoError(t, json.Unmarshal([]byte(raw), &conns))
+	require.Len(t, conns, 1)
+	assert.Equal(t, "warehouse", conns[0].Alias)
+	assert.Equal(t, "postgres://x", conns[0].ConnectionString)
+	assert.Equal(t, "warehouse.example.com", conns[0].Host)
+	assert.Equal(t, "false", conns[0].ReadOnly)
+	assert.Equal(t, "require", conns[0].SSLMode)
 }


### PR DESCRIPTION
## Summary

- Add snake_case JSON tags to `pages.PostgresConnection` so additional connections round-trip cleanly through the web UI. Addresses the latest review comment on #109 — without tags, snake_case payload fields like `connection_string` and `read_only` did not bind on reload, came back blank, and were effectively wiped on the next save (the JS gather skips empty inputs, so connections appeared to vanish after the second save).
- Stop calling `integration.Configure()` on every GET to `/integrations/postgres/setup`. With multi-postgres each call re-opens every configured database and pings them with a 5s timeout, which makes the setup page hang noticeably as more connections are added. The integration is already configured at startup; the page now only does a short-timeout `Healthy()` probe.
- Regenerate `postgres_setup_templ.go`.

## Changes

| Area | File | What |
|------|------|------|
| Web UI struct | `web/templates/pages/postgres_setup.templ` | Add `json:\"...\"` tags to all `PostgresConnection` fields |
| Generated | `web/templates/pages/postgres_setup_templ.go` | `templ generate` output |
| Web handler | `web/web.go` | Drop `Configure()` from `handlePostgresSetup`; bound `Healthy()` with a 1s timeout |
| Tests | `web/web_test.go` | `TestPostgresConnection_JSONRoundTrip`, `TestPostgresConnection_DecodesSnakeCase` |

## Test plan

- [x] `make ci` passes (build, vet, race tests, lint, gosec, govulncheck)
- [x] New unit tests cover the JSON round-trip and explicit snake-case decode case
- [ ] Manual: open the postgres setup page with 2+ additional connections, save, reload, and confirm fields are populated and the page loads instantly

🤖 Generated with Crush