### PR TITLE
chore: add Elastic License 2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,93 @@
+Elastic License 2.0
+
+URL: https://www.elastic.co/licensing/elastic-license
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject to
+the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set of
+the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key functionality
+in the software, and you may not remove or obscure any functionality in the
+software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other notices
+of the licensor in the software. Any use of the licensor's trademarks is subject
+to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to
+the software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license for
+the software granted under these terms ends immediately. If your company makes
+such a claim, your patent license ends immediately for work on behalf of your
+company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you
+also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in
+these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not licensed,
+and your licenses will automatically terminate. If the licensor provides you
+with a notice of your violation, and you cease all violation of this license no
+later than 30 days after you receive that notice, your licenses will be
+reinstated retroactively. However, if you violate these terms after such
+reinstatement, any additional violation of these terms will cause your licenses
+to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.*
+
+## Definitions
+
+The **licensor** is the entity offering these terms, and the **software** is the
+software the licensor makes available under these terms, including any portion
+of it.
+
+**you** refers to the individual or entity agreeing to these terms.
+
+**your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that
+organization. **control** means ownership of substantially all the assets of an
+entity, or the power to direct its management and policies by vote, contract, or
+otherwise. Control can be direct or indirect.
+
+**your licenses** are all the licenses granted to you for the software under
+these terms.
+
+**use** means anything you do with the software requiring one of your licenses.
+
+**trademark** means trademarks, service marks, and similar rights.

--- a/README.md
+++ b/README.md
@@ -235,3 +235,16 @@ Then run with live-reload:
 ```bash
 air
 ```
+
+## License
+
+Switchboard is source-available under the [Elastic License 2.0](LICENSE).
+
+In plain English: you can freely use, modify, redistribute, and self-host
+Switchboard — including for commercial and internal-business use. The only
+restriction is that you cannot offer Switchboard to third parties as a hosted
+or managed service that exposes a substantial portion of its functionality.
+That is the business reserved for the official hosted Switchboard service.
+
+If you have questions about licensing or want to discuss other arrangements,
+open an issue or get in touch.


### PR DESCRIPTION
## Summary

- Adds `LICENSE` with the Elastic License 2.0, making Switchboard source-available.
- Adds a "License" section to `README.md` explaining the terms in plain English.

## Why this license?

ELv2 keeps Switchboard free for the use cases that matter to the community — self-hosting, internal commercial use, modification, redistribution, and contributions — while preventing third parties from offering a competing hosted/managed Switchboard service. That hosted business is reserved for the official Switchboard Hosted service.

Compared to alternatives we considered:
- **MIT/Apache** — permits anyone to spin up a competing hosted clone with no restrictions.
- **AGPL** — protects against hosted clones but is viral and creates real adoption friction for users embedding Switchboard in proprietary stacks.
- **BSL** — flexible but requires picking an additional-use grant and a change date; more complexity than needed today.
- **ELv2** — minimal, readable, addresses the one restriction we care about, and is battle-tested by Elastic, MinIO, Redpanda, and others.

## Test plan

- [x] `LICENSE` file added at repo root.
- [x] `README.md` includes a clear License section linking to the file.
- [ ] Confirm the GitHub repo "License" detector picks up ELv2 once merged.


💘 Generated with Crush