### PR TITLE
fix(rwx): inject RWX_ACCESS_TOKEN into CLI subprocess env

### DIFF
--- a/integrations/rwx/logs.go
+++ b/integrations/rwx/logs.go
@@ -400,12 +400,12 @@ func grepLogs(ctx context.Context, r *rwx, args map[string]any) (*mcp.ToolResult
 func (r *rwx) runRWXCommand(args []string, timeoutMs int) (string, error) {
 	bin := r.cliPath
 	cmd := exec.Command(bin, args...) // #nosec G204 -- resolved binary path, args are controlled
-	cmd.Env = os.Environ()
+	cmd.Env = r.cmdEnv()
 	if timeoutMs > 0 {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutMs)*time.Millisecond)
 		defer cancel()
 		cmd = exec.CommandContext(ctx, bin, args...) // #nosec G204 -- resolved binary path, args are controlled
-		cmd.Env = os.Environ()
+		cmd.Env = r.cmdEnv()
 	}
 
 	var stdout, stderr bytes.Buffer

--- a/integrations/rwx/proxy.go
+++ b/integrations/rwx/proxy.go
@@ -63,8 +63,9 @@ func newProxyClient() *proxyClient {
 	}
 }
 
-func (p *proxyClient) start(rwxBin string) error {
-	cmd := exec.Command(rwxBin, "mcp", "serve")
+func (p *proxyClient) start(rwxBin string, env []string) error {
+	cmd := exec.Command(rwxBin, "mcp", "serve") // #nosec G204 -- resolved binary path
+	cmd.Env = env
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		return fmt.Errorf("stdin pipe: %w", err)

--- a/integrations/rwx/rwx.go
+++ b/integrations/rwx/rwx.go
@@ -107,11 +107,31 @@ func (r *rwx) Execute(ctx context.Context, toolName mcp.ToolName, args map[strin
 // Called from main after Configure. Non-fatal — tools still work via CLI/API.
 func (r *rwx) StartProxy() {
 	p := newProxyClient()
-	if err := p.start(r.cliPath); err != nil {
+	if err := p.start(r.cliPath, r.cmdEnv()); err != nil {
 		fmt.Printf("[rwx] proxy start failed (tools still available via CLI): %v\n", err)
 		return
 	}
 	r.proxy = p
+}
+
+// cmdEnv builds the environment for rwx CLI subprocesses, injecting
+// RWX_ACCESS_TOKEN from the configured credentials.
+//
+// The rwx CLI (v3.13+) authenticates via the RWX_ACCESS_TOKEN env var,
+// the --access-token flag, or a local credentials file written by
+// `rwx login`. Without one of these, every command fails with
+// "no access token configured" — even though the plugin holds the
+// token in r.accessToken from Configure().
+//
+// We inject the env var on every subprocess so the plugin Just Works
+// after the user pastes their token into the switchboard UI, with no
+// separate `rwx login` step required.
+func (r *rwx) cmdEnv() []string {
+	env := os.Environ()
+	if r.accessToken != "" {
+		env = append(env, "RWX_ACCESS_TOKEN="+r.accessToken)
+	}
+	return env
 }
 
 // StopProxy shuts down the MCP proxy subprocess.

--- a/integrations/rwx/rwx_test.go
+++ b/integrations/rwx/rwx_test.go
@@ -533,6 +533,49 @@ func TestRunRWXCommand_FailureWithStdoutReturnsStdout(t *testing.T) {
 	assert.Contains(t, out, "{\"partial\":true}")
 }
 
+// --- Access token env injection tests ---
+
+// The rwx CLI authenticates via the RWX_ACCESS_TOKEN env var (or --access-token
+// flag, or a credentials file from `rwx login`). The plugin holds the token in
+// r.accessToken from Configure() but must inject it into every CLI subprocess
+// or commands fail with "no access token configured" — see cmdEnv() in rwx.go.
+
+func TestCmdEnv_InjectsAccessToken(t *testing.T) {
+	r := &rwx{accessToken: "rwx_pat_test_token_123"}
+	env := r.cmdEnv()
+
+	var found bool
+	for _, e := range env {
+		if e == "RWX_ACCESS_TOKEN=rwx_pat_test_token_123" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "cmdEnv must include RWX_ACCESS_TOKEN=<token>")
+}
+
+func TestCmdEnv_SkipsWhenTokenEmpty(t *testing.T) {
+	r := &rwx{accessToken: ""}
+	env := r.cmdEnv()
+
+	for _, e := range env {
+		assert.NotEqual(t, "RWX_ACCESS_TOKEN=", e, "must not append an empty token entry")
+	}
+}
+
+func TestRunRWXCommand_PassesAccessTokenToSubprocess(t *testing.T) {
+	tmp := t.TempDir()
+	bin := filepath.Join(tmp, "rwx")
+	// Fake CLI: echoes the access token from its env. If the plugin doesn't
+	// inject it, this prints an empty string and the test fails.
+	require.NoError(t, os.WriteFile(bin, []byte("#!/bin/sh\necho \"$RWX_ACCESS_TOKEN\"\n"), 0o755))
+
+	r := &rwx{cliPath: bin, accessToken: "rwx_pat_subprocess_token"}
+	out, err := r.runRWXCommand(nil, 0)
+	require.NoError(t, err)
+	assert.Equal(t, "rwx_pat_subprocess_token\n", out)
+}
+
 // --- Dispatch handler tests ---
 
 func fakeBin(t *testing.T, script string) string {


### PR DESCRIPTION
The plugin holds the access token in r.accessToken from Configure() but never propagates it to the rwx CLI subprocesses. CLI-backed tools (logs, results, artifacts, mcp serve) fail with "no access token configured" even when the UI shows CONNECTED.

The rwx CLI v3.13+ authenticates via RWX_ACCESS_TOKEN, --access-token, or a credentials file from rwx login. Users who paste the token into switchboard's UI without running rwx login have no auth path.

Fix: new r.cmdEnv() appends RWX_ACCESS_TOKEN=<token> to subprocess env. Applied in runRWXCommand and proxyClient.start.