### PR TITLE
Fix Jira/Confluence list and nested-list formatting

### DIFF
--- a/integrations/jira/markdown.go
+++ b/integrations/jira/markdown.go
@@ -202,7 +202,9 @@ func renderADFNodes(sb *strings.Builder, nodes []any, listPrefix string) {
 				sb.WriteString(listPrefix + "- ")
 				renderADFListItem(sb, li, listPrefix)
 			}
-			sb.WriteString("\n")
+			if listPrefix == "" {
+				sb.WriteString("\n")
+			}
 
 		case "orderedList":
 			for idx, item := range content {
@@ -213,7 +215,9 @@ func renderADFNodes(sb *strings.Builder, nodes []any, listPrefix string) {
 				fmt.Fprintf(sb, "%s%d. ", listPrefix, idx+1)
 				renderADFListItem(sb, li, listPrefix)
 			}
-			sb.WriteString("\n")
+			if listPrefix == "" {
+				sb.WriteString("\n")
+			}
 
 		case "codeBlock":
 			lang, _ := adfAttrStr(n, "language")

--- a/integrations/jira/markdown_test.go
+++ b/integrations/jira/markdown_test.go
@@ -125,6 +125,26 @@ func TestADFToMarkdown(t *testing.T) {
 			want: "1. First\n2. Second\n\n",
 		},
 		{
+			name: "nested bullet list",
+			adf: map[string]any{"type": "doc", "content": []any{
+				map[string]any{"type": "bulletList", "content": []any{
+					map[string]any{"type": "listItem", "content": []any{
+						map[string]any{"type": "paragraph", "content": []any{
+							map[string]any{"type": "text", "text": "Parent"},
+						}},
+						map[string]any{"type": "bulletList", "content": []any{
+							map[string]any{"type": "listItem", "content": []any{
+								map[string]any{"type": "paragraph", "content": []any{
+									map[string]any{"type": "text", "text": "Child"},
+								}},
+							}},
+						}},
+					}},
+				}},
+			}},
+			want: "- Parent\n  - Child\n\n",
+		},
+		{
 			name: "code block with language",
 			adf: map[string]any{"type": "doc", "content": []any{
 				map[string]any{"type": "codeBlock", "attrs": map[string]any{"language": "go"}, "content": []any{

--- a/markdown/html.go
+++ b/markdown/html.go
@@ -166,18 +166,23 @@ func renderList(sb *strings.Builder, n *html.Node, depth int, ordered bool) {
 			sb.WriteString(indent + "- ")
 		}
 
-		endsWithNestedList := false
+		// First pass: collect inline (non-list) children.
+		// Confluence storage format wraps <li> content in <p> tags, which emit
+		// "\n\n". Buffering and trimming here normalises that to a single "\n".
+		var inlineBuf strings.Builder
 		for gc := c.FirstChild; gc != nil; gc = gc.NextSibling {
 			if gc.Type == html.ElementNode && (gc.DataAtom == atom.Ul || gc.DataAtom == atom.Ol) {
-				sb.WriteString("\n")
-				renderNode(sb, gc, depth+1, false)
-				endsWithNestedList = gc.NextSibling == nil
-			} else {
-				renderNode(sb, gc, depth, false)
+				continue
 			}
+			renderNode(&inlineBuf, gc, depth, false)
 		}
-		if !endsWithNestedList {
-			sb.WriteString("\n")
+		sb.WriteString(strings.TrimRight(inlineBuf.String(), " \t\n") + "\n")
+
+		// Second pass: render nested lists beneath the item line.
+		for gc := c.FirstChild; gc != nil; gc = gc.NextSibling {
+			if gc.Type == html.ElementNode && (gc.DataAtom == atom.Ul || gc.DataAtom == atom.Ol) {
+				renderNode(sb, gc, depth+1, false)
+			}
 		}
 	}
 }

--- a/markdown/html_test.go
+++ b/markdown/html_test.go
@@ -42,6 +42,24 @@ func TestFromHTML(t *testing.T) {
 			want:  "- Top\n  - Nested\n\n",
 		},
 		{
+			// Confluence storage format wraps <li> content in <p> tags.
+			name:  "list with p-wrapped items (Confluence style)",
+			input: "<ul><li><p>First</p></li><li><p>Second</p></li></ul>",
+			want:  "- First\n- Second\n\n",
+		},
+		{
+			// Ordered list with Confluence-style <p> wrapping.
+			name:  "ordered list with p-wrapped items (Confluence style)",
+			input: "<ol><li><p>Alpha</p></li><li><p>Beta</p></li></ol>",
+			want:  "1. Alpha\n2. Beta\n\n",
+		},
+		{
+			// Nested list where outer item uses <p> wrapping.
+			name:  "nested list with p-wrapped parent (Confluence style)",
+			input: "<ul><li><p>Top</p><ul><li>Nested</li></ul></li></ul>",
+			want:  "- Top\n  - Nested\n\n",
+		},
+		{
 			name:  "pre code block",
 			input: `<pre><code>fmt.Println("hello")</code></pre>`,
 			want:  "```\nfmt.Println(\"hello\")\n```\n\n",


### PR DESCRIPTION
## Summary

- **Confluence lists broken**: The HTML renderer (`markdown/html.go`) passed `<li>` children directly to `renderNode`, so `<p>` elements inside list items emitted `\n\n`, producing `- text\n\n\n` per item. Confluence storage format wraps all list-item content in `<p>` tags, so this affected essentially every Confluence list. Fixed by buffering inline children and `TrimRight`-trimming trailing whitespace before writing each item with a single `\n`.
- **Jira ADF nested lists**: `renderADFNodes` always appended a trailing `\n` after bullet/ordered lists regardless of nesting depth, creating an extra blank line after nested lists. Fixed to only emit the trailing blank-line separator when at top level (`listPrefix == ""`).

## Test plan

- [ ] `make ci` passes (all tests green, no lint/vet/security findings)
- [ ] New `TestFromHTML` cases cover `<p>`-wrapped `<li>` items for both `<ul>` and `<ol>`, and nested lists with `<p>`-wrapped parent items
- [ ] New `TestADFToMarkdown` case covers nested bullet lists without extra trailing blank line

🤖 Generated with [Claude Code](https://claude.com/claude-code)