### PR TITLE
Self-heal stale Slack xoxc tokens at startup

### DIFF
--- a/integrations/slack/slack.go
+++ b/integrations/slack/slack.go
@@ -30,6 +30,9 @@ type slackIntegration struct {
 	clients map[string]*slack.Client // keyed by team_id
 	store   *tokenStore
 	stopBg  chan struct{}
+
+	// refreshWorkspace is overridable in tests; defaults to (*slackIntegration).tryRefreshWorkspace.
+	refreshWorkspace func(teamID string) bool
 }
 
 func New() mcp.Integration {
@@ -45,25 +48,40 @@ func (s *slackIntegration) Configure(ctx context.Context, creds mcp.Credentials)
 	s.mu.Unlock()
 
 	configToken := creds["token"]
+	// xoxc-* tokens are browser session tokens that rotate constantly. Even
+	// when bootstrapped from config, they must participate in the local
+	// refresh/file-persistence loop or they go stale within hours.
+	//   - token_source: "browser"            → explicitly a browser snapshot
+	//   - token has xoxc- prefix             → structurally a session token
+	// Genuine externally-managed tokens (xoxb-, xoxp-, OAuth) keep the old
+	// "config is authoritative" behavior so we never clobber them.
+	isBrowserConfig := configToken != "" &&
+		(creds[mcp.CredKeyTokenSource] == "browser" || strings.HasPrefix(configToken, "xoxc-"))
+
 	if configToken != "" {
 		teamID := creds["team_id"]
 		if teamID == "" {
 			teamID = "_config"
 		}
+		source := "config"
+		if isBrowserConfig {
+			source = "browser"
+		}
 		s.store.setWorkspace(&workspace{
 			TeamID: teamID,
 			Token:  configToken,
 			Cookie: creds["cookie"],
-			Source: "config",
+			Source: source,
 		})
 		if creds["team_id"] != "" {
 			s.store.setDefault(creds["team_id"])
 		}
 	}
 
-	// When a token was provided via config (e.g. OAuth in hosted environments),
-	// skip local file and Chrome extraction — the config token is authoritative.
-	if configToken == "" {
+	// When the config token is a rotating browser snapshot, also load the
+	// persisted file. The file may carry a fresher copy (background refresh
+	// writes there) and we want that to win.
+	if configToken == "" || isBrowserConfig {
 		s.store.loadFromFile()
 
 		if len(s.store.allWorkspaces()) == 0 {
@@ -89,9 +107,10 @@ func (s *slackIntegration) Configure(ctx context.Context, creds mcp.Credentials)
 		s.store.setDefault(tid)
 	}
 
-	// Only persist and run background refresh for locally-sourced tokens.
-	// Config-provided tokens are managed externally and don't need local refresh.
-	if configToken == "" {
+	// Persist + run background refresh for any non-OAuth-style token (file-
+	// loaded or browser-sourced from config). Only genuine externally-managed
+	// tokens skip this.
+	if configToken == "" || isBrowserConfig {
 		_ = s.store.saveToFile()
 
 		if s.stopBg != nil {
@@ -131,8 +150,11 @@ func (s *slackIntegration) resolveWorkspaceIdentities(ctx context.Context) {
 		}
 		resp, err := client.AuthTestContext(ctx)
 		if err != nil {
-			log.Printf("slack: auth test failed for workspace %s: %v", ws.TeamID, err)
-			continue
+			recovered, retryResp := s.tryRecoverAuth(ctx, ws, err)
+			if !recovered {
+				continue
+			}
+			resp = retryResp
 		}
 		if ws.TeamID == resp.TeamID {
 			if ws.TeamName == "" {
@@ -166,6 +188,50 @@ func (s *slackIntegration) resolveWorkspaceIdentities(ctx context.Context) {
 	}
 }
 
+// tryRecoverAuth attempts a one-shot self-refresh for a workspace whose
+// startup auth.test just failed. xoxc-* browser session tokens rotate
+// frequently and the fresh token usually sits in the browser's local storage;
+// config-provided and OAuth (xoxp-*) tokens are managed externally and must
+// never be clobbered by a local refresh. Returns (true, newResp) when the
+// post-refresh auth.test succeeds, (false, nil) otherwise (caller logs the
+// original error and gives up).
+func (s *slackIntegration) tryRecoverAuth(ctx context.Context, ws *workspace, origErr error) (bool, *slack.AuthTestResponse) {
+	if !s.canSelfRefresh(ws) {
+		log.Printf("slack: auth test failed for workspace %s: %v (skipping self-refresh: source=%s token=%s)", ws.TeamID, origErr, ws.Source, tokenPrefix(ws.Token))
+		return false, nil
+	}
+	log.Printf("slack: auth test failed for workspace %s: %v — attempting startup refresh", ws.TeamID, origErr)
+	if !s.refreshFn()(ws.TeamID) {
+		log.Printf("slack: startup refresh failed for workspace %s — manual re-extract may be required (open Slack in Chrome and re-extract via web UI)", ws.TeamID)
+		return false, nil
+	}
+	c := s.getClientForTeam(ws.TeamID)
+	if c == nil {
+		log.Printf("slack: startup refresh produced no client for workspace %s", ws.TeamID)
+		return false, nil
+	}
+	resp, err := c.AuthTestContext(ctx)
+	if err != nil {
+		log.Printf("slack: post-refresh auth test still failing for workspace %s: %v", ws.TeamID, err)
+		return false, nil
+	}
+	log.Printf("slack: auth recovered for workspace %s after startup refresh", ws.TeamID)
+	return true, resp
+}
+
+// tokenPrefix returns the leading non-secret portion of a Slack token for
+// log diagnostics. xoxc-/xoxp-/xoxb-/xoxd- prefixes are intentionally kept;
+// the secret body is replaced with ellipsis.
+func tokenPrefix(tok string) string {
+	if tok == "" {
+		return "<empty>"
+	}
+	if len(tok) <= 6 {
+		return tok
+	}
+	return tok[:6] + "…"
+}
+
 func (s *slackIntegration) getClientForTeam(teamID string) *slack.Client {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -173,6 +239,29 @@ func (s *slackIntegration) getClientForTeam(teamID string) *slack.Client {
 		teamID = s.store.defaultID()
 	}
 	return s.clients[teamID]
+}
+
+// canSelfRefresh reports whether the workspace's token may be safely replaced
+// by a locally-sourced (cookie/browser) refresh. Config-provided tokens are
+// managed externally; OAuth (xoxp-*) tokens do not rotate and a refresh path
+// for them does not exist.
+func (s *slackIntegration) canSelfRefresh(ws *workspace) bool {
+	if ws == nil || ws.Source == "config" {
+		return false
+	}
+	if strings.HasPrefix(ws.Token, "xoxp-") {
+		return false
+	}
+	return true
+}
+
+// refreshFn returns the workspace-refresh callback, defaulting to the real
+// browser/cookie path. Tests override s.refreshWorkspace for determinism.
+func (s *slackIntegration) refreshFn() func(teamID string) bool {
+	if s.refreshWorkspace != nil {
+		return s.refreshWorkspace
+	}
+	return s.tryRefreshWorkspace
 }
 
 func (s *slackIntegration) getClientForArgs(args map[string]any) (*slack.Client, error) {

--- a/integrations/slack/slack.go
+++ b/integrations/slack/slack.go
@@ -255,10 +255,10 @@ func (s *slackIntegration) canSelfRefresh(ws *workspace) bool {
 	if ws == nil || ws.Source == "config" {
 		return false
 	}
-	if strings.HasPrefix(ws.Token, "xoxp-") {
-		return false
-	}
-	return true
+	// Only xoxc-* browser session tokens rotate and have a local refresh
+	// path. xoxb-/xoxp-/xapp-/etc. are externally managed and must never
+	// be replaced by a browser extract, even when stored locally.
+	return strings.HasPrefix(ws.Token, "xoxc-")
 }
 
 // refreshFn returns the workspace-refresh callback, defaulting to the real

--- a/integrations/slack/slack.go
+++ b/integrations/slack/slack.go
@@ -325,11 +325,12 @@ func (s *slackIntegration) backgroundRefresh() {
 
 func (s *slackIntegration) tryRefresh() bool {
 	allOk := true
+	refresh := s.refreshFn()
 	for _, ws := range s.store.allWorkspaces() {
-		if strings.HasPrefix(ws.Token, "xoxp-") {
+		if !s.canSelfRefresh(ws) {
 			continue
 		}
-		if !s.tryRefreshWorkspace(ws.TeamID) {
+		if !refresh(ws.TeamID) {
 			allOk = false
 		}
 	}

--- a/integrations/slack/slack.go
+++ b/integrations/slack/slack.go
@@ -205,6 +205,10 @@ func (s *slackIntegration) tryRecoverAuth(ctx context.Context, ws *workspace, or
 		log.Printf("slack: startup refresh failed for workspace %s — manual re-extract may be required (open Slack in Chrome and re-extract via web UI)", ws.TeamID)
 		return false, nil
 	}
+	// Defensive: tryRefreshWorkspace's success path always calls
+	// buildClientForWorkspace (see tryRefreshWorkspace + tryRefreshViaCookieForTeam),
+	// so this branch is unreachable under the current implementation. Kept to
+	// avoid a startup-goroutine panic if that invariant ever regresses.
 	c := s.getClientForTeam(ws.TeamID)
 	if c == nil {
 		log.Printf("slack: startup refresh produced no client for workspace %s", ws.TeamID)
@@ -220,16 +224,18 @@ func (s *slackIntegration) tryRecoverAuth(ctx context.Context, ws *workspace, or
 }
 
 // tokenPrefix returns the leading non-secret portion of a Slack token for
-// log diagnostics. xoxc-/xoxp-/xoxb-/xoxd- prefixes are intentionally kept;
-// the secret body is replaced with ellipsis.
+// log diagnostics. Slack token type prefixes ("xoxc-", "xoxp-", "xoxb-",
+// "xoxd-") are 5 bytes; anything past that is the secret body and is
+// replaced with an ellipsis.
 func tokenPrefix(tok string) string {
+	const prefixLen = 5 // len("xoxc-")
 	if tok == "" {
 		return "<empty>"
 	}
-	if len(tok) <= 6 {
+	if len(tok) <= prefixLen {
 		return tok
 	}
-	return tok[:6] + "…"
+	return tok[:prefixLen] + "…"
 }
 
 func (s *slackIntegration) getClientForTeam(teamID string) *slack.Client {

--- a/integrations/slack/slack_test.go
+++ b/integrations/slack/slack_test.go
@@ -515,6 +515,31 @@ func TestErrResult_NonRetryableProducesToolResult(t *testing.T) {
 
 // --- canSelfRefresh policy ---
 
+func TestTokenPrefix(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", "<empty>"},
+		{"short xoxc-", "xoxc-", "xoxc-"},
+		{"xoxc with body", "xoxc-225638936291-secret-stuff", "xoxc-…"},
+		{"xoxp with body", "xoxp-abc-def", "xoxp-…"},
+		{"xoxd cookie", "xoxd-encryptedblob", "xoxd-…"},
+		{"only prefix length", "xoxb-", "xoxb-"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tokenPrefix(tc.in)
+			assert.Equal(t, tc.want, got)
+			// Stronger guarantee: the secret body never leaks.
+			if len(tc.in) > 5 {
+				assert.NotContains(t, got, tc.in[5:], "tokenPrefix leaked secret body")
+			}
+		})
+	}
+}
+
 func TestCanSelfRefresh(t *testing.T) {
 	s := &slackIntegration{}
 	cases := []struct {

--- a/integrations/slack/slack_test.go
+++ b/integrations/slack/slack_test.go
@@ -1,11 +1,15 @@
 package slack
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -401,9 +405,239 @@ func TestConfigure_SwitchToConfigTokenStopsBackgroundRefresh(t *testing.T) {
 	assert.Nil(t, s.stopBg)
 }
 
+// --- Browser-snapshot config tokens (xoxc-* with token_source=browser) ---
+// These rotate constantly and must participate in the local refresh loop,
+// even when bootstrapped via config.
+
+func TestConfigure_BrowserConfigTokenMarksSourceBrowser(t *testing.T) {
+	// Point the file store somewhere empty so loadFromFile is a no-op.
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	s := &slackIntegration{}
+	s.Configure(t.Context(), mcp.Credentials{
+		"token":                "xoxc-rotating-session-token",
+		"team_id":              "T_BROWSER",
+		mcp.CredKeyTokenSource: "browser",
+	})
+
+	ws := s.store.getWorkspace("T_BROWSER")
+	require.NotNil(t, ws)
+	assert.Equal(t, "browser", ws.Source, "browser-source xoxc-* config token should not be marked source=config")
+	assert.NotNil(t, s.stopBg, "background refresh should run for browser-snapshot tokens")
+
+	// And canSelfRefresh should allow it.
+	assert.True(t, s.canSelfRefresh(ws))
+}
+
+func TestConfigure_XoxcConfigTokenWithoutSourceFlagIsStillBrowser(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	s := &slackIntegration{}
+	// xoxc- prefix alone is structurally a browser session token; treat it
+	// as such even if the token_source flag was lost.
+	s.Configure(t.Context(), mcp.Credentials{
+		"token":   "xoxc-rotating-session-token",
+		"team_id": "T_XOXC",
+	})
+
+	ws := s.store.getWorkspace("T_XOXC")
+	require.NotNil(t, ws)
+	assert.Equal(t, "browser", ws.Source)
+	assert.NotNil(t, s.stopBg)
+}
+
+func TestConfigure_FileTokenWinsOverConfigForSameTeamID(t *testing.T) {
+	// Persisted file carries the fresher xoxc-* token; config token is the
+	// stale bootstrap copy. After Configure(), the file's token must win.
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	fp := filepath.Join(tmp, ".slack-mcp-tokens.json")
+	fileJSON := `{
+	  "version": 2,
+	  "default_team_id": "T_DUP",
+	  "workspaces": [
+	    {
+	      "team_id": "T_DUP",
+	      "team_name": "Fresh Workspace",
+	      "token": "xoxc-FRESH-from-file",
+	      "cookie": "xoxd-fresh",
+	      "source": "chrome",
+	      "updated_at": "` + time.Now().UTC().Format(time.RFC3339) + `"
+	    }
+	  ]
+	}`
+	require.NoError(t, os.WriteFile(fp, []byte(fileJSON), 0600))
+
+	s := &slackIntegration{}
+	s.Configure(t.Context(), mcp.Credentials{
+		"token":                "xoxc-STALE-from-config",
+		"team_id":              "T_DUP",
+		mcp.CredKeyTokenSource: "browser",
+	})
+
+	ws := s.store.getWorkspace("T_DUP")
+	require.NotNil(t, ws)
+	assert.Equal(t, "xoxc-FRESH-from-file", ws.Token, "fresher file token should overwrite stale config token")
+}
+
+func TestConfigure_OAuthConfigTokenStillSkipsFile(t *testing.T) {
+	// xoxb-/xoxp- tokens are externally managed and must NOT be replaced
+	// by file-loaded entries — keep the "config is authoritative" path.
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	fp := filepath.Join(tmp, ".slack-mcp-tokens.json")
+	fileJSON := `{"version":2,"workspaces":[{"team_id":"T_OAUTH","token":"xoxc-from-file","source":"chrome","updated_at":"` + time.Now().UTC().Format(time.RFC3339) + `"}]}`
+	require.NoError(t, os.WriteFile(fp, []byte(fileJSON), 0600))
+
+	s := &slackIntegration{}
+	s.Configure(t.Context(), mcp.Credentials{
+		"token":   "xoxb-bot-from-config",
+		"team_id": "T_OAUTH",
+	})
+
+	ws := s.store.getWorkspace("T_OAUTH")
+	require.NotNil(t, ws)
+	assert.Equal(t, "xoxb-bot-from-config", ws.Token)
+	assert.Equal(t, "config", ws.Source)
+	assert.Nil(t, s.stopBg, "no background refresh for OAuth/bot config tokens")
+}
+
 func TestErrResult_NonRetryableProducesToolResult(t *testing.T) {
 	result, err := mcp.ErrResult(fmt.Errorf("no workspace"))
 	require.NoError(t, err)
 	assert.True(t, result.IsError)
 	assert.Equal(t, "no workspace", result.Data)
+}
+
+// --- canSelfRefresh policy ---
+
+func TestCanSelfRefresh(t *testing.T) {
+	s := &slackIntegration{}
+	cases := []struct {
+		name string
+		ws   *workspace
+		want bool
+	}{
+		{"nil workspace", nil, false},
+		{"config source", &workspace{Token: "xoxb-1", Source: "config"}, false},
+		{"OAuth user token", &workspace{Token: "xoxp-1", Source: "chrome"}, false},
+		{"browser session token", &workspace{Token: "xoxc-1", Source: "chrome"}, true},
+		{"slack desktop source", &workspace{Token: "xoxc-1", Source: "slack"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, s.canSelfRefresh(tc.ws))
+		})
+	}
+}
+
+// --- resolveWorkspaceIdentities self-healing ---
+
+// newAuthTestServer returns an httptest server that fails the first N
+// auth.test calls with invalid_auth, then succeeds with the given team_id.
+func newAuthTestServer(t *testing.T, teamID string, failFirstN int32) *httptest.Server {
+	t.Helper()
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if calls.Add(1) <= failFirstN {
+			_, _ = w.Write([]byte(`{"ok":false,"error":"invalid_auth"}`))
+			return
+		}
+		_, _ = fmt.Fprintf(w, `{"ok":true,"team":"Test","team_id":%q,"user":"u","user_id":"U1","url":"https://test.slack.com/"}`, teamID)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func newClientForAPI(apiURL string) *slack.Client {
+	// slack-go's OptionAPIURL expects a trailing slash.
+	u := apiURL
+	if u[len(u)-1] != '/' {
+		u += "/"
+	}
+	if _, err := url.Parse(u); err != nil {
+		panic(err)
+	}
+	return slack.New("xoxc-stale", slack.OptionAPIURL(u))
+}
+
+func TestResolveWorkspaceIdentities_RecoversAfterRefresh(t *testing.T) {
+	teamID := "T6MJSTJ8K"
+	srv := newAuthTestServer(t, teamID, 1) // first call fails, second succeeds
+
+	s := &slackIntegration{
+		clients: map[string]*slack.Client{teamID: newClientForAPI(srv.URL)},
+		store:   &tokenStore{workspaces: map[string]*workspace{teamID: {TeamID: teamID, Token: "xoxc-stale", Source: "chrome"}}},
+	}
+
+	var refreshCalls atomic.Int32
+	s.refreshWorkspace = func(id string) bool {
+		assert.Equal(t, teamID, id)
+		refreshCalls.Add(1)
+		// Simulate a successful refresh by replacing the client with a fresh
+		// one that points at the same test server (which will now succeed).
+		s.mu.Lock()
+		s.clients[id] = newClientForAPI(srv.URL)
+		s.mu.Unlock()
+		return true
+	}
+
+	s.resolveWorkspaceIdentities(context.Background())
+
+	assert.Equal(t, int32(1), refreshCalls.Load(), "refresh should be attempted exactly once")
+	ws := s.store.getWorkspace(teamID)
+	require.NotNil(t, ws)
+	assert.Equal(t, "Test", ws.TeamName, "team name should be filled in from successful auth.test")
+}
+
+func TestResolveWorkspaceIdentities_GivesUpWhenRefreshFails(t *testing.T) {
+	teamID := "T1"
+	srv := newAuthTestServer(t, teamID, 99) // always fails
+
+	s := &slackIntegration{
+		clients: map[string]*slack.Client{teamID: newClientForAPI(srv.URL)},
+		store:   &tokenStore{workspaces: map[string]*workspace{teamID: {TeamID: teamID, Token: "xoxc-stale", Source: "chrome"}}},
+	}
+	s.refreshWorkspace = func(string) bool { return false }
+
+	// Should not panic; workspace should remain present with no team name.
+	s.resolveWorkspaceIdentities(context.Background())
+	ws := s.store.getWorkspace(teamID)
+	require.NotNil(t, ws)
+	assert.Empty(t, ws.TeamName)
+}
+
+func TestResolveWorkspaceIdentities_SkipsRefreshForConfigToken(t *testing.T) {
+	teamID := "T_CFG"
+	srv := newAuthTestServer(t, teamID, 99) // always fails
+
+	s := &slackIntegration{
+		clients: map[string]*slack.Client{teamID: newClientForAPI(srv.URL)},
+		store:   &tokenStore{workspaces: map[string]*workspace{teamID: {TeamID: teamID, Token: "xoxb-cfg", Source: "config"}}},
+	}
+	var called atomic.Bool
+	s.refreshWorkspace = func(string) bool { called.Store(true); return true }
+
+	s.resolveWorkspaceIdentities(context.Background())
+	assert.False(t, called.Load(), "config-sourced tokens must not trigger local refresh")
+}
+
+func TestResolveWorkspaceIdentities_SkipsRefreshForOAuthToken(t *testing.T) {
+	teamID := "T_OAUTH"
+	srv := newAuthTestServer(t, teamID, 99)
+
+	s := &slackIntegration{
+		clients: map[string]*slack.Client{teamID: newClientForAPI(srv.URL)},
+		store:   &tokenStore{workspaces: map[string]*workspace{teamID: {TeamID: teamID, Token: "xoxp-user", Source: "chrome"}}},
+	}
+	var called atomic.Bool
+	s.refreshWorkspace = func(string) bool { called.Store(true); return true }
+
+	s.resolveWorkspaceIdentities(context.Background())
+	assert.False(t, called.Load(), "OAuth user tokens must not trigger local refresh")
 }

--- a/integrations/slack/slack_test.go
+++ b/integrations/slack/slack_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -569,6 +570,37 @@ func TestCanSelfRefresh(t *testing.T) {
 }
 
 // --- resolveWorkspaceIdentities self-healing ---
+
+// TestTryRefresh_OnlyAttemptsRefreshableTokens locks in that the background
+// refresh loop delegates its skip policy to canSelfRefresh, so non-rotating
+// token types (xoxb-, xoxp-, xapp-, config-sourced) are never sent through
+// the browser/cookie extraction path even if they end up sharing a store
+// with xoxc-* workspaces.
+func TestTryRefresh_OnlyAttemptsRefreshableTokens(t *testing.T) {
+	store := &tokenStore{workspaces: map[string]*workspace{
+		"T_XOXC":   {TeamID: "T_XOXC", Token: "xoxc-rotating", Source: "browser"},
+		"T_XOXB":   {TeamID: "T_XOXB", Token: "xoxb-bot", Source: "chrome"},
+		"T_XOXP":   {TeamID: "T_XOXP", Token: "xoxp-user", Source: "chrome"},
+		"T_XAPP":   {TeamID: "T_XAPP", Token: "xapp-app", Source: "chrome"},
+		"T_CONFIG": {TeamID: "T_CONFIG", Token: "xoxc-cfg", Source: "config"},
+	}}
+
+	var attempted []string
+	var mu sync.Mutex
+	s := &slackIntegration{store: store}
+	s.refreshWorkspace = func(id string) bool {
+		mu.Lock()
+		attempted = append(attempted, id)
+		mu.Unlock()
+		return true
+	}
+
+	s.tryRefresh()
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []string{"T_XOXC"}, attempted, "only xoxc-* with non-config source should be refreshed")
+}
 
 // newAuthTestServer returns an httptest server that fails the first N
 // auth.test calls with invalid_auth, then succeeds with the given team_id.

--- a/integrations/slack/slack_test.go
+++ b/integrations/slack/slack_test.go
@@ -424,7 +424,8 @@ func TestConfigure_BrowserConfigTokenMarksSourceBrowser(t *testing.T) {
 	ws := s.store.getWorkspace("T_BROWSER")
 	require.NotNil(t, ws)
 	assert.Equal(t, "browser", ws.Source, "browser-source xoxc-* config token should not be marked source=config")
-	assert.NotNil(t, s.stopBg, "background refresh should run for browser-snapshot tokens")
+	require.NotNil(t, s.stopBg, "background refresh should run for browser-snapshot tokens")
+	t.Cleanup(func() { close(s.stopBg) })
 
 	// And canSelfRefresh should allow it.
 	assert.True(t, s.canSelfRefresh(ws))
@@ -445,7 +446,8 @@ func TestConfigure_XoxcConfigTokenWithoutSourceFlagIsStillBrowser(t *testing.T) 
 	ws := s.store.getWorkspace("T_XOXC")
 	require.NotNil(t, ws)
 	assert.Equal(t, "browser", ws.Source)
-	assert.NotNil(t, s.stopBg)
+	require.NotNil(t, s.stopBg)
+	t.Cleanup(func() { close(s.stopBg) })
 }
 
 func TestConfigure_FileTokenWinsOverConfigForSameTeamID(t *testing.T) {
@@ -481,6 +483,9 @@ func TestConfigure_FileTokenWinsOverConfigForSameTeamID(t *testing.T) {
 	ws := s.store.getWorkspace("T_DUP")
 	require.NotNil(t, ws)
 	assert.Equal(t, "xoxc-FRESH-from-file", ws.Token, "fresher file token should overwrite stale config token")
+	if s.stopBg != nil {
+		t.Cleanup(func() { close(s.stopBg) })
+	}
 }
 
 func TestConfigure_OAuthConfigTokenStillSkipsFile(t *testing.T) {
@@ -550,6 +555,9 @@ func TestCanSelfRefresh(t *testing.T) {
 		{"nil workspace", nil, false},
 		{"config source", &workspace{Token: "xoxb-1", Source: "config"}, false},
 		{"OAuth user token", &workspace{Token: "xoxp-1", Source: "chrome"}, false},
+		{"bot token with non-config source", &workspace{Token: "xoxb-1", Source: "chrome"}, false},
+		{"app-level token", &workspace{Token: "xapp-1", Source: "chrome"}, false},
+		{"empty token", &workspace{Token: "", Source: "chrome"}, false},
 		{"browser session token", &workspace{Token: "xoxc-1", Source: "chrome"}, true},
 		{"slack desktop source", &workspace{Token: "xoxc-1", Source: "slack"}, true},
 	}


### PR DESCRIPTION
## Summary

- `xoxc-*` Slack browser session tokens rotate constantly. Two startup-time failure modes were leaving workspaces dead until a manual re-extract from the web UI: (a) `resolveWorkspaceIdentities` logged `auth test failed for workspace …: invalid_auth` and moved on without attempting recovery, and (b) `Configure` treated *any* config-supplied token as authoritative, skipping both `loadFromFile()` and the background refresh — which is correct for OAuth/bot tokens but wrong for `xoxc-*` browser snapshots whose fresher copy is sitting in `~/.slack-mcp-tokens.json`.
- This PR makes startup self-healing: a one-shot cookie/browser refresh + retry on initial auth.test failure, and a new "browser-snapshot config token" path (detected via `token_source=browser` or `xoxc-` prefix) that loads the persisted file, lets its fresher token win, and enables the normal background refresh loop. Genuine externally-managed `xoxp-`/`xoxb-` tokens keep the existing "config is authoritative, no local refresh" behavior so they're never clobbered.

## Test plan

- [x] `go test -race ./integrations/slack/` — 9 new tests added (5 self-heal paths + 4 Configure paths); all pass
- [x] `go tool golangci-lint run ./integrations/slack/` — 0 issues
- [x] `go vet ./...` — clean
- [x] `make build` — succeeds
- [x] Verified end-to-end on a real workspace whose persisted `xoxc-` token had gone stale: restarting switchboard now logs `attempting startup refresh` → `tokens refreshed from chrome` → `auth recovered for workspace T… after startup refresh` instead of the previous dead-until-manual-re-extract failure

💘 Generated with Crush

Assisted-by: Claude Sonnet 4.5 via Crush <crush@charm.land>