### PR TITLE
Add Stripe integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ Any integration with credentials provided via env vars will auto-enable without 
 | Readarr | `api_key` | `READARR_API_KEY` |
 | Readarr | `base_url` | `READARR_URL` |
 | DigitalOcean | `api_token` | `DIGITALOCEAN_TOKEN` |
+| Stripe | `api_key` | `STRIPE_API_KEY` |
+| Stripe | `account` | `STRIPE_ACCOUNT` (optional — `Stripe-Account` header for Connect) |
 
 ### OAuth Setup
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Any integration with credentials provided via env vars will auto-enable without 
 | DigitalOcean | `api_token` | `DIGITALOCEAN_TOKEN` |
 | Stripe | `api_key` | `STRIPE_API_KEY` |
 | Stripe | `account` | `STRIPE_ACCOUNT` (optional — `Stripe-Account` header for Connect) |
+| Stripe | `base_url` | `STRIPE_BASE_URL` (optional — override API endpoint, e.g. stripe-mock) |
 
 ### OAuth Setup
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -45,6 +45,7 @@ import (
 	signozInt "github.com/daltoniam/switchboard/integrations/signoz"
 	slackInt "github.com/daltoniam/switchboard/integrations/slack"
 	snowflakeInt "github.com/daltoniam/switchboard/integrations/snowflake"
+	"github.com/daltoniam/switchboard/integrations/stripe"
 	"github.com/daltoniam/switchboard/integrations/suno"
 	switchboardInt "github.com/daltoniam/switchboard/integrations/switchboard"
 	webfetchInt "github.com/daltoniam/switchboard/integrations/webfetch"
@@ -218,6 +219,7 @@ func runServer(stdioMode bool, port int, discoverAll bool) {
 		pganalyze.New(),
 		rwx.New(),
 		ynab.New(),
+		stripe.New(),
 		amazonIntegration,
 		gmailIntegration,
 		jira.New(),

--- a/config/config.go
+++ b/config/config.go
@@ -140,8 +140,9 @@ var envMapping = map[string]map[string]string{
 		"token":    "AGENTS_TOKEN",
 	},
 	"stripe": {
-		"api_key": "STRIPE_API_KEY",
-		"account": "STRIPE_ACCOUNT",
+		"api_key":  "STRIPE_API_KEY",
+		"account":  "STRIPE_ACCOUNT",
+		"base_url": "STRIPE_BASE_URL",
 	},
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -139,6 +139,10 @@ var envMapping = map[string]map[string]string{
 		"a2a_url":  "AGENTS_A2A_URL",
 		"token":    "AGENTS_TOKEN",
 	},
+	"stripe": {
+		"api_key": "STRIPE_API_KEY",
+		"account": "STRIPE_ACCOUNT",
+	},
 }
 
 // EnvMapping returns the env var mapping table. Useful for documentation and debugging.
@@ -246,6 +250,10 @@ func defaultConfig() *mcp.Config {
 			"ynab": {
 				Enabled:     false,
 				Credentials: mcp.Credentials{"api_key": ""},
+			},
+			"stripe": {
+				Enabled:     false,
+				Credentials: mcp.Credentials{"api_key": "", "account": "", "base_url": ""},
 			},
 			"jira": {
 				Enabled:     false,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -33,7 +33,7 @@ func TestLoad_CreatesDefaultWhenMissing(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Len(t, m.cfg.Integrations, 36)
-	for _, name := range []string{"github", "datadog", "linear", "sentry", "slack", "metabase", "aws", "posthog", "postgres", "clickhouse", "elasticsearch", "pganalyze", "rwx", "gmail", "notion", "ollama", "ynab", "gcp", "suno", "amazon", "jira", "confluence", "salesforce", "cloudflare", "digitalocean", "fly", "snowflake", "acp", "web", "botidentity", "x", "signoz", "nomad", "switchboard"} {
+	for _, name := range []string{"github", "datadog", "linear", "sentry", "slack", "metabase", "aws", "posthog", "postgres", "clickhouse", "elasticsearch", "pganalyze", "rwx", "gmail", "notion", "ollama", "ynab", "stripe", "gcp", "suno", "amazon", "jira", "confluence", "salesforce", "cloudflare", "digitalocean", "fly", "snowflake", "acp", "web", "botidentity", "x", "signoz", "nomad", "agents", "switchboard"} {
 		ic, ok := m.cfg.Integrations[name]
 		assert.True(t, ok, "missing default integration: %s", name)
 		assert.False(t, ic.Enabled)
@@ -503,6 +503,9 @@ func TestEnvMapping_ReturnsMapping(t *testing.T) {
 	assert.Equal(t, "SIGNOZ_API_KEY", m["signoz"]["api_key"])
 	assert.Equal(t, "NOMAD_ADDR", m["nomad"]["address"])
 	assert.Equal(t, "NOMAD_TOKEN", m["nomad"]["token"])
+	assert.Equal(t, "STRIPE_API_KEY", m["stripe"]["api_key"])
+	assert.Equal(t, "STRIPE_ACCOUNT", m["stripe"]["account"])
+	assert.Equal(t, "STRIPE_BASE_URL", m["stripe"]["base_url"])
 	assert.Len(t, m, 26)
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -32,7 +32,7 @@ func TestLoad_CreatesDefaultWhenMissing(t *testing.T) {
 	_, err = os.Stat(path)
 	assert.NoError(t, err)
 
-	assert.Len(t, m.cfg.Integrations, 35)
+	assert.Len(t, m.cfg.Integrations, 36)
 	for _, name := range []string{"github", "datadog", "linear", "sentry", "slack", "metabase", "aws", "posthog", "postgres", "clickhouse", "elasticsearch", "pganalyze", "rwx", "gmail", "notion", "ollama", "ynab", "gcp", "suno", "amazon", "jira", "confluence", "salesforce", "cloudflare", "digitalocean", "fly", "snowflake", "acp", "web", "botidentity", "x", "signoz", "nomad", "switchboard"} {
 		ic, ok := m.cfg.Integrations[name]
 		assert.True(t, ok, "missing default integration: %s", name)
@@ -134,7 +134,7 @@ func TestSave(t *testing.T) {
 
 	var cfg mcp.Config
 	require.NoError(t, json.Unmarshal(data, &cfg))
-	assert.Len(t, cfg.Integrations, 35)
+	assert.Len(t, cfg.Integrations, 36)
 }
 
 func TestGet(t *testing.T) {
@@ -143,7 +143,7 @@ func TestGet(t *testing.T) {
 
 	cfg := m.Get()
 	assert.NotNil(t, cfg)
-	assert.Len(t, cfg.Integrations, 35)
+	assert.Len(t, cfg.Integrations, 36)
 }
 
 func TestUpdate(t *testing.T) {
@@ -253,7 +253,7 @@ func TestEnabledIntegrations_Multiple(t *testing.T) {
 func TestDefaultConfig(t *testing.T) {
 	cfg := defaultConfig()
 	require.NotNil(t, cfg)
-	assert.Len(t, cfg.Integrations, 35)
+	assert.Len(t, cfg.Integrations, 36)
 
 	expected := map[string][]string{
 		"github":        {"token", "client_id", "token_source"},
@@ -503,7 +503,7 @@ func TestEnvMapping_ReturnsMapping(t *testing.T) {
 	assert.Equal(t, "SIGNOZ_API_KEY", m["signoz"]["api_key"])
 	assert.Equal(t, "NOMAD_ADDR", m["nomad"]["address"])
 	assert.Equal(t, "NOMAD_TOKEN", m["nomad"]["token"])
-	assert.Len(t, m, 25)
+	assert.Len(t, m, 26)
 }
 
 func TestToolGlobs_PersistThroughSaveLoad(t *testing.T) {

--- a/integrations/stripe/compact_specs.go
+++ b/integrations/stripe/compact_specs.go
@@ -1,0 +1,360 @@
+package stripe
+
+import (
+	"fmt"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+// rawFieldCompactionSpecs maps Stripe list/retrieve tools to the subset of
+// JSON fields the LLM needs for routing decisions. Stripe list responses
+// always have shape: {"object":"list","data":[...],"has_more":bool}.
+// We always include "object" and "has_more" so the LLM can paginate.
+//
+// Single-object retrieve specs use top-level dotted paths.
+var rawFieldCompactionSpecs = map[mcp.ToolName][]string{
+	// ── Balance ──────────────────────────────────────────────────────
+	// stripe_get_balance returns a balance object (no list), keep top-level only.
+	mcp.ToolName("stripe_get_balance"): {
+		"object", "livemode",
+		"available[].amount", "available[].currency",
+		"pending[].amount", "pending[].currency",
+		"connect_reserved[].amount", "connect_reserved[].currency",
+		"instant_available[].amount", "instant_available[].currency",
+	},
+	mcp.ToolName("stripe_list_balance_transactions"): {
+		"object", "has_more",
+		"data[].id", "data[].type", "data[].status",
+		"data[].amount", "data[].fee", "data[].net", "data[].currency",
+		"data[].created", "data[].available_on",
+		"data[].source", "data[].description",
+	},
+	mcp.ToolName("stripe_retrieve_balance_transaction"): {
+		"id", "object", "type", "status", "amount", "fee", "net", "currency",
+		"created", "available_on", "source", "description",
+	},
+
+	// ── Customers ────────────────────────────────────────────────────
+	mcp.ToolName("stripe_list_customers"): {
+		"object", "has_more",
+		"data[].id", "data[].email", "data[].name", "data[].phone",
+		"data[].description", "data[].created", "data[].currency",
+		"data[].balance", "data[].delinquent", "data[].default_source",
+		"data[].invoice_prefix",
+	},
+	mcp.ToolName("stripe_retrieve_customer"): {
+		"id", "object", "email", "name", "phone", "description",
+		"created", "currency", "balance", "delinquent", "default_source",
+		"invoice_prefix", "address", "shipping",
+		"invoice_settings.default_payment_method",
+	},
+	mcp.ToolName("stripe_search_customers"): {
+		"object", "has_more", "next_page", "total_count",
+		"data[].id", "data[].email", "data[].name", "data[].created",
+		"data[].balance", "data[].delinquent", "data[].description",
+	},
+
+	// ── Charges ──────────────────────────────────────────────────────
+	mcp.ToolName("stripe_list_charges"): {
+		"object", "has_more",
+		"data[].id", "data[].amount", "data[].amount_captured", "data[].amount_refunded",
+		"data[].currency", "data[].status", "data[].paid", "data[].captured", "data[].refunded",
+		"data[].created", "data[].customer", "data[].payment_intent", "data[].payment_method",
+		"data[].description", "data[].failure_code", "data[].failure_message",
+		"data[].receipt_email", "data[].disputed",
+		"data[].outcome.network_status", "data[].outcome.risk_level", "data[].outcome.seller_message",
+	},
+	mcp.ToolName("stripe_retrieve_charge"): {
+		"id", "object", "amount", "amount_captured", "amount_refunded",
+		"currency", "status", "paid", "captured", "refunded", "disputed",
+		"created", "customer", "payment_intent", "payment_method",
+		"description", "failure_code", "failure_message", "receipt_email",
+		"receipt_url", "billing_details.email", "billing_details.name",
+		"outcome.network_status", "outcome.risk_level", "outcome.seller_message",
+		"payment_method_details.type",
+		"payment_method_details.card.brand", "payment_method_details.card.last4",
+		"payment_method_details.card.exp_month", "payment_method_details.card.exp_year",
+		"payment_method_details.card.country",
+		"refunds.data[].id", "refunds.data[].amount", "refunds.data[].status",
+	},
+	mcp.ToolName("stripe_search_charges"): {
+		"object", "has_more", "next_page", "total_count",
+		"data[].id", "data[].amount", "data[].currency", "data[].status",
+		"data[].created", "data[].customer", "data[].payment_intent",
+		"data[].description",
+	},
+
+	// ── Payment Intents ──────────────────────────────────────────────
+	mcp.ToolName("stripe_list_payment_intents"): {
+		"object", "has_more",
+		"data[].id", "data[].amount", "data[].amount_received", "data[].currency",
+		"data[].status", "data[].created", "data[].customer", "data[].payment_method",
+		"data[].latest_charge", "data[].description", "data[].capture_method",
+		"data[].cancellation_reason", "data[].canceled_at",
+		"data[].next_action.type",
+	},
+	mcp.ToolName("stripe_retrieve_payment_intent"): {
+		"id", "object", "amount", "amount_received", "amount_capturable",
+		"currency", "status", "created", "customer", "payment_method",
+		"latest_charge", "description", "receipt_email", "capture_method",
+		"confirmation_method", "cancellation_reason", "canceled_at",
+		"client_secret", "next_action.type", "next_action.redirect_to_url.url",
+		"payment_method_types",
+		"last_payment_error.code", "last_payment_error.message", "last_payment_error.type",
+	},
+	mcp.ToolName("stripe_search_payment_intents"): {
+		"object", "has_more", "next_page", "total_count",
+		"data[].id", "data[].amount", "data[].currency", "data[].status",
+		"data[].created", "data[].customer", "data[].latest_charge",
+	},
+
+	// ── Refunds ──────────────────────────────────────────────────────
+	mcp.ToolName("stripe_list_refunds"): {
+		"object", "has_more",
+		"data[].id", "data[].amount", "data[].currency", "data[].status",
+		"data[].created", "data[].charge", "data[].payment_intent",
+		"data[].reason", "data[].description",
+	},
+	mcp.ToolName("stripe_retrieve_refund"): {
+		"id", "object", "amount", "currency", "status", "created",
+		"charge", "payment_intent", "reason", "description",
+		"failure_reason", "receipt_number",
+	},
+
+	// ── Disputes ─────────────────────────────────────────────────────
+	mcp.ToolName("stripe_list_disputes"): {
+		"object", "has_more",
+		"data[].id", "data[].amount", "data[].currency", "data[].status",
+		"data[].reason", "data[].created", "data[].charge", "data[].payment_intent",
+		"data[].is_charge_refundable", "data[].evidence_details.due_by",
+		"data[].evidence_details.has_evidence", "data[].evidence_details.submission_count",
+	},
+	mcp.ToolName("stripe_retrieve_dispute"): {
+		"id", "object", "amount", "currency", "status", "reason",
+		"created", "charge", "payment_intent", "is_charge_refundable",
+		"evidence_details.due_by", "evidence_details.has_evidence",
+		"evidence_details.past_due", "evidence_details.submission_count",
+		"network_reason_code",
+	},
+
+	// ── Payouts ──────────────────────────────────────────────────────
+	mcp.ToolName("stripe_list_payouts"): {
+		"object", "has_more",
+		"data[].id", "data[].amount", "data[].currency", "data[].status",
+		"data[].arrival_date", "data[].created", "data[].method", "data[].type",
+		"data[].destination", "data[].description", "data[].failure_code",
+		"data[].failure_message", "data[].automatic",
+	},
+	mcp.ToolName("stripe_retrieve_payout"): {
+		"id", "object", "amount", "currency", "status", "arrival_date",
+		"created", "method", "type", "destination", "description",
+		"failure_code", "failure_message", "automatic", "balance_transaction",
+		"source_type", "statement_descriptor",
+	},
+
+	// ── Subscriptions ────────────────────────────────────────────────
+	mcp.ToolName("stripe_list_subscriptions"): {
+		"object", "has_more",
+		"data[].id", "data[].status", "data[].customer", "data[].created",
+		"data[].current_period_start", "data[].current_period_end",
+		"data[].cancel_at_period_end", "data[].canceled_at", "data[].cancel_at",
+		"data[].trial_start", "data[].trial_end", "data[].collection_method",
+		"data[].currency", "data[].default_payment_method",
+		"data[].items.data[].id", "data[].items.data[].quantity",
+		"data[].items.data[].price.id", "data[].items.data[].price.nickname",
+		"data[].items.data[].price.unit_amount", "data[].items.data[].price.currency",
+		"data[].items.data[].price.recurring.interval", "data[].items.data[].price.recurring.interval_count",
+		"data[].items.data[].price.product",
+	},
+	mcp.ToolName("stripe_retrieve_subscription"): {
+		"id", "object", "status", "customer", "created",
+		"current_period_start", "current_period_end",
+		"cancel_at_period_end", "canceled_at", "cancel_at", "ended_at",
+		"trial_start", "trial_end", "collection_method", "currency",
+		"default_payment_method", "default_source", "latest_invoice",
+		"items.data[].id", "items.data[].quantity",
+		"items.data[].price.id", "items.data[].price.nickname",
+		"items.data[].price.unit_amount", "items.data[].price.currency",
+		"items.data[].price.recurring.interval", "items.data[].price.recurring.interval_count",
+		"items.data[].price.product",
+	},
+	mcp.ToolName("stripe_search_subscriptions"): {
+		"object", "has_more", "next_page", "total_count",
+		"data[].id", "data[].status", "data[].customer", "data[].created",
+		"data[].current_period_end", "data[].cancel_at_period_end",
+	},
+	mcp.ToolName("stripe_list_subscription_items"): {
+		"object", "has_more",
+		"data[].id", "data[].quantity", "data[].subscription",
+		"data[].created",
+		"data[].price.id", "data[].price.nickname", "data[].price.unit_amount",
+		"data[].price.currency", "data[].price.recurring.interval",
+		"data[].price.recurring.interval_count", "data[].price.product",
+	},
+	mcp.ToolName("stripe_retrieve_subscription_item"): {
+		"id", "object", "quantity", "subscription", "created",
+		"price.id", "price.nickname", "price.unit_amount", "price.currency",
+		"price.recurring.interval", "price.recurring.interval_count", "price.product",
+	},
+
+	// ── Products ─────────────────────────────────────────────────────
+	mcp.ToolName("stripe_list_products"): {
+		"object", "has_more",
+		"data[].id", "data[].name", "data[].description", "data[].active",
+		"data[].created", "data[].updated", "data[].default_price",
+		"data[].shippable", "data[].type", "data[].url", "data[].unit_label",
+	},
+	mcp.ToolName("stripe_retrieve_product"): {
+		"id", "object", "name", "description", "active", "created", "updated",
+		"default_price", "shippable", "type", "url", "unit_label", "images",
+		"tax_code", "statement_descriptor",
+	},
+
+	// ── Prices ───────────────────────────────────────────────────────
+	mcp.ToolName("stripe_list_prices"): {
+		"object", "has_more",
+		"data[].id", "data[].product", "data[].nickname", "data[].active",
+		"data[].currency", "data[].unit_amount", "data[].unit_amount_decimal",
+		"data[].type", "data[].billing_scheme", "data[].lookup_key",
+		"data[].recurring.interval", "data[].recurring.interval_count",
+		"data[].recurring.usage_type", "data[].created",
+	},
+	mcp.ToolName("stripe_retrieve_price"): {
+		"id", "object", "product", "nickname", "active", "currency",
+		"unit_amount", "unit_amount_decimal", "type", "billing_scheme",
+		"lookup_key", "tax_behavior", "created",
+		"recurring.interval", "recurring.interval_count", "recurring.usage_type",
+	},
+
+	// ── Invoices ─────────────────────────────────────────────────────
+	mcp.ToolName("stripe_list_invoices"): {
+		"object", "has_more",
+		"data[].id", "data[].number", "data[].status", "data[].customer",
+		"data[].subscription", "data[].created", "data[].due_date",
+		"data[].period_start", "data[].period_end",
+		"data[].amount_due", "data[].amount_paid", "data[].amount_remaining",
+		"data[].total", "data[].subtotal", "data[].currency",
+		"data[].collection_method", "data[].paid", "data[].attempted",
+		"data[].hosted_invoice_url", "data[].invoice_pdf",
+	},
+	mcp.ToolName("stripe_retrieve_invoice"): {
+		"id", "object", "number", "status", "customer", "subscription",
+		"created", "due_date", "period_start", "period_end",
+		"amount_due", "amount_paid", "amount_remaining", "total", "subtotal",
+		"currency", "collection_method", "paid", "attempted",
+		"hosted_invoice_url", "invoice_pdf", "billing_reason", "description",
+		"default_payment_method", "default_source",
+		"lines.data[].id", "lines.data[].amount", "lines.data[].currency",
+		"lines.data[].description", "lines.data[].quantity",
+		"lines.data[].price.id", "lines.data[].price.unit_amount",
+		"lines.data[].price.nickname", "lines.data[].price.product",
+		"lines.data[].period.start", "lines.data[].period.end",
+	},
+	mcp.ToolName("stripe_retrieve_upcoming_invoice"): {
+		"id", "object", "status", "customer", "subscription",
+		"period_start", "period_end",
+		"amount_due", "amount_paid", "amount_remaining", "total", "subtotal",
+		"currency", "billing_reason",
+		"lines.data[].amount", "lines.data[].currency", "lines.data[].description",
+		"lines.data[].quantity",
+		"lines.data[].price.id", "lines.data[].price.unit_amount",
+		"lines.data[].price.nickname", "lines.data[].price.product",
+		"lines.data[].period.start", "lines.data[].period.end",
+	},
+	mcp.ToolName("stripe_search_invoices"): {
+		"object", "has_more", "next_page", "total_count",
+		"data[].id", "data[].number", "data[].status", "data[].customer",
+		"data[].total", "data[].currency", "data[].created", "data[].due_date",
+	},
+	mcp.ToolName("stripe_list_invoice_items"): {
+		"object", "has_more",
+		"data[].id", "data[].amount", "data[].currency", "data[].description",
+		"data[].customer", "data[].invoice", "data[].subscription",
+		"data[].quantity", "data[].date",
+		"data[].price.id", "data[].price.unit_amount", "data[].price.nickname",
+		"data[].price.product",
+	},
+
+	// ── Payment Methods ──────────────────────────────────────────────
+	mcp.ToolName("stripe_list_payment_methods"): {
+		"object", "has_more",
+		"data[].id", "data[].type", "data[].customer", "data[].created",
+		"data[].billing_details.email", "data[].billing_details.name",
+		"data[].card.brand", "data[].card.last4", "data[].card.exp_month",
+		"data[].card.exp_year", "data[].card.country", "data[].card.funding",
+		"data[].us_bank_account.bank_name", "data[].us_bank_account.last4",
+	},
+	mcp.ToolName("stripe_retrieve_payment_method"): {
+		"id", "object", "type", "customer", "created",
+		"billing_details.email", "billing_details.name", "billing_details.phone",
+		"billing_details.address",
+		"card.brand", "card.last4", "card.exp_month", "card.exp_year",
+		"card.country", "card.funding", "card.fingerprint",
+		"us_bank_account.bank_name", "us_bank_account.last4",
+	},
+
+	// ── Setup Intents ────────────────────────────────────────────────
+	mcp.ToolName("stripe_list_setup_intents"): {
+		"object", "has_more",
+		"data[].id", "data[].status", "data[].customer", "data[].payment_method",
+		"data[].created", "data[].usage", "data[].description",
+		"data[].cancellation_reason", "data[].latest_attempt",
+		"data[].next_action.type",
+	},
+	mcp.ToolName("stripe_retrieve_setup_intent"): {
+		"id", "object", "status", "customer", "payment_method", "created",
+		"usage", "description", "cancellation_reason", "latest_attempt",
+		"client_secret", "next_action.type", "next_action.redirect_to_url.url",
+		"payment_method_types",
+		"last_setup_error.code", "last_setup_error.message", "last_setup_error.type",
+	},
+
+	// ── Coupons / Promotion Codes ────────────────────────────────────
+	mcp.ToolName("stripe_list_coupons"): {
+		"object", "has_more",
+		"data[].id", "data[].name", "data[].valid", "data[].duration",
+		"data[].duration_in_months", "data[].percent_off", "data[].amount_off",
+		"data[].currency", "data[].max_redemptions", "data[].times_redeemed",
+		"data[].redeem_by", "data[].created",
+	},
+	mcp.ToolName("stripe_retrieve_coupon"): {
+		"id", "object", "name", "valid", "duration", "duration_in_months",
+		"percent_off", "amount_off", "currency", "max_redemptions",
+		"times_redeemed", "redeem_by", "created",
+	},
+	mcp.ToolName("stripe_list_promotion_codes"): {
+		"object", "has_more",
+		"data[].id", "data[].code", "data[].active", "data[].coupon.id",
+		"data[].coupon.percent_off", "data[].coupon.amount_off",
+		"data[].customer", "data[].expires_at", "data[].max_redemptions",
+		"data[].times_redeemed", "data[].created",
+	},
+
+	// ── Events ───────────────────────────────────────────────────────
+	mcp.ToolName("stripe_list_events"): {
+		"object", "has_more",
+		"data[].id", "data[].type", "data[].created", "data[].livemode",
+		"data[].api_version", "data[].pending_webhooks",
+		"data[].data.object.id", "data[].data.object.object",
+	},
+	mcp.ToolName("stripe_retrieve_event"): {
+		"id", "object", "type", "created", "livemode", "api_version",
+		"pending_webhooks",
+		"data.object.id", "data.object.object",
+		"request.id", "request.idempotency_key",
+	},
+}
+
+var fieldCompactionSpecs = mustBuildFieldCompactionSpecs(rawFieldCompactionSpecs)
+
+func mustBuildFieldCompactionSpecs(raw map[mcp.ToolName][]string) map[mcp.ToolName][]mcp.CompactField {
+	parsed := make(map[mcp.ToolName][]mcp.CompactField, len(raw))
+	for tool, specs := range raw {
+		fields, err := mcp.ParseCompactSpecs(specs)
+		if err != nil {
+			panic(fmt.Sprintf("stripe: invalid field compaction spec for %q: %v", tool, err))
+		}
+		parsed[tool] = fields
+	}
+	return parsed
+}

--- a/integrations/stripe/compact_specs_test.go
+++ b/integrations/stripe/compact_specs_test.go
@@ -1,0 +1,69 @@
+package stripe
+
+import (
+	"strings"
+	"testing"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFieldCompactionSpecs_AllParse(t *testing.T) {
+	require.NotEmpty(t, fieldCompactionSpecs, "fieldCompactionSpecs should not be empty")
+}
+
+func TestFieldCompactionSpecs_NoDuplicateTools(t *testing.T) {
+	assert.Equal(t, len(rawFieldCompactionSpecs), len(fieldCompactionSpecs))
+}
+
+func TestFieldCompactionSpecs_NoOrphanSpecs(t *testing.T) {
+	for toolName := range fieldCompactionSpecs {
+		_, ok := dispatch[toolName]
+		assert.True(t, ok, "field compaction spec for %q has no dispatch handler", toolName)
+	}
+}
+
+func TestFieldCompactionSpec_ReturnsFieldsForListTool(t *testing.T) {
+	s := &stripe{}
+	fields, ok := s.CompactSpec("stripe_list_customers")
+	require.True(t, ok, "stripe_list_customers should have field compaction spec")
+	assert.NotEmpty(t, fields)
+}
+
+func TestFieldCompactionSpec_ReturnsFalseForUnknownTool(t *testing.T) {
+	s := &stripe{}
+	_, ok := s.CompactSpec("stripe_nonexistent")
+	assert.False(t, ok, "unknown tools should return false")
+}
+
+func TestFieldCompactionSpec_ReturnsFalseForMutationTool(t *testing.T) {
+	s := &stripe{}
+	_, ok := s.CompactSpec("stripe_create_customer")
+	assert.False(t, ok, "mutation tools should not have compaction specs")
+}
+
+// List-shape specs should include "object" and "has_more" so the LLM can paginate.
+func TestFieldCompactionSpecs_ListShapeIncludesPaginationFields(t *testing.T) {
+	for toolName, raw := range rawFieldCompactionSpecs {
+		name := string(toolName)
+		if !strings.HasPrefix(name, "stripe_list_") && !strings.HasPrefix(name, "stripe_search_") {
+			continue
+		}
+		joined := strings.Join(raw, ",")
+		assert.Contains(t, joined, "object", "list/search spec %s missing 'object'", toolName)
+		assert.Contains(t, joined, "has_more", "list/search spec %s missing 'has_more'", toolName)
+	}
+}
+
+// All compaction-spec tool names must reference defined tools.
+func TestFieldCompactionSpecs_AllToolsDefined(t *testing.T) {
+	i := New()
+	defined := map[mcp.ToolName]bool{}
+	for _, tool := range i.Tools() {
+		defined[tool.Name] = true
+	}
+	for toolName := range rawFieldCompactionSpecs {
+		assert.True(t, defined[toolName], "compaction spec for undefined tool: %s", toolName)
+	}
+}

--- a/integrations/stripe/customers.go
+++ b/integrations/stripe/customers.go
@@ -1,0 +1,115 @@
+package stripe
+
+import (
+	"context"
+	"fmt"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+// --- Balance ---
+
+func getBalance(ctx context.Context, s *stripe, _ map[string]any) (*mcp.ToolResult, error) {
+	data, err := s.get(ctx, "/balance", nil)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func listBalanceTransactions(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	params := listParamsFrom(args, "type", "currency", "payout", "source", "created")
+	data, err := s.get(ctx, "/balance_transactions", params)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func retrieveBalanceTransaction(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := s.get(ctx, fmt.Sprintf("/balance_transactions/%s", id), nil)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+// --- Customers ---
+
+func listCustomers(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	params := listParamsFrom(args, "email", "created")
+	data, err := s.get(ctx, "/customers", params)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func retrieveCustomer(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := s.get(ctx, fmt.Sprintf("/customers/%s", id), nil)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func searchCustomers(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	_ = r.Str("query") // required, validated below
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := s.get(ctx, "/customers/search", searchParamsFrom(args))
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func createCustomer(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	body := map[string]any{}
+	copyIfPresent(body, args, "email", "name", "phone", "description", "metadata", "address", "shipping", "payment_method", "default_source", "invoice_settings")
+	data, err := s.post(ctx, "/customers", body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func updateCustomer(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	body := map[string]any{}
+	copyIfPresent(body, args, "email", "name", "phone", "description", "metadata", "address", "shipping", "default_source", "invoice_settings")
+	data, err := s.post(ctx, fmt.Sprintf("/customers/%s", id), body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func deleteCustomer(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := s.del(ctx, fmt.Sprintf("/customers/%s", id), nil)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}

--- a/integrations/stripe/dispatch.go
+++ b/integrations/stripe/dispatch.go
@@ -1,0 +1,114 @@
+package stripe
+
+import mcp "github.com/daltoniam/switchboard"
+
+// dispatch routes a tool name to its handler.
+var dispatch = map[mcp.ToolName]handlerFunc{
+	// Balance
+	mcp.ToolName("stripe_get_balance"):                  getBalance,
+	mcp.ToolName("stripe_list_balance_transactions"):    listBalanceTransactions,
+	mcp.ToolName("stripe_retrieve_balance_transaction"): retrieveBalanceTransaction,
+
+	// Customers
+	mcp.ToolName("stripe_list_customers"):    listCustomers,
+	mcp.ToolName("stripe_retrieve_customer"): retrieveCustomer,
+	mcp.ToolName("stripe_search_customers"):  searchCustomers,
+	mcp.ToolName("stripe_create_customer"):   createCustomer,
+	mcp.ToolName("stripe_update_customer"):   updateCustomer,
+	mcp.ToolName("stripe_delete_customer"):   deleteCustomer,
+
+	// Charges
+	mcp.ToolName("stripe_list_charges"):    listCharges,
+	mcp.ToolName("stripe_retrieve_charge"): retrieveCharge,
+	mcp.ToolName("stripe_search_charges"):  searchCharges,
+	mcp.ToolName("stripe_capture_charge"):  captureCharge,
+
+	// Payment Intents
+	mcp.ToolName("stripe_list_payment_intents"):    listPaymentIntents,
+	mcp.ToolName("stripe_retrieve_payment_intent"): retrievePaymentIntent,
+	mcp.ToolName("stripe_create_payment_intent"):   createPaymentIntent,
+	mcp.ToolName("stripe_update_payment_intent"):   updatePaymentIntent,
+	mcp.ToolName("stripe_confirm_payment_intent"):  confirmPaymentIntent,
+	mcp.ToolName("stripe_cancel_payment_intent"):   cancelPaymentIntent,
+	mcp.ToolName("stripe_search_payment_intents"):  searchPaymentIntents,
+
+	// Refunds
+	mcp.ToolName("stripe_list_refunds"):    listRefunds,
+	mcp.ToolName("stripe_retrieve_refund"): retrieveRefund,
+	mcp.ToolName("stripe_create_refund"):   createRefund,
+	mcp.ToolName("stripe_update_refund"):   updateRefund,
+
+	// Disputes
+	mcp.ToolName("stripe_list_disputes"):    listDisputes,
+	mcp.ToolName("stripe_retrieve_dispute"): retrieveDispute,
+	mcp.ToolName("stripe_update_dispute"):   updateDispute,
+
+	// Payouts
+	mcp.ToolName("stripe_list_payouts"):    listPayouts,
+	mcp.ToolName("stripe_retrieve_payout"): retrievePayout,
+	mcp.ToolName("stripe_create_payout"):   createPayout,
+
+	// Subscriptions
+	mcp.ToolName("stripe_list_subscriptions"):    listSubscriptions,
+	mcp.ToolName("stripe_retrieve_subscription"): retrieveSubscription,
+	mcp.ToolName("stripe_search_subscriptions"):  searchSubscriptions,
+	mcp.ToolName("stripe_create_subscription"):   createSubscription,
+	mcp.ToolName("stripe_update_subscription"):   updateSubscription,
+	mcp.ToolName("stripe_cancel_subscription"):   cancelSubscription,
+
+	// Subscription Items
+	mcp.ToolName("stripe_list_subscription_items"):    listSubscriptionItems,
+	mcp.ToolName("stripe_retrieve_subscription_item"): retrieveSubscriptionItem,
+
+	// Products
+	mcp.ToolName("stripe_list_products"):    listProducts,
+	mcp.ToolName("stripe_retrieve_product"): retrieveProduct,
+	mcp.ToolName("stripe_create_product"):   createProduct,
+	mcp.ToolName("stripe_update_product"):   updateProduct,
+	mcp.ToolName("stripe_delete_product"):   deleteProduct,
+
+	// Prices
+	mcp.ToolName("stripe_list_prices"):    listPrices,
+	mcp.ToolName("stripe_retrieve_price"): retrievePrice,
+	mcp.ToolName("stripe_create_price"):   createPrice,
+	mcp.ToolName("stripe_update_price"):   updatePrice,
+
+	// Invoices
+	mcp.ToolName("stripe_list_invoices"):             listInvoices,
+	mcp.ToolName("stripe_retrieve_invoice"):          retrieveInvoice,
+	mcp.ToolName("stripe_retrieve_upcoming_invoice"): retrieveUpcomingInvoice,
+	mcp.ToolName("stripe_search_invoices"):           searchInvoices,
+	mcp.ToolName("stripe_create_invoice"):            createInvoice,
+	mcp.ToolName("stripe_finalize_invoice"):          finalizeInvoice,
+	mcp.ToolName("stripe_pay_invoice"):               payInvoice,
+	mcp.ToolName("stripe_send_invoice"):              sendInvoice,
+	mcp.ToolName("stripe_void_invoice"):              voidInvoice,
+	mcp.ToolName("stripe_delete_invoice"):            deleteInvoice,
+
+	// Invoice Items
+	mcp.ToolName("stripe_list_invoice_items"):  listInvoiceItems,
+	mcp.ToolName("stripe_create_invoice_item"): createInvoiceItem,
+
+	// Payment Methods
+	mcp.ToolName("stripe_list_payment_methods"):    listPaymentMethods,
+	mcp.ToolName("stripe_retrieve_payment_method"): retrievePaymentMethod,
+	mcp.ToolName("stripe_attach_payment_method"):   attachPaymentMethod,
+	mcp.ToolName("stripe_detach_payment_method"):   detachPaymentMethod,
+
+	// Setup Intents
+	mcp.ToolName("stripe_list_setup_intents"):    listSetupIntents,
+	mcp.ToolName("stripe_retrieve_setup_intent"): retrieveSetupIntent,
+	mcp.ToolName("stripe_create_setup_intent"):   createSetupIntent,
+
+	// Coupons / Promotion Codes
+	mcp.ToolName("stripe_list_coupons"):          listCoupons,
+	mcp.ToolName("stripe_retrieve_coupon"):       retrieveCoupon,
+	mcp.ToolName("stripe_create_coupon"):         createCoupon,
+	mcp.ToolName("stripe_delete_coupon"):         deleteCoupon,
+	mcp.ToolName("stripe_list_promotion_codes"):  listPromotionCodes,
+	mcp.ToolName("stripe_create_promotion_code"): createPromotionCode,
+
+	// Events
+	mcp.ToolName("stripe_list_events"):    listEvents,
+	mcp.ToolName("stripe_retrieve_event"): retrieveEvent,
+}

--- a/integrations/stripe/extras.go
+++ b/integrations/stripe/extras.go
@@ -1,0 +1,200 @@
+package stripe
+
+import (
+	"context"
+	"fmt"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+// --- Payment Methods ---
+
+func listPaymentMethods(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	customer := r.Str("customer")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	params := listParamsFrom(args, "type")
+	params["customer"] = customer
+	data, err := s.get(ctx, "/payment_methods", params)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func retrievePaymentMethod(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := s.get(ctx, fmt.Sprintf("/payment_methods/%s", id), nil)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func attachPaymentMethod(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("id")
+	customer := r.Str("customer")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	body := map[string]any{"customer": customer}
+	data, err := s.post(ctx, fmt.Sprintf("/payment_methods/%s/attach", id), body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func detachPaymentMethod(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := s.post(ctx, fmt.Sprintf("/payment_methods/%s/detach", id), nil)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+// --- Setup Intents ---
+
+func listSetupIntents(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	params := listParamsFrom(args, "customer", "payment_method", "created", "attach_to_self")
+	data, err := s.get(ctx, "/setup_intents", params)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func retrieveSetupIntent(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := s.get(ctx, fmt.Sprintf("/setup_intents/%s", id), nil)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func createSetupIntent(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	body := map[string]any{}
+	copyIfPresent(body, args, "customer", "payment_method", "payment_method_types", "usage", "confirm", "description", "metadata", "automatic_payment_methods", "return_url", "on_behalf_of", "single_use", "mandate_data")
+	data, err := s.post(ctx, "/setup_intents", body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+// --- Coupons ---
+
+func listCoupons(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	params := listParamsFrom(args, "created")
+	data, err := s.get(ctx, "/coupons", params)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func retrieveCoupon(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := s.get(ctx, fmt.Sprintf("/coupons/%s", id), nil)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func createCoupon(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	duration := r.Str("duration")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	body := map[string]any{"duration": duration}
+	copyIfPresent(body, args, "id", "name", "percent_off", "amount_off", "currency", "duration_in_months", "max_redemptions", "redeem_by", "metadata", "applies_to", "currency_options")
+	data, err := s.post(ctx, "/coupons", body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func deleteCoupon(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := s.del(ctx, fmt.Sprintf("/coupons/%s", id), nil)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func listPromotionCodes(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	params := listParamsFrom(args, "coupon", "customer", "active", "code", "created")
+	data, err := s.get(ctx, "/promotion_codes", params)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func createPromotionCode(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	coupon := r.Str("coupon")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	body := map[string]any{"coupon": coupon}
+	copyIfPresent(body, args, "code", "customer", "max_redemptions", "expires_at", "active", "metadata", "restrictions")
+	data, err := s.post(ctx, "/promotion_codes", body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+// --- Events ---
+
+func listEvents(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	params := listParamsFrom(args, "type", "types", "created", "delivery_success")
+	data, err := s.get(ctx, "/events", params)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func retrieveEvent(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := s.get(ctx, fmt.Sprintf("/events/%s", id), nil)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}

--- a/integrations/stripe/invoices.go
+++ b/integrations/stripe/invoices.go
@@ -1,0 +1,165 @@
+package stripe
+
+import (
+	"context"
+	"fmt"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+// --- Invoices ---
+
+func listInvoices(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	params := listParamsFrom(args, "customer", "subscription", "status", "collection_method", "created", "due_date")
+	data, err := s.get(ctx, "/invoices", params)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func retrieveInvoice(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := s.get(ctx, fmt.Sprintf("/invoices/%s", id), nil)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func retrieveUpcomingInvoice(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	params := map[string]any{}
+	copyIfPresent(params, args, "customer", "subscription", "coupon", "subscription_items", "subscription_proration_date", "subscription_proration_behavior", "subscription_trial_end", "subscription_cancel_at_period_end", "subscription_cancel_now", "subscription_billing_cycle_anchor", "schedule", "automatic_tax", "invoice_items", "discounts")
+	data, err := s.get(ctx, "/invoices/upcoming", params)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func searchInvoices(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	_ = r.Str("query")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := s.get(ctx, "/invoices/search", searchParamsFrom(args))
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func createInvoice(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	customer := r.Str("customer")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	body := map[string]any{"customer": customer}
+	copyIfPresent(body, args, "auto_advance", "collection_method", "days_until_due", "description", "subscription", "metadata", "default_payment_method", "default_source", "due_date", "footer", "statement_descriptor", "automatic_tax", "discounts", "default_tax_rates", "account_tax_ids", "custom_fields", "payment_settings", "transfer_data", "rendering", "shipping_cost", "shipping_details")
+	data, err := s.post(ctx, "/invoices", body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func finalizeInvoice(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	body := map[string]any{}
+	copyIfPresent(body, args, "auto_advance")
+	data, err := s.post(ctx, fmt.Sprintf("/invoices/%s/finalize", id), body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func payInvoice(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	body := map[string]any{}
+	copyIfPresent(body, args, "payment_method", "source", "paid_out_of_band", "off_session", "forgive", "mandate")
+	data, err := s.post(ctx, fmt.Sprintf("/invoices/%s/pay", id), body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func sendInvoice(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := s.post(ctx, fmt.Sprintf("/invoices/%s/send", id), nil)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func voidInvoice(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := s.post(ctx, fmt.Sprintf("/invoices/%s/void", id), nil)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func deleteInvoice(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := s.del(ctx, fmt.Sprintf("/invoices/%s", id), nil)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+// --- Invoice Items ---
+
+func listInvoiceItems(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	params := listParamsFrom(args, "customer", "invoice", "pending", "created")
+	data, err := s.get(ctx, "/invoiceitems", params)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func createInvoiceItem(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	customer := r.Str("customer")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	body := map[string]any{"customer": customer}
+	copyIfPresent(body, args, "amount", "currency", "description", "price", "quantity", "invoice", "subscription", "metadata", "discountable", "discounts", "period", "tax_rates", "unit_amount", "unit_amount_decimal", "price_data")
+	data, err := s.post(ctx, "/invoiceitems", body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}

--- a/integrations/stripe/params.go
+++ b/integrations/stripe/params.go
@@ -1,0 +1,29 @@
+package stripe
+
+// Shared parameter helpers used across handlers.
+
+// copyIfPresent copies a key from src into out if the key exists in src.
+// This preserves the value as-is so encodeForm can flatten objects/arrays/scalars correctly.
+func copyIfPresent(out map[string]any, src map[string]any, keys ...string) {
+	for _, k := range keys {
+		if v, ok := src[k]; ok {
+			out[k] = v
+		}
+	}
+}
+
+// listParamsFrom extracts the standard list-pagination params (limit, starting_after, ending_before)
+// plus any additional named keys from args.
+func listParamsFrom(args map[string]any, extra ...string) map[string]any {
+	out := map[string]any{}
+	copyIfPresent(out, args, "limit", "starting_after", "ending_before")
+	copyIfPresent(out, args, extra...)
+	return out
+}
+
+// searchParamsFrom extracts query/limit/page from args for Stripe search endpoints.
+func searchParamsFrom(args map[string]any) map[string]any {
+	out := map[string]any{}
+	copyIfPresent(out, args, "query", "limit", "page")
+	return out
+}

--- a/integrations/stripe/payments.go
+++ b/integrations/stripe/payments.go
@@ -1,0 +1,292 @@
+package stripe
+
+import (
+	"context"
+	"fmt"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+// --- Charges ---
+
+func listCharges(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	params := listParamsFrom(args, "customer", "payment_intent", "transfer_group", "created")
+	data, err := s.get(ctx, "/charges", params)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func retrieveCharge(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := s.get(ctx, fmt.Sprintf("/charges/%s", id), nil)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func searchCharges(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	_ = r.Str("query")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := s.get(ctx, "/charges/search", searchParamsFrom(args))
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func captureCharge(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	body := map[string]any{}
+	copyIfPresent(body, args, "amount", "application_fee_amount", "receipt_email", "statement_descriptor", "transfer_data", "transfer_group")
+	data, err := s.post(ctx, fmt.Sprintf("/charges/%s/capture", id), body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+// --- Payment Intents ---
+
+func listPaymentIntents(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	params := listParamsFrom(args, "customer", "created")
+	data, err := s.get(ctx, "/payment_intents", params)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func retrievePaymentIntent(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := s.get(ctx, fmt.Sprintf("/payment_intents/%s", id), nil)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func createPaymentIntent(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	amount := r.Int("amount")
+	currency := r.Str("currency")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	body := map[string]any{
+		"amount":   amount,
+		"currency": currency,
+	}
+	copyIfPresent(body, args, "customer", "payment_method", "payment_method_types", "description", "receipt_email", "statement_descriptor", "statement_descriptor_suffix", "capture_method", "confirm", "off_session", "metadata", "transfer_data", "application_fee_amount", "automatic_payment_methods", "setup_future_usage", "shipping", "return_url")
+	data, err := s.post(ctx, "/payment_intents", body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func updatePaymentIntent(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	body := map[string]any{}
+	copyIfPresent(body, args, "amount", "currency", "customer", "description", "metadata", "payment_method", "receipt_email", "statement_descriptor", "statement_descriptor_suffix", "shipping", "transfer_data", "application_fee_amount", "setup_future_usage")
+	data, err := s.post(ctx, fmt.Sprintf("/payment_intents/%s", id), body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func confirmPaymentIntent(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	body := map[string]any{}
+	copyIfPresent(body, args, "payment_method", "return_url", "off_session", "receipt_email", "shipping", "use_stripe_sdk", "mandate", "mandate_data")
+	data, err := s.post(ctx, fmt.Sprintf("/payment_intents/%s/confirm", id), body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func cancelPaymentIntent(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	body := map[string]any{}
+	copyIfPresent(body, args, "cancellation_reason")
+	data, err := s.post(ctx, fmt.Sprintf("/payment_intents/%s/cancel", id), body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func searchPaymentIntents(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	_ = r.Str("query")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := s.get(ctx, "/payment_intents/search", searchParamsFrom(args))
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+// --- Refunds ---
+
+func listRefunds(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	params := listParamsFrom(args, "charge", "payment_intent", "created")
+	data, err := s.get(ctx, "/refunds", params)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func retrieveRefund(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := s.get(ctx, fmt.Sprintf("/refunds/%s", id), nil)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func createRefund(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	body := map[string]any{}
+	copyIfPresent(body, args, "charge", "payment_intent", "amount", "reason", "refund_application_fee", "reverse_transfer", "metadata", "instructions_email")
+	data, err := s.post(ctx, "/refunds", body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func updateRefund(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	body := map[string]any{}
+	copyIfPresent(body, args, "metadata")
+	data, err := s.post(ctx, fmt.Sprintf("/refunds/%s", id), body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+// --- Disputes ---
+
+func listDisputes(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	params := listParamsFrom(args, "charge", "payment_intent", "created")
+	data, err := s.get(ctx, "/disputes", params)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func retrieveDispute(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := s.get(ctx, fmt.Sprintf("/disputes/%s", id), nil)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func updateDispute(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	body := map[string]any{}
+	copyIfPresent(body, args, "evidence", "submit", "metadata")
+	data, err := s.post(ctx, fmt.Sprintf("/disputes/%s", id), body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+// --- Payouts ---
+
+func listPayouts(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	params := listParamsFrom(args, "status", "destination", "arrival_date", "created")
+	data, err := s.get(ctx, "/payouts", params)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func retrievePayout(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := s.get(ctx, fmt.Sprintf("/payouts/%s", id), nil)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func createPayout(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	amount := r.Int("amount")
+	currency := r.Str("currency")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	body := map[string]any{
+		"amount":   amount,
+		"currency": currency,
+	}
+	copyIfPresent(body, args, "description", "method", "destination", "metadata", "source_type", "statement_descriptor")
+	data, err := s.post(ctx, "/payouts", body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}

--- a/integrations/stripe/stripe.go
+++ b/integrations/stripe/stripe.go
@@ -71,15 +71,17 @@ func (s *stripe) CompactSpec(toolName mcp.ToolName) ([]mcp.CompactField, bool) {
 
 // --- HTTP helpers ---
 
-// doRequest performs a Stripe API call. For GET/DELETE, params are query string.
-// For POST, params are application/x-www-form-urlencoded body.
+// doRequest performs a Stripe API call. For GET, params are query string.
+// For POST and DELETE, params are application/x-www-form-urlencoded body
+// when non-empty (Stripe documents DELETE params like invoice_now/prorate
+// as body parameters).
 func (s *stripe) doRequest(ctx context.Context, method, path string, params map[string]any) (json.RawMessage, error) {
 	form := encodeForm(params)
 
 	fullURL := s.baseURL + path
 	var bodyReader io.Reader
 	switch method {
-	case http.MethodGet, http.MethodDelete:
+	case http.MethodGet:
 		if form != "" {
 			if strings.Contains(fullURL, "?") {
 				fullURL += "&" + form
@@ -87,8 +89,10 @@ func (s *stripe) doRequest(ctx context.Context, method, path string, params map[
 				fullURL += "?" + form
 			}
 		}
-	default:
-		bodyReader = strings.NewReader(form)
+	default: // POST, DELETE with body
+		if form != "" {
+			bodyReader = strings.NewReader(form)
+		}
 	}
 
 	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)

--- a/integrations/stripe/stripe.go
+++ b/integrations/stripe/stripe.go
@@ -1,0 +1,229 @@
+package stripe
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+type stripe struct {
+	apiKey  string
+	account string // optional Stripe-Account header (Connect)
+	client  *http.Client
+	baseURL string
+}
+
+var _ mcp.FieldCompactionIntegration = (*stripe)(nil)
+
+const maxResponseSize = 10 * 1024 * 1024 // 10 MB
+
+func New() mcp.Integration {
+	return &stripe{
+		client:  &http.Client{Timeout: 30 * time.Second},
+		baseURL: "https://api.stripe.com/v1",
+	}
+}
+
+func (s *stripe) Name() string { return "stripe" }
+
+func (s *stripe) Configure(_ context.Context, creds mcp.Credentials) error {
+	s.apiKey = creds["api_key"]
+	if s.apiKey == "" {
+		return fmt.Errorf("stripe: api_key is required")
+	}
+	if v := creds["base_url"]; v != "" {
+		s.baseURL = strings.TrimRight(v, "/")
+	}
+	s.account = creds["account"]
+	return nil
+}
+
+func (s *stripe) Healthy(ctx context.Context) bool {
+	_, err := s.get(ctx, "/balance", nil)
+	return err == nil
+}
+
+func (s *stripe) Tools() []mcp.ToolDefinition {
+	return tools
+}
+
+func (s *stripe) Execute(ctx context.Context, toolName mcp.ToolName, args map[string]any) (*mcp.ToolResult, error) {
+	fn, ok := dispatch[toolName]
+	if !ok {
+		return &mcp.ToolResult{Data: fmt.Sprintf("unknown tool: %s", toolName), IsError: true}, nil
+	}
+	return fn(ctx, s, args)
+}
+
+func (s *stripe) CompactSpec(toolName mcp.ToolName) ([]mcp.CompactField, bool) {
+	fields, ok := fieldCompactionSpecs[toolName]
+	return fields, ok
+}
+
+// --- HTTP helpers ---
+
+// doRequest performs a Stripe API call. For GET/DELETE, params are query string.
+// For POST, params are application/x-www-form-urlencoded body.
+func (s *stripe) doRequest(ctx context.Context, method, path string, params map[string]any) (json.RawMessage, error) {
+	form := encodeForm(params)
+
+	fullURL := s.baseURL + path
+	var bodyReader io.Reader
+	switch method {
+	case http.MethodGet, http.MethodDelete:
+		if form != "" {
+			if strings.Contains(fullURL, "?") {
+				fullURL += "&" + form
+			} else {
+				fullURL += "?" + form
+			}
+		}
+	default:
+		bodyReader = strings.NewReader(form)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+s.apiKey)
+	if bodyReader != nil {
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	}
+	if s.account != "" {
+		req.Header.Set("Stripe-Account", s.account)
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == 429 || resp.StatusCode >= 500 {
+		re := &mcp.RetryableError{StatusCode: resp.StatusCode, Err: fmt.Errorf("stripe API error (%d): %s", resp.StatusCode, string(data))}
+		re.RetryAfter = mcp.ParseRetryAfter(resp.Header.Get("Retry-After"))
+		return nil, re
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("stripe API error (%d): %s", resp.StatusCode, string(data))
+	}
+	if resp.StatusCode == 204 || len(data) == 0 {
+		return json.RawMessage(`{"status":"success"}`), nil
+	}
+	return json.RawMessage(data), nil
+}
+
+func (s *stripe) get(ctx context.Context, path string, params map[string]any) (json.RawMessage, error) {
+	return s.doRequest(ctx, http.MethodGet, path, params)
+}
+
+func (s *stripe) post(ctx context.Context, path string, params map[string]any) (json.RawMessage, error) {
+	return s.doRequest(ctx, http.MethodPost, path, params)
+}
+
+func (s *stripe) del(ctx context.Context, path string, params map[string]any) (json.RawMessage, error) {
+	return s.doRequest(ctx, http.MethodDelete, path, params)
+}
+
+// --- Form encoding ---
+
+// encodeForm flattens a params map into Stripe's bracket-notation
+// application/x-www-form-urlencoded representation.
+//   - {"metadata": {"k": "v"}}     → metadata[k]=v
+//   - {"items": [{"price":"p_1"}]} → items[0][price]=p_1
+//   - {"expand": ["customer"]}     → expand[0]=customer
+//   - scalar values are stringified directly
+//
+// Keys with empty/nil values are skipped to avoid sending empty Stripe params.
+func encodeForm(params map[string]any) string {
+	if len(params) == 0 {
+		return ""
+	}
+	vals := url.Values{}
+	for k, v := range params {
+		flatten(vals, k, v)
+	}
+	if len(vals) == 0 {
+		return ""
+	}
+	// Stable ordering for tests/idempotency.
+	keys := make([]string, 0, len(vals))
+	for k := range vals {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	for i, k := range keys {
+		for j, val := range vals[k] {
+			if i > 0 || j > 0 {
+				b.WriteByte('&')
+			}
+			b.WriteString(url.QueryEscape(k))
+			b.WriteByte('=')
+			b.WriteString(url.QueryEscape(val))
+		}
+	}
+	return b.String()
+}
+
+func flatten(out url.Values, key string, val any) {
+	switch v := val.(type) {
+	case nil:
+		return
+	case string:
+		if v == "" {
+			return
+		}
+		out.Add(key, v)
+	case bool:
+		out.Add(key, strconv.FormatBool(v))
+	case int:
+		out.Add(key, strconv.Itoa(v))
+	case int32:
+		out.Add(key, strconv.FormatInt(int64(v), 10))
+	case int64:
+		out.Add(key, strconv.FormatInt(v, 10))
+	case float64:
+		// Stripe amounts are integers in the smallest currency unit; JSON unmarshals
+		// numbers as float64. Render as int when there is no fractional part.
+		if v == float64(int64(v)) {
+			out.Add(key, strconv.FormatInt(int64(v), 10))
+		} else {
+			out.Add(key, strconv.FormatFloat(v, 'f', -1, 64))
+		}
+	case json.Number:
+		out.Add(key, v.String())
+	case map[string]any:
+		for k, sub := range v {
+			flatten(out, key+"["+k+"]", sub)
+		}
+	case []any:
+		for i, sub := range v {
+			flatten(out, key+"["+strconv.Itoa(i)+"]", sub)
+		}
+	case []string:
+		for i, sub := range v {
+			out.Add(key+"["+strconv.Itoa(i)+"]", sub)
+		}
+	default:
+		out.Add(key, fmt.Sprintf("%v", v))
+	}
+}
+
+// --- Handler signature + dispatch map ---
+
+type handlerFunc func(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error)

--- a/integrations/stripe/stripe_test.go
+++ b/integrations/stripe/stripe_test.go
@@ -2,8 +2,10 @@ package stripe
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -452,12 +454,20 @@ func TestCancelSubscription_UsesDELETE(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodDelete, r.Method)
 		assert.Equal(t, "/subscriptions/sub_42", r.URL.Path)
+		assert.Empty(t, r.URL.Query().Get("invoice_now"), "invoice_now should be in body, not query string")
+		assert.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
+		body, _ := io.ReadAll(r.Body)
+		parsed, _ := url.ParseQuery(string(body))
+		assert.Equal(t, "true", parsed.Get("invoice_now"), "invoice_now should be form-encoded in request body")
 		_, _ = w.Write([]byte(`{"id":"sub_42","status":"canceled"}`))
 	}))
 	defer ts.Close()
 
 	s := &stripe{apiKey: "sk_test", client: ts.Client(), baseURL: ts.URL}
-	result, err := s.Execute(context.Background(), "stripe_cancel_subscription", map[string]any{"id": "sub_42"})
+	result, err := s.Execute(context.Background(), "stripe_cancel_subscription", map[string]any{
+		"id":          "sub_42",
+		"invoice_now": true,
+	})
 	require.NoError(t, err)
 	assert.False(t, result.IsError)
 	assert.Contains(t, result.Data, "canceled")

--- a/integrations/stripe/stripe_test.go
+++ b/integrations/stripe/stripe_test.go
@@ -1,0 +1,486 @@
+package stripe
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	i := New()
+	require.NotNil(t, i)
+	assert.Equal(t, "stripe", i.Name())
+}
+
+func TestConfigure_Success(t *testing.T) {
+	i := New()
+	err := i.Configure(context.Background(), mcp.Credentials{"api_key": "sk_test_123"})
+	assert.NoError(t, err)
+}
+
+func TestConfigure_MissingAPIKey(t *testing.T) {
+	i := New()
+	err := i.Configure(context.Background(), mcp.Credentials{"api_key": ""})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "api_key is required")
+}
+
+func TestConfigure_CustomBaseURL(t *testing.T) {
+	s := &stripe{client: &http.Client{}, baseURL: "https://api.stripe.com/v1"}
+	err := s.Configure(context.Background(), mcp.Credentials{
+		"api_key":  "sk_test",
+		"base_url": "https://custom.stripe.example/v1/",
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "https://custom.stripe.example/v1", s.baseURL)
+}
+
+func TestConfigure_Account(t *testing.T) {
+	s := &stripe{client: &http.Client{}, baseURL: "https://api.stripe.com/v1"}
+	err := s.Configure(context.Background(), mcp.Credentials{
+		"api_key": "sk_test",
+		"account": "acct_123",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "acct_123", s.account)
+}
+
+func TestTools(t *testing.T) {
+	i := New()
+	tools := i.Tools()
+	assert.NotEmpty(t, tools)
+
+	for _, tool := range tools {
+		assert.NotEmpty(t, tool.Name, "tool has empty name")
+		assert.NotEmpty(t, tool.Description, "tool %s has empty description", tool.Name)
+	}
+}
+
+func TestTools_AllHaveStripePrefix(t *testing.T) {
+	i := New()
+	for _, tool := range i.Tools() {
+		assert.True(t, strings.HasPrefix(string(tool.Name), "stripe_"), "tool %s missing stripe_ prefix", tool.Name)
+	}
+}
+
+func TestTools_NoDuplicateNames(t *testing.T) {
+	i := New()
+	seen := make(map[mcp.ToolName]bool)
+	for _, tool := range i.Tools() {
+		assert.False(t, seen[tool.Name], "duplicate tool name: %s", tool.Name)
+		seen[tool.Name] = true
+	}
+}
+
+func TestExecute_UnknownTool(t *testing.T) {
+	s := &stripe{apiKey: "sk_test", client: &http.Client{}, baseURL: "http://localhost"}
+	result, err := s.Execute(context.Background(), "stripe_nonexistent", nil)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "unknown tool")
+}
+
+func TestDispatchMap_AllToolsCovered(t *testing.T) {
+	i := New()
+	for _, tool := range i.Tools() {
+		_, ok := dispatch[tool.Name]
+		assert.True(t, ok, "tool %s has no dispatch handler", tool.Name)
+	}
+}
+
+func TestDispatchMap_NoOrphanHandlers(t *testing.T) {
+	i := New()
+	toolNames := make(map[mcp.ToolName]bool)
+	for _, tool := range i.Tools() {
+		toolNames[tool.Name] = true
+	}
+	for name := range dispatch {
+		assert.True(t, toolNames[name], "dispatch handler %s has no tool definition", name)
+	}
+}
+
+// --- HTTP helper tests ---
+
+func TestDoRequest_GETSuccess(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer sk_test_123", r.Header.Get("Authorization"))
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"cus_abc"}`))
+	}))
+	defer ts.Close()
+
+	s := &stripe{apiKey: "sk_test_123", client: ts.Client(), baseURL: ts.URL}
+	data, err := s.get(context.Background(), "/customers/cus_abc", nil)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "cus_abc")
+}
+
+func TestDoRequest_StripeAccountHeader(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "acct_999", r.Header.Get("Stripe-Account"))
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer ts.Close()
+
+	s := &stripe{apiKey: "sk_test", account: "acct_999", client: ts.Client(), baseURL: ts.URL}
+	_, err := s.get(context.Background(), "/balance", nil)
+	require.NoError(t, err)
+}
+
+func TestDoRequest_APIError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(400)
+		_, _ = w.Write([]byte(`{"error":{"type":"invalid_request_error","message":"missing param"}}`))
+	}))
+	defer ts.Close()
+
+	s := &stripe{apiKey: "sk_test", client: ts.Client(), baseURL: ts.URL}
+	_, err := s.get(context.Background(), "/customers", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stripe API error (400)")
+}
+
+func TestDoRequest_RetryableOn429(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "2")
+		w.WriteHeader(429)
+		_, _ = w.Write([]byte(`{"error":"rate limit"}`))
+	}))
+	defer ts.Close()
+
+	s := &stripe{apiKey: "sk_test", client: ts.Client(), baseURL: ts.URL}
+	_, err := s.get(context.Background(), "/balance", nil)
+	require.Error(t, err)
+	re, ok := err.(*mcp.RetryableError)
+	require.True(t, ok, "expected *mcp.RetryableError, got %T", err)
+	assert.Equal(t, 429, re.StatusCode)
+}
+
+func TestDoRequest_RetryableOn500(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(503)
+	}))
+	defer ts.Close()
+
+	s := &stripe{apiKey: "sk_test", client: ts.Client(), baseURL: ts.URL}
+	_, err := s.get(context.Background(), "/balance", nil)
+	require.Error(t, err)
+	_, ok := err.(*mcp.RetryableError)
+	assert.True(t, ok)
+}
+
+func TestDoRequest_204NoContent(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(204)
+	}))
+	defer ts.Close()
+
+	s := &stripe{apiKey: "sk_test", client: ts.Client(), baseURL: ts.URL}
+	data, err := s.del(context.Background(), "/customers/cus_x", nil)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "success")
+}
+
+func TestPost_FormEncoded(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
+		_ = r.ParseForm()
+		assert.Equal(t, "alice@example.com", r.PostForm.Get("email"))
+		assert.Equal(t, "v1", r.PostForm.Get("metadata[k1]"))
+		_, _ = w.Write([]byte(`{"id":"cus_new","email":"alice@example.com"}`))
+	}))
+	defer ts.Close()
+
+	s := &stripe{apiKey: "sk_test", client: ts.Client(), baseURL: ts.URL}
+	data, err := s.post(context.Background(), "/customers", map[string]any{
+		"email":    "alice@example.com",
+		"metadata": map[string]any{"k1": "v1"},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "cus_new")
+}
+
+func TestDoRequest_GETWithQuery(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "10", r.URL.Query().Get("limit"))
+		assert.Equal(t, "alice@example.com", r.URL.Query().Get("email"))
+		_, _ = w.Write([]byte(`{"object":"list","data":[]}`))
+	}))
+	defer ts.Close()
+
+	s := &stripe{apiKey: "sk_test", client: ts.Client(), baseURL: ts.URL}
+	_, err := s.get(context.Background(), "/customers", map[string]any{
+		"limit": 10,
+		"email": "alice@example.com",
+	})
+	require.NoError(t, err)
+}
+
+// --- Form encoder tests ---
+
+func TestEncodeForm_Empty(t *testing.T) {
+	assert.Empty(t, encodeForm(nil))
+	assert.Empty(t, encodeForm(map[string]any{}))
+}
+
+func TestEncodeForm_Scalars(t *testing.T) {
+	out := encodeForm(map[string]any{
+		"a": "x",
+		"b": 42,
+		"c": true,
+	})
+	// keys sorted
+	assert.Equal(t, "a=x&b=42&c=true", out)
+}
+
+func TestEncodeForm_SkipsEmptyString(t *testing.T) {
+	out := encodeForm(map[string]any{"a": "", "b": "x"})
+	assert.Equal(t, "b=x", out)
+}
+
+func TestEncodeForm_NestedMap(t *testing.T) {
+	out := encodeForm(map[string]any{
+		"metadata": map[string]any{"plan": "pro", "tier": "gold"},
+	})
+	// keys are sorted; bracket-encoded keys URL-escaped
+	assert.Contains(t, out, "metadata%5Bplan%5D=pro")
+	assert.Contains(t, out, "metadata%5Btier%5D=gold")
+}
+
+func TestEncodeForm_ArrayOfObjects(t *testing.T) {
+	out := encodeForm(map[string]any{
+		"items": []any{
+			map[string]any{"price": "price_1"},
+			map[string]any{"price": "price_2"},
+		},
+	})
+	assert.Contains(t, out, "items%5B0%5D%5Bprice%5D=price_1")
+	assert.Contains(t, out, "items%5B1%5D%5Bprice%5D=price_2")
+}
+
+func TestEncodeForm_FloatAsInt(t *testing.T) {
+	// JSON numbers come in as float64; integral values should render as ints.
+	out := encodeForm(map[string]any{"amount": float64(2000)})
+	assert.Equal(t, "amount=2000", out)
+}
+
+func TestEncodeForm_StringSlice(t *testing.T) {
+	out := encodeForm(map[string]any{"expand": []string{"customer", "default_payment_method"}})
+	assert.Contains(t, out, "expand%5B0%5D=customer")
+	assert.Contains(t, out, "expand%5B1%5D=default_payment_method")
+}
+
+// --- Param helper tests ---
+
+func TestListParamsFrom(t *testing.T) {
+	args := map[string]any{
+		"limit":          50,
+		"starting_after": "cus_abc",
+		"email":          "alice@example.com",
+		"unused":         "ignored",
+	}
+	out := listParamsFrom(args, "email")
+	assert.Equal(t, 50, out["limit"])
+	assert.Equal(t, "cus_abc", out["starting_after"])
+	assert.Equal(t, "alice@example.com", out["email"])
+	_, hasUnused := out["unused"]
+	assert.False(t, hasUnused)
+}
+
+func TestSearchParamsFrom(t *testing.T) {
+	args := map[string]any{"query": "email:'a@b.com'", "limit": 25, "page": "next_x", "extra": "drop"}
+	out := searchParamsFrom(args)
+	assert.Equal(t, "email:'a@b.com'", out["query"])
+	assert.Equal(t, 25, out["limit"])
+	assert.Equal(t, "next_x", out["page"])
+	_, hasExtra := out["extra"]
+	assert.False(t, hasExtra)
+}
+
+// --- Handler integration tests ---
+
+func TestGetBalance(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/balance", r.URL.Path)
+		_, _ = w.Write([]byte(`{"object":"balance","available":[{"amount":1000,"currency":"usd"}]}`))
+	}))
+	defer ts.Close()
+
+	s := &stripe{apiKey: "sk_test", client: ts.Client(), baseURL: ts.URL}
+	result, err := s.Execute(context.Background(), "stripe_get_balance", map[string]any{})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "available")
+}
+
+func TestListCustomers(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/customers", r.URL.Path)
+		assert.Equal(t, "alice@example.com", r.URL.Query().Get("email"))
+		_, _ = w.Write([]byte(`{"object":"list","has_more":false,"data":[{"id":"cus_1","email":"alice@example.com"}]}`))
+	}))
+	defer ts.Close()
+
+	s := &stripe{apiKey: "sk_test", client: ts.Client(), baseURL: ts.URL}
+	result, err := s.Execute(context.Background(), "stripe_list_customers", map[string]any{
+		"email": "alice@example.com",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "cus_1")
+}
+
+func TestRetrieveCustomer(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/customers/cus_42", r.URL.Path)
+		_, _ = w.Write([]byte(`{"id":"cus_42","email":"x@example.com"}`))
+	}))
+	defer ts.Close()
+
+	s := &stripe{apiKey: "sk_test", client: ts.Client(), baseURL: ts.URL}
+	result, err := s.Execute(context.Background(), "stripe_retrieve_customer", map[string]any{"id": "cus_42"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "cus_42")
+}
+
+func TestCreateCustomer(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/customers", r.URL.Path)
+		assert.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
+		_ = r.ParseForm()
+		assert.Equal(t, "Alice", r.PostForm.Get("name"))
+		assert.Equal(t, "pro", r.PostForm.Get("metadata[plan]"))
+		_, _ = w.Write([]byte(`{"id":"cus_new","name":"Alice"}`))
+	}))
+	defer ts.Close()
+
+	s := &stripe{apiKey: "sk_test", client: ts.Client(), baseURL: ts.URL}
+	result, err := s.Execute(context.Background(), "stripe_create_customer", map[string]any{
+		"name":     "Alice",
+		"metadata": map[string]any{"plan": "pro"},
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "cus_new")
+}
+
+func TestUpdateCustomer(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/customers/cus_42", r.URL.Path)
+		_ = r.ParseForm()
+		assert.Equal(t, "new@example.com", r.PostForm.Get("email"))
+		_, _ = w.Write([]byte(`{"id":"cus_42","email":"new@example.com"}`))
+	}))
+	defer ts.Close()
+
+	s := &stripe{apiKey: "sk_test", client: ts.Client(), baseURL: ts.URL}
+	result, err := s.Execute(context.Background(), "stripe_update_customer", map[string]any{
+		"id":    "cus_42",
+		"email": "new@example.com",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "new@example.com")
+}
+
+func TestDeleteCustomer(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/customers/cus_42", r.URL.Path)
+		_, _ = w.Write([]byte(`{"id":"cus_42","deleted":true}`))
+	}))
+	defer ts.Close()
+
+	s := &stripe{apiKey: "sk_test", client: ts.Client(), baseURL: ts.URL}
+	result, err := s.Execute(context.Background(), "stripe_delete_customer", map[string]any{"id": "cus_42"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "deleted")
+}
+
+func TestSearchCustomers(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/customers/search", r.URL.Path)
+		assert.Equal(t, `email:"a@b.com"`, r.URL.Query().Get("query"))
+		_, _ = w.Write([]byte(`{"object":"search_result","data":[],"has_more":false}`))
+	}))
+	defer ts.Close()
+
+	s := &stripe{apiKey: "sk_test", client: ts.Client(), baseURL: ts.URL}
+	result, err := s.Execute(context.Background(), "stripe_search_customers", map[string]any{
+		"query": `email:"a@b.com"`,
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+}
+
+func TestCreatePaymentIntent(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/payment_intents", r.URL.Path)
+		_ = r.ParseForm()
+		assert.Equal(t, "2000", r.PostForm.Get("amount"))
+		assert.Equal(t, "usd", r.PostForm.Get("currency"))
+		_, _ = w.Write([]byte(`{"id":"pi_new","amount":2000,"currency":"usd"}`))
+	}))
+	defer ts.Close()
+
+	s := &stripe{apiKey: "sk_test", client: ts.Client(), baseURL: ts.URL}
+	result, err := s.Execute(context.Background(), "stripe_create_payment_intent", map[string]any{
+		"amount":   float64(2000),
+		"currency": "usd",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "pi_new")
+}
+
+func TestCancelSubscription_UsesDELETE(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/subscriptions/sub_42", r.URL.Path)
+		_, _ = w.Write([]byte(`{"id":"sub_42","status":"canceled"}`))
+	}))
+	defer ts.Close()
+
+	s := &stripe{apiKey: "sk_test", client: ts.Client(), baseURL: ts.URL}
+	result, err := s.Execute(context.Background(), "stripe_cancel_subscription", map[string]any{"id": "sub_42"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "canceled")
+}
+
+func TestListInvoices(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/invoices", r.URL.Path)
+		assert.Equal(t, "open", r.URL.Query().Get("status"))
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"in_1","status":"open"}],"has_more":false}`))
+	}))
+	defer ts.Close()
+
+	s := &stripe{apiKey: "sk_test", client: ts.Client(), baseURL: ts.URL}
+	result, err := s.Execute(context.Background(), "stripe_list_invoices", map[string]any{"status": "open"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "in_1")
+}
+
+func TestRetrieveBalanceTransaction_MissingID(t *testing.T) {
+	s := &stripe{apiKey: "sk_test", client: &http.Client{}, baseURL: "http://localhost"}
+	result, err := s.Execute(context.Background(), "stripe_retrieve_balance_transaction", map[string]any{})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+}

--- a/integrations/stripe/subscriptions.go
+++ b/integrations/stripe/subscriptions.go
@@ -1,0 +1,249 @@
+package stripe
+
+import (
+	"context"
+	"fmt"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+// --- Subscriptions ---
+
+func listSubscriptions(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	params := listParamsFrom(args, "customer", "price", "status", "collection_method", "created", "current_period_end", "current_period_start")
+	data, err := s.get(ctx, "/subscriptions", params)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func retrieveSubscription(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := s.get(ctx, fmt.Sprintf("/subscriptions/%s", id), nil)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func searchSubscriptions(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	_ = r.Str("query")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := s.get(ctx, "/subscriptions/search", searchParamsFrom(args))
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func createSubscription(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	customer := r.Str("customer")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if _, ok := args["items"]; !ok {
+		return mcp.ErrResult(fmt.Errorf("stripe: items is required"))
+	}
+	body := map[string]any{
+		"customer": customer,
+		"items":    args["items"],
+	}
+	copyIfPresent(body, args, "default_payment_method", "default_source", "trial_period_days", "trial_end", "trial_from_plan", "collection_method", "days_until_due", "coupon", "promotion_code", "metadata", "off_session", "payment_behavior", "proration_behavior", "billing_cycle_anchor", "cancel_at", "cancel_at_period_end", "automatic_tax", "description", "currency")
+	data, err := s.post(ctx, "/subscriptions", body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func updateSubscription(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	body := map[string]any{}
+	copyIfPresent(body, args, "items", "cancel_at_period_end", "cancel_at", "default_payment_method", "default_source", "proration_behavior", "trial_end", "metadata", "pause_collection", "collection_method", "days_until_due", "coupon", "promotion_code", "description", "billing_cycle_anchor", "payment_behavior", "automatic_tax")
+	data, err := s.post(ctx, fmt.Sprintf("/subscriptions/%s", id), body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func cancelSubscription(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	// Stripe's cancel uses DELETE for immediate cancellation.
+	// Pass invoice_now / prorate / cancellation_details as form params.
+	body := map[string]any{}
+	copyIfPresent(body, args, "invoice_now", "prorate", "cancellation_details")
+	data, err := s.del(ctx, fmt.Sprintf("/subscriptions/%s", id), body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+// --- Subscription Items ---
+
+func listSubscriptionItems(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	sub := r.Str("subscription")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	params := listParamsFrom(args)
+	params["subscription"] = sub
+	data, err := s.get(ctx, "/subscription_items", params)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func retrieveSubscriptionItem(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := s.get(ctx, fmt.Sprintf("/subscription_items/%s", id), nil)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+// --- Products ---
+
+func listProducts(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	params := listParamsFrom(args, "active", "ids", "shippable", "url", "created")
+	data, err := s.get(ctx, "/products", params)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func retrieveProduct(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := s.get(ctx, fmt.Sprintf("/products/%s", id), nil)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func createProduct(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	name := r.Str("name")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	body := map[string]any{"name": name}
+	copyIfPresent(body, args, "id", "description", "active", "default_price_data", "images", "metadata", "shippable", "tax_code", "url", "package_dimensions", "statement_descriptor", "unit_label", "features")
+	data, err := s.post(ctx, "/products", body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func updateProduct(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	body := map[string]any{}
+	copyIfPresent(body, args, "name", "description", "active", "default_price", "images", "metadata", "shippable", "url", "tax_code", "package_dimensions", "statement_descriptor", "unit_label", "features")
+	data, err := s.post(ctx, fmt.Sprintf("/products/%s", id), body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func deleteProduct(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := s.del(ctx, fmt.Sprintf("/products/%s", id), nil)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+// --- Prices ---
+
+func listPrices(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	params := listParamsFrom(args, "product", "active", "currency", "type", "created", "lookup_keys")
+	data, err := s.get(ctx, "/prices", params)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func retrievePrice(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := s.get(ctx, fmt.Sprintf("/prices/%s", id), nil)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func createPrice(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	currency := r.Str("currency")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	body := map[string]any{"currency": currency}
+	copyIfPresent(body, args, "product", "product_data", "unit_amount", "unit_amount_decimal", "recurring", "nickname", "active", "billing_scheme", "tiers", "tiers_mode", "metadata", "lookup_key", "transfer_lookup_key", "tax_behavior", "currency_options")
+	data, err := s.post(ctx, "/prices", body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func updatePrice(ctx context.Context, s *stripe, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	body := map[string]any{}
+	copyIfPresent(body, args, "active", "nickname", "metadata", "lookup_key", "transfer_lookup_key", "tax_behavior", "currency_options")
+	data, err := s.post(ctx, fmt.Sprintf("/prices/%s", id), body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}

--- a/integrations/stripe/tools.go
+++ b/integrations/stripe/tools.go
@@ -1,0 +1,770 @@
+package stripe
+
+import mcp "github.com/daltoniam/switchboard"
+
+// Standard list-pagination params reused across many list tools.
+var listParams = map[string]string{
+	"limit":          "Number of objects to return (1-100, default 10)",
+	"starting_after": "Cursor for pagination — an object ID for the next page",
+	"ending_before":  "Cursor for pagination — an object ID for the previous page",
+}
+
+var tools = []mcp.ToolDefinition{
+	// ── Balance ──────────────────────────────────────────────────────
+	{
+		Name:        mcp.ToolName("stripe_get_balance"),
+		Description: "Get the current Stripe account balance (available, pending, connect_reserved). Start here to inspect funds on the Stripe account.",
+	},
+	{
+		Name:        mcp.ToolName("stripe_list_balance_transactions"),
+		Description: "List balance transactions (charges, refunds, payouts, fees, transfers) that affected the Stripe account balance. Use for accounting reconciliation, financial audits, fee analysis, and tracking money movement on the Stripe platform.",
+		Parameters: mergeParams(listParams, map[string]string{
+			"type":     "Filter by type (charge, refund, payout, transfer, adjustment, fee, etc.)",
+			"currency": "Three-letter ISO currency code lowercase (e.g. usd)",
+			"payout":   "Filter to transactions paid out in this payout ID",
+			"source":   "Filter by source ID (charge, refund, etc.)",
+		}),
+	},
+	{
+		Name:        mcp.ToolName("stripe_retrieve_balance_transaction"),
+		Description: "Retrieve (get) a single balance transaction by ID.",
+		Parameters:  map[string]string{"id": "Balance transaction ID (e.g. txn_...)"},
+		Required:    []string{"id"},
+	},
+
+	// ── Customers ────────────────────────────────────────────────────
+	{
+		Name:        mcp.ToolName("stripe_list_customers"),
+		Description: "List Stripe customers. Use for browsing payers, finding accounts by email, exporting customer rosters, or paginating the customer directory.",
+		Parameters: mergeParams(listParams, map[string]string{
+			"email":   "Filter by exact email match",
+			"created": "Filter by created timestamp (Unix epoch seconds) — pass a number or use nested keys gt/gte/lt/lte for ranges",
+		}),
+	},
+	{
+		Name:        mcp.ToolName("stripe_retrieve_customer"),
+		Description: "Retrieve (get) a single customer by ID including their default payment method, billing address, and metadata.",
+		Parameters:  map[string]string{"id": "Customer ID (e.g. cus_...)"},
+		Required:    []string{"id"},
+	},
+	{
+		Name:        mcp.ToolName("stripe_search_customers"),
+		Description: "Search Stripe customers using Stripe search query language (e.g. email:\"alice@example.com\" or metadata['plan']:\"pro\"). Returns matching customer records.",
+		Parameters: map[string]string{
+			"query": "Stripe search query syntax",
+			"limit": "Number of results (1-100)",
+			"page":  "Cursor for pagination (from prior response.next_page)",
+		},
+		Required: []string{"query"},
+	},
+	{
+		Name:        mcp.ToolName("stripe_create_customer"),
+		Description: "Create a new Stripe customer record for a payer.",
+		Parameters: map[string]string{
+			"email":       "Customer email address",
+			"name":        "Full customer name",
+			"phone":       "Phone number",
+			"description": "Arbitrary description for internal use",
+			"metadata":    "Object of key-value strings to attach (max 50 keys)",
+			"address":     "Object with line1, line2, city, state, postal_code, country",
+			"shipping":    "Object with name, phone, address",
+		},
+	},
+	{
+		Name:        mcp.ToolName("stripe_update_customer"),
+		Description: "Update (edit) a customer's profile, contact info, default payment method, or metadata.",
+		Parameters: map[string]string{
+			"id":               "Customer ID",
+			"email":            "New email",
+			"name":             "New name",
+			"phone":            "New phone",
+			"description":      "New description",
+			"metadata":         "Object to merge into existing metadata (set key to empty string to clear it)",
+			"default_source":   "Default payment source ID",
+			"invoice_settings": "Object with default_payment_method, custom_fields, footer",
+			"address":          "Billing address object",
+			"shipping":         "Shipping address object",
+		},
+		Required: []string{"id"},
+	},
+	{
+		Name:        mcp.ToolName("stripe_delete_customer"),
+		Description: "Delete (remove) a customer permanently. Cancels active subscriptions and disassociates payment methods.",
+		Parameters:  map[string]string{"id": "Customer ID"},
+		Required:    []string{"id"},
+	},
+
+	// ── Charges ──────────────────────────────────────────────────────
+	{
+		Name:        mcp.ToolName("stripe_list_charges"),
+		Description: "List charges (card and bank transactions) processed on the Stripe account. Use for transaction history, sales reports, revenue analytics, and finding individual successful or failed payments.",
+		Parameters: mergeParams(listParams, map[string]string{
+			"customer":       "Filter by customer ID",
+			"payment_intent": "Filter by payment intent ID",
+			"transfer_group": "Filter by transfer group",
+			"created":        "Filter by creation timestamp",
+		}),
+	},
+	{
+		Name:        mcp.ToolName("stripe_retrieve_charge"),
+		Description: "Retrieve (get) a single charge by ID with full details (amount, currency, status, customer, payment_method, refunds, dispute, outcome).",
+		Parameters:  map[string]string{"id": "Charge ID (e.g. ch_...)"},
+		Required:    []string{"id"},
+	},
+	{
+		Name:        mcp.ToolName("stripe_search_charges"),
+		Description: "Search charges using Stripe search query language (e.g. amount>1000 AND status:\"succeeded\").",
+		Parameters: map[string]string{
+			"query": "Stripe search query",
+			"limit": "Number of results (1-100)",
+			"page":  "Cursor for pagination",
+		},
+		Required: []string{"query"},
+	},
+	{
+		Name:        mcp.ToolName("stripe_capture_charge"),
+		Description: "Capture a previously authorized but uncaptured charge (manual capture flow).",
+		Parameters: map[string]string{
+			"id":     "Charge ID",
+			"amount": "Optional amount to capture in smallest currency unit (cents). Defaults to full authorized amount.",
+		},
+		Required: []string{"id"},
+	},
+
+	// ── Payment Intents ──────────────────────────────────────────────
+	{
+		Name:        mcp.ToolName("stripe_list_payment_intents"),
+		Description: "List PaymentIntents — the modern payment flow object representing intent to collect from a customer. Use for monitoring in-progress, succeeded, requires_action, or failed payments.",
+		Parameters: mergeParams(listParams, map[string]string{
+			"customer": "Filter by customer ID",
+			"created":  "Filter by creation timestamp",
+		}),
+	},
+	{
+		Name:        mcp.ToolName("stripe_retrieve_payment_intent"),
+		Description: "Retrieve (get) a single PaymentIntent by ID with status, next_action, latest_charge, and client_secret.",
+		Parameters:  map[string]string{"id": "PaymentIntent ID (e.g. pi_...)"},
+		Required:    []string{"id"},
+	},
+	{
+		Name:        mcp.ToolName("stripe_create_payment_intent"),
+		Description: "Create a new PaymentIntent to charge a customer. Amounts are in the smallest currency unit (e.g. cents for USD).",
+		Parameters: map[string]string{
+			"amount":               "Amount in smallest currency unit (e.g. 1099 = $10.99)",
+			"currency":             "Three-letter ISO currency lowercase (e.g. usd)",
+			"customer":             "Customer ID to associate with this payment",
+			"payment_method":       "Payment method ID to charge",
+			"payment_method_types": "Array of payment method types (e.g. [\"card\"])",
+			"description":          "Arbitrary description shown to the customer",
+			"receipt_email":        "Email address to send receipt to",
+			"statement_descriptor": "Up to 22 chars shown on the customer's statement",
+			"capture_method":       "automatic or manual",
+			"confirm":              "If true, confirm the PaymentIntent in the same request (boolean)",
+			"off_session":          "Boolean indicating customer is not present",
+			"metadata":             "Object of key-value strings",
+		},
+		Required: []string{"amount", "currency"},
+	},
+	{
+		Name:        mcp.ToolName("stripe_update_payment_intent"),
+		Description: "Update (edit) a PaymentIntent before it is confirmed.",
+		Parameters: map[string]string{
+			"id":             "PaymentIntent ID",
+			"amount":         "New amount in smallest currency unit",
+			"currency":       "Currency code",
+			"customer":       "Customer ID",
+			"description":    "New description",
+			"metadata":       "Metadata object",
+			"payment_method": "Payment method ID",
+			"receipt_email":  "Receipt email address",
+		},
+		Required: []string{"id"},
+	},
+	{
+		Name:        mcp.ToolName("stripe_confirm_payment_intent"),
+		Description: "Confirm a PaymentIntent to attempt to collect payment.",
+		Parameters: map[string]string{
+			"id":             "PaymentIntent ID",
+			"payment_method": "Payment method ID to attach for confirmation",
+			"return_url":     "URL to redirect after 3DS/redirect-based authentication",
+			"off_session":    "Boolean — confirming on behalf of an absent customer",
+		},
+		Required: []string{"id"},
+	},
+	{
+		Name:        mcp.ToolName("stripe_cancel_payment_intent"),
+		Description: "Cancel a PaymentIntent that is in a cancelable state (requires_payment_method, requires_capture, requires_confirmation, requires_action, processing).",
+		Parameters: map[string]string{
+			"id":                  "PaymentIntent ID",
+			"cancellation_reason": "duplicate, fraudulent, requested_by_customer, abandoned",
+		},
+		Required: []string{"id"},
+	},
+	{
+		Name:        mcp.ToolName("stripe_search_payment_intents"),
+		Description: "Search PaymentIntents with Stripe search query (e.g. status:\"requires_action\" AND amount>5000).",
+		Parameters: map[string]string{
+			"query": "Stripe search query",
+			"limit": "Number of results",
+			"page":  "Cursor for pagination",
+		},
+		Required: []string{"query"},
+	},
+
+	// ── Refunds ──────────────────────────────────────────────────────
+	{
+		Name:        mcp.ToolName("stripe_list_refunds"),
+		Description: "List refunds processed on the Stripe account. Use for reviewing returned money, refund audits, and tracking refund status.",
+		Parameters: mergeParams(listParams, map[string]string{
+			"charge":         "Filter by charge ID",
+			"payment_intent": "Filter by payment intent ID",
+			"created":        "Filter by creation timestamp",
+		}),
+	},
+	{
+		Name:        mcp.ToolName("stripe_retrieve_refund"),
+		Description: "Retrieve (get) a single refund by ID.",
+		Parameters:  map[string]string{"id": "Refund ID (e.g. re_...)"},
+		Required:    []string{"id"},
+	},
+	{
+		Name:        mcp.ToolName("stripe_create_refund"),
+		Description: "Create a refund (full or partial) for a charge or PaymentIntent. Returns money to the customer.",
+		Parameters: map[string]string{
+			"charge":                 "Charge ID to refund (one of charge or payment_intent required)",
+			"payment_intent":         "PaymentIntent ID to refund",
+			"amount":                 "Amount to refund in smallest currency unit (defaults to full)",
+			"reason":                 "duplicate, fraudulent, or requested_by_customer",
+			"refund_application_fee": "Boolean — whether to refund the application fee",
+			"reverse_transfer":       "Boolean — reverse the transfer to a connected account",
+			"metadata":               "Metadata object",
+		},
+	},
+	{
+		Name:        mcp.ToolName("stripe_update_refund"),
+		Description: "Update (edit) a refund's metadata.",
+		Parameters: map[string]string{
+			"id":       "Refund ID",
+			"metadata": "Metadata object to merge",
+		},
+		Required: []string{"id"},
+	},
+
+	// ── Disputes ─────────────────────────────────────────────────────
+	{
+		Name:        mcp.ToolName("stripe_list_disputes"),
+		Description: "List chargeback disputes filed against charges on the Stripe account. Use for fraud monitoring, chargeback response workflows, and dispute analytics.",
+		Parameters: mergeParams(listParams, map[string]string{
+			"charge":         "Filter by charge ID",
+			"payment_intent": "Filter by payment intent ID",
+			"created":        "Filter by creation timestamp",
+		}),
+	},
+	{
+		Name:        mcp.ToolName("stripe_retrieve_dispute"),
+		Description: "Retrieve (get) a single dispute by ID including evidence and status.",
+		Parameters:  map[string]string{"id": "Dispute ID (e.g. dp_...)"},
+		Required:    []string{"id"},
+	},
+	{
+		Name:        mcp.ToolName("stripe_update_dispute"),
+		Description: "Update (edit) a dispute to submit evidence for chargeback response.",
+		Parameters: map[string]string{
+			"id":       "Dispute ID",
+			"evidence": "Evidence object (e.g. customer_communication, receipt, service_documentation, shipping_documentation, etc.)",
+			"submit":   "Boolean — submit evidence immediately",
+			"metadata": "Metadata object",
+		},
+		Required: []string{"id"},
+	},
+
+	// ── Payouts ──────────────────────────────────────────────────────
+	{
+		Name:        mcp.ToolName("stripe_list_payouts"),
+		Description: "List payouts (transfers from the Stripe balance to a bank account). Use for cash-out tracking, settlement reconciliation, and finance reports.",
+		Parameters: mergeParams(listParams, map[string]string{
+			"status":       "Filter by status (paid, pending, in_transit, canceled, failed)",
+			"destination":  "Filter by bank account or card destination ID",
+			"arrival_date": "Filter by arrival_date timestamp",
+			"created":      "Filter by creation timestamp",
+		}),
+	},
+	{
+		Name:        mcp.ToolName("stripe_retrieve_payout"),
+		Description: "Retrieve (get) a single payout by ID.",
+		Parameters:  map[string]string{"id": "Payout ID (e.g. po_...)"},
+		Required:    []string{"id"},
+	},
+	{
+		Name:        mcp.ToolName("stripe_create_payout"),
+		Description: "Create a manual payout from the Stripe balance to the default bank account.",
+		Parameters: map[string]string{
+			"amount":      "Amount in smallest currency unit",
+			"currency":    "Three-letter ISO currency lowercase",
+			"description": "Description",
+			"method":      "standard or instant",
+			"destination": "Bank account or debit card ID (optional override)",
+			"metadata":    "Metadata object",
+		},
+		Required: []string{"amount", "currency"},
+	},
+
+	// ── Subscriptions ────────────────────────────────────────────────
+	{
+		Name:        mcp.ToolName("stripe_list_subscriptions"),
+		Description: "List recurring billing subscriptions. Use for MRR/ARR reports, churn analysis, active customer counts, and finding subscriptions in trial, past_due, or canceled state.",
+		Parameters: mergeParams(listParams, map[string]string{
+			"customer":          "Filter by customer ID",
+			"price":             "Filter by price ID",
+			"status":            "Filter by status (active, past_due, unpaid, canceled, incomplete, incomplete_expired, trialing, all)",
+			"collection_method": "charge_automatically or send_invoice",
+			"created":           "Filter by creation timestamp",
+		}),
+	},
+	{
+		Name:        mcp.ToolName("stripe_retrieve_subscription"),
+		Description: "Retrieve (get) a single subscription by ID including items, current period, and billing cycle.",
+		Parameters:  map[string]string{"id": "Subscription ID (e.g. sub_...)"},
+		Required:    []string{"id"},
+	},
+	{
+		Name:        mcp.ToolName("stripe_search_subscriptions"),
+		Description: "Search subscriptions using Stripe search query (e.g. status:\"trialing\" AND created>1700000000).",
+		Parameters: map[string]string{
+			"query": "Stripe search query",
+			"limit": "Number of results",
+			"page":  "Cursor for pagination",
+		},
+		Required: []string{"query"},
+	},
+	{
+		Name:        mcp.ToolName("stripe_create_subscription"),
+		Description: "Create a new subscription that recurringly bills a customer for one or more prices.",
+		Parameters: map[string]string{
+			"customer":               "Customer ID to subscribe (required)",
+			"items":                  "Array of subscription items, each with a 'price' ID and optional 'quantity'",
+			"default_payment_method": "Payment method ID to use for invoices",
+			"trial_period_days":      "Number of days for free trial",
+			"trial_end":              "Unix timestamp when trial ends (or 'now')",
+			"collection_method":      "charge_automatically or send_invoice",
+			"days_until_due":         "Days until invoice is due (only for send_invoice)",
+			"coupon":                 "Coupon ID to apply",
+			"metadata":               "Metadata object",
+		},
+		Required: []string{"customer", "items"},
+	},
+	{
+		Name:        mcp.ToolName("stripe_update_subscription"),
+		Description: "Update (edit) a subscription's items, prices, quantities, billing settings, or metadata.",
+		Parameters: map[string]string{
+			"id":                     "Subscription ID",
+			"items":                  "Updated items array — each item may include 'id' (existing item), 'price', 'quantity', or 'deleted':true",
+			"cancel_at_period_end":   "Boolean — cancel at end of current period",
+			"default_payment_method": "Payment method ID",
+			"proration_behavior":     "create_prorations, none, or always_invoice",
+			"trial_end":              "Unix timestamp or 'now'",
+			"metadata":               "Metadata object",
+			"pause_collection":       "Object with behavior (keep_as_draft, mark_uncollectible, void) and resumes_at",
+		},
+		Required: []string{"id"},
+	},
+	{
+		Name:        mcp.ToolName("stripe_cancel_subscription"),
+		Description: "Cancel a subscription immediately (or at period end via stripe_update_subscription with cancel_at_period_end).",
+		Parameters: map[string]string{
+			"id":                   "Subscription ID",
+			"invoice_now":          "Boolean — generate a final invoice for unbilled usage",
+			"prorate":              "Boolean — credit prorated unused time",
+			"cancellation_details": "Object with comment and feedback",
+		},
+		Required: []string{"id"},
+	},
+
+	// ── Subscription Items ───────────────────────────────────────────
+	{
+		Name:        mcp.ToolName("stripe_list_subscription_items"),
+		Description: "List items (line items) belonging to a subscription.",
+		Parameters: mergeParams(listParams, map[string]string{
+			"subscription": "Subscription ID",
+		}),
+		Required: []string{"subscription"},
+	},
+	{
+		Name:        mcp.ToolName("stripe_retrieve_subscription_item"),
+		Description: "Retrieve (get) a single subscription item by ID.",
+		Parameters:  map[string]string{"id": "Subscription item ID (e.g. si_...)"},
+		Required:    []string{"id"},
+	},
+
+	// ── Products ─────────────────────────────────────────────────────
+	{
+		Name:        mcp.ToolName("stripe_list_products"),
+		Description: "List products (goods or services sold on Stripe). Use for product catalog browsing and finding SKUs.",
+		Parameters: mergeParams(listParams, map[string]string{
+			"active":    "Filter by active (true/false)",
+			"ids":       "Comma-separated product IDs",
+			"shippable": "Filter shippable goods (true/false)",
+			"url":       "Filter by URL",
+		}),
+	},
+	{
+		Name:        mcp.ToolName("stripe_retrieve_product"),
+		Description: "Retrieve (get) a single product by ID.",
+		Parameters:  map[string]string{"id": "Product ID (e.g. prod_...)"},
+		Required:    []string{"id"},
+	},
+	{
+		Name:        mcp.ToolName("stripe_create_product"),
+		Description: "Create a new product to sell.",
+		Parameters: map[string]string{
+			"name":               "Product name (required)",
+			"description":        "Product description",
+			"active":             "Boolean — whether the product can be used",
+			"default_price_data": "Object describing the default price (currency, unit_amount, recurring)",
+			"images":             "Array of image URLs",
+			"metadata":           "Metadata object",
+			"shippable":          "Boolean — whether the product is shippable",
+			"tax_code":           "Tax code ID",
+			"url":                "Product URL",
+		},
+		Required: []string{"name"},
+	},
+	{
+		Name:        mcp.ToolName("stripe_update_product"),
+		Description: "Update (edit) a product's name, description, images, or metadata.",
+		Parameters: map[string]string{
+			"id":            "Product ID",
+			"name":          "New name",
+			"description":   "New description",
+			"active":        "Boolean",
+			"default_price": "Default price ID",
+			"images":        "Array of image URLs",
+			"metadata":      "Metadata object",
+			"url":           "Product URL",
+		},
+		Required: []string{"id"},
+	},
+	{
+		Name:        mcp.ToolName("stripe_delete_product"),
+		Description: "Delete (remove) a product. Only succeeds if no prices reference it.",
+		Parameters:  map[string]string{"id": "Product ID"},
+		Required:    []string{"id"},
+	},
+
+	// ── Prices ───────────────────────────────────────────────────────
+	{
+		Name:        mcp.ToolName("stripe_list_prices"),
+		Description: "List prices attached to products. Each price defines how much and how often to charge.",
+		Parameters: mergeParams(listParams, map[string]string{
+			"product":  "Filter by product ID",
+			"active":   "Filter by active",
+			"currency": "Filter by currency",
+			"type":     "one_time or recurring",
+		}),
+	},
+	{
+		Name:        mcp.ToolName("stripe_retrieve_price"),
+		Description: "Retrieve (get) a single price by ID.",
+		Parameters:  map[string]string{"id": "Price ID (e.g. price_...)"},
+		Required:    []string{"id"},
+	},
+	{
+		Name:        mcp.ToolName("stripe_create_price"),
+		Description: "Create a new price for a product (one-time or recurring).",
+		Parameters: map[string]string{
+			"product":        "Product ID (required if product_data not given)",
+			"product_data":   "Inline product object with name to create alongside the price",
+			"currency":       "Three-letter ISO currency lowercase (required)",
+			"unit_amount":    "Price in smallest currency unit (required for fixed pricing)",
+			"recurring":      "Object with interval (day/week/month/year) and interval_count",
+			"nickname":       "Internal display name",
+			"active":         "Boolean",
+			"billing_scheme": "per_unit or tiered",
+			"tiers":          "Array of tier objects (for tiered pricing)",
+			"tiers_mode":     "graduated or volume",
+			"metadata":       "Metadata object",
+		},
+		Required: []string{"currency"},
+	},
+	{
+		Name:        mcp.ToolName("stripe_update_price"),
+		Description: "Update (edit) a price's nickname, active flag, or metadata. Note: most fields are immutable on existing prices.",
+		Parameters: map[string]string{
+			"id":       "Price ID",
+			"active":   "Boolean",
+			"nickname": "Nickname",
+			"metadata": "Metadata object",
+		},
+		Required: []string{"id"},
+	},
+
+	// ── Invoices ─────────────────────────────────────────────────────
+	{
+		Name:        mcp.ToolName("stripe_list_invoices"),
+		Description: "List invoices on the Stripe account. Use for billing audits, finding past_due/open/paid invoices, and revenue reporting.",
+		Parameters: mergeParams(listParams, map[string]string{
+			"customer":          "Filter by customer ID",
+			"subscription":      "Filter by subscription ID",
+			"status":            "draft, open, paid, uncollectible, void",
+			"collection_method": "charge_automatically or send_invoice",
+			"created":           "Filter by creation timestamp",
+			"due_date":          "Filter by due_date timestamp",
+		}),
+	},
+	{
+		Name:        mcp.ToolName("stripe_retrieve_invoice"),
+		Description: "Retrieve (get) a single invoice by ID with line items, totals, and status.",
+		Parameters:  map[string]string{"id": "Invoice ID (e.g. in_...)"},
+		Required:    []string{"id"},
+	},
+	{
+		Name:        mcp.ToolName("stripe_retrieve_upcoming_invoice"),
+		Description: "Retrieve (get) the upcoming (preview) invoice for a customer or subscription before it is finalized. Useful for previewing the next bill.",
+		Parameters: map[string]string{
+			"customer":     "Customer ID",
+			"subscription": "Subscription ID",
+			"coupon":       "Coupon ID for preview",
+		},
+	},
+	{
+		Name:        mcp.ToolName("stripe_search_invoices"),
+		Description: "Search invoices with Stripe search query (e.g. status:\"open\" AND total>10000).",
+		Parameters: map[string]string{
+			"query": "Stripe search query",
+			"limit": "Number of results",
+			"page":  "Cursor for pagination",
+		},
+		Required: []string{"query"},
+	},
+	{
+		Name:        mcp.ToolName("stripe_create_invoice"),
+		Description: "Create a draft invoice for a customer. Add invoice items separately or use auto_advance to finalize automatically.",
+		Parameters: map[string]string{
+			"customer":          "Customer ID (required)",
+			"auto_advance":      "Boolean — finalize and attempt collection automatically",
+			"collection_method": "charge_automatically or send_invoice",
+			"days_until_due":    "Days until due (for send_invoice)",
+			"description":       "Description",
+			"subscription":      "Subscription ID to associate",
+			"metadata":          "Metadata object",
+		},
+		Required: []string{"customer"},
+	},
+	{
+		Name:        mcp.ToolName("stripe_finalize_invoice"),
+		Description: "Finalize a draft invoice — locks line items and generates the final amount.",
+		Parameters: map[string]string{
+			"id":           "Invoice ID",
+			"auto_advance": "Boolean — proceed with payment collection",
+		},
+		Required: []string{"id"},
+	},
+	{
+		Name:        mcp.ToolName("stripe_pay_invoice"),
+		Description: "Pay an open invoice using a payment method or by charging the customer's default source.",
+		Parameters: map[string]string{
+			"id":               "Invoice ID",
+			"payment_method":   "Payment method ID to charge",
+			"paid_out_of_band": "Boolean — mark as paid externally without collecting funds",
+			"off_session":      "Boolean",
+		},
+		Required: []string{"id"},
+	},
+	{
+		Name:        mcp.ToolName("stripe_send_invoice"),
+		Description: "Email an open invoice to the customer.",
+		Parameters:  map[string]string{"id": "Invoice ID"},
+		Required:    []string{"id"},
+	},
+	{
+		Name:        mcp.ToolName("stripe_void_invoice"),
+		Description: "Void an open invoice. Cannot be undone.",
+		Parameters:  map[string]string{"id": "Invoice ID"},
+		Required:    []string{"id"},
+	},
+	{
+		Name:        mcp.ToolName("stripe_delete_invoice"),
+		Description: "Delete (remove) a draft invoice permanently. Only allowed for draft invoices.",
+		Parameters:  map[string]string{"id": "Invoice ID"},
+		Required:    []string{"id"},
+	},
+
+	// ── Invoice Items ────────────────────────────────────────────────
+	{
+		Name:        mcp.ToolName("stripe_list_invoice_items"),
+		Description: "List pending or attached invoice items (line items added to a customer's next invoice).",
+		Parameters: mergeParams(listParams, map[string]string{
+			"customer": "Filter by customer ID",
+			"invoice":  "Filter by invoice ID",
+			"pending":  "Only return pending items (true/false)",
+		}),
+	},
+	{
+		Name:        mcp.ToolName("stripe_create_invoice_item"),
+		Description: "Create an invoice item that will be added to a customer's next invoice or attached to a specific invoice.",
+		Parameters: map[string]string{
+			"customer":     "Customer ID (required)",
+			"amount":       "Amount in smallest currency unit",
+			"currency":     "Currency code",
+			"description":  "Line item description",
+			"price":        "Price ID (alternative to amount+currency)",
+			"quantity":     "Quantity (defaults to 1)",
+			"invoice":      "Optional invoice ID to attach to",
+			"subscription": "Subscription ID to attach to",
+			"metadata":     "Metadata object",
+		},
+		Required: []string{"customer"},
+	},
+
+	// ── Payment Methods ──────────────────────────────────────────────
+	{
+		Name:        mcp.ToolName("stripe_list_payment_methods"),
+		Description: "List payment methods attached to a customer (cards, bank accounts, wallets).",
+		Parameters: mergeParams(listParams, map[string]string{
+			"customer": "Customer ID (required)",
+			"type":     "card, us_bank_account, sepa_debit, etc.",
+		}),
+		Required: []string{"customer"},
+	},
+	{
+		Name:        mcp.ToolName("stripe_retrieve_payment_method"),
+		Description: "Retrieve (get) a single payment method by ID.",
+		Parameters:  map[string]string{"id": "Payment method ID (e.g. pm_...)"},
+		Required:    []string{"id"},
+	},
+	{
+		Name:        mcp.ToolName("stripe_attach_payment_method"),
+		Description: "Attach a payment method to a customer for later reuse.",
+		Parameters: map[string]string{
+			"id":       "Payment method ID",
+			"customer": "Customer ID to attach to",
+		},
+		Required: []string{"id", "customer"},
+	},
+	{
+		Name:        mcp.ToolName("stripe_detach_payment_method"),
+		Description: "Detach (remove) a payment method from its customer.",
+		Parameters:  map[string]string{"id": "Payment method ID"},
+		Required:    []string{"id"},
+	},
+
+	// ── Setup Intents ────────────────────────────────────────────────
+	{
+		Name:        mcp.ToolName("stripe_list_setup_intents"),
+		Description: "List SetupIntents (objects representing intent to save a payment method for future use).",
+		Parameters: mergeParams(listParams, map[string]string{
+			"customer":       "Filter by customer ID",
+			"payment_method": "Filter by payment method ID",
+			"created":        "Filter by creation timestamp",
+		}),
+	},
+	{
+		Name:        mcp.ToolName("stripe_retrieve_setup_intent"),
+		Description: "Retrieve (get) a single SetupIntent by ID.",
+		Parameters:  map[string]string{"id": "SetupIntent ID (e.g. seti_...)"},
+		Required:    []string{"id"},
+	},
+	{
+		Name:        mcp.ToolName("stripe_create_setup_intent"),
+		Description: "Create a SetupIntent to collect a customer's payment method for future use.",
+		Parameters: map[string]string{
+			"customer":             "Customer ID",
+			"payment_method":       "Payment method ID",
+			"payment_method_types": "Array of allowed payment method types",
+			"usage":                "on_session or off_session",
+			"confirm":              "Boolean — confirm immediately",
+			"description":          "Description",
+			"metadata":             "Metadata object",
+		},
+	},
+
+	// ── Coupons / Promotion Codes ────────────────────────────────────
+	{
+		Name:        mcp.ToolName("stripe_list_coupons"),
+		Description: "List discount coupons defined on the Stripe account.",
+		Parameters:  mergeParams(listParams, nil),
+	},
+	{
+		Name:        mcp.ToolName("stripe_retrieve_coupon"),
+		Description: "Retrieve (get) a single coupon by ID.",
+		Parameters:  map[string]string{"id": "Coupon ID"},
+		Required:    []string{"id"},
+	},
+	{
+		Name:        mcp.ToolName("stripe_create_coupon"),
+		Description: "Create a discount coupon that can be applied to customers, invoices, or subscriptions.",
+		Parameters: map[string]string{
+			"id":                 "Optional coupon ID (auto-generated if omitted)",
+			"name":               "Display name shown on receipts/invoices",
+			"percent_off":        "Percentage discount (0-100). Use this or amount_off.",
+			"amount_off":         "Fixed amount discount in smallest currency unit",
+			"currency":           "Required when amount_off is set",
+			"duration":           "once, repeating, or forever",
+			"duration_in_months": "Number of months (for duration=repeating)",
+			"max_redemptions":    "Maximum total redemptions",
+			"redeem_by":          "Unix timestamp coupon expires for new redemptions",
+			"metadata":           "Metadata object",
+		},
+		Required: []string{"duration"},
+	},
+	{
+		Name:        mcp.ToolName("stripe_delete_coupon"),
+		Description: "Delete (remove) a coupon.",
+		Parameters:  map[string]string{"id": "Coupon ID"},
+		Required:    []string{"id"},
+	},
+	{
+		Name:        mcp.ToolName("stripe_list_promotion_codes"),
+		Description: "List customer-facing promotion codes (the code strings tied to a coupon).",
+		Parameters: mergeParams(listParams, map[string]string{
+			"coupon":   "Filter by coupon ID",
+			"customer": "Filter by customer ID",
+			"active":   "Filter by active",
+			"code":     "Filter by code string",
+		}),
+	},
+	{
+		Name:        mcp.ToolName("stripe_create_promotion_code"),
+		Description: "Create a customer-facing promotion code tied to a coupon.",
+		Parameters: map[string]string{
+			"coupon":          "Coupon ID (required)",
+			"code":            "Customer-facing code (auto-generated if omitted)",
+			"customer":        "Restrict to a specific customer ID",
+			"max_redemptions": "Maximum total redemptions",
+			"expires_at":      "Unix timestamp",
+			"active":          "Boolean",
+			"metadata":        "Metadata object",
+		},
+		Required: []string{"coupon"},
+	},
+
+	// ── Events ───────────────────────────────────────────────────────
+	{
+		Name:        mcp.ToolName("stripe_list_events"),
+		Description: "List Stripe events (webhook event log). Use for auditing webhook history, replaying missed events, or finding when a specific object changed.",
+		Parameters: mergeParams(listParams, map[string]string{
+			"type":             "Filter by event type (e.g. charge.succeeded, invoice.paid)",
+			"types":            "Array of event types",
+			"created":          "Filter by creation timestamp",
+			"delivery_success": "Boolean — filter by webhook delivery outcome",
+		}),
+	},
+	{
+		Name:        mcp.ToolName("stripe_retrieve_event"),
+		Description: "Retrieve (get) a single event by ID.",
+		Parameters:  map[string]string{"id": "Event ID (e.g. evt_...)"},
+		Required:    []string{"id"},
+	},
+}
+
+// mergeParams merges base + extra into a fresh map (base takes precedence for duplicates).
+func mergeParams(base, extra map[string]string) map[string]string {
+	out := make(map[string]string, len(base)+len(extra))
+	for k, v := range extra {
+		out[k] = v
+	}
+	for k, v := range base {
+		out[k] = v
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

- Adds a native Go integration adapter for the Stripe API with ~75 tools across balance, customers, charges, payment intents, refunds, disputes, payouts, subscriptions, products, prices, invoices, payment methods, setup intents, coupons, promotion codes, and events.
- Handles Stripe's distinct conventions: `application/x-www-form-urlencoded` request bodies with bracket-notation flattening, optional `Stripe-Account` Connect header, and `Retry-After`-aware `RetryableError` on 429/5xx.
- Configurable via `STRIPE_API_KEY` (required) and `STRIPE_ACCOUNT` (optional Connect header).

## Test plan

- [x] `make ci` passes (build, vet, test-race, lint)
- [x] Unit tests cover form encoder, HTTP helpers (success/error/retryable/204), dispatch parity, compaction-spec parity, and handler smoke tests via `httptest`
- [x] Live verification against the real Stripe test API: 18/18 tool calls succeeded end-to-end including create/retrieve/update/search/delete on customers, products, prices, payment intents, and pagination on every list endpoint
- [x] `Healthy()` ping verified against `/balance`