### PR TITLE
Marketplace: rewrite GitHub HTML URLs to Contents API

### DIFF
--- a/marketplace/github_url.go
+++ b/marketplace/github_url.go
@@ -38,10 +38,14 @@ func normalizeGitHubURL(rawURL string) (newURL string, useRawAccept bool) {
 	owner, repo, ref := parts[0], parts[1], parts[3]
 	path := strings.Join(parts[4:], "/")
 
-	api := &url.URL{
-		Scheme: "https",
-		Host:   "api.github.com",
-		Path:   "/repos/" + owner + "/" + repo + "/contents/" + path,
+	apiURL, err := url.JoinPath("https://api.github.com",
+		"repos", owner, repo, "contents", path)
+	if err != nil {
+		return rawURL, false
+	}
+	api, err := url.Parse(apiURL)
+	if err != nil {
+		return rawURL, false
 	}
 	q := api.Query()
 	q.Set("ref", ref)

--- a/marketplace/github_url.go
+++ b/marketplace/github_url.go
@@ -1,0 +1,51 @@
+package marketplace
+
+import (
+	"net/url"
+	"strings"
+)
+
+// normalizeGitHubURL rewrites GitHub HTML URLs (the kind a user copies from
+// the browser) into the GitHub Contents API form so the file's raw bytes can
+// be fetched with an Authorization header. This is the only way to retrieve
+// files from a private repository over HTTPS without using `git` itself.
+//
+// Supported input forms:
+//
+//   - https://github.com/{owner}/{repo}/blob/{ref}/{path}   →  Contents API
+//   - https://github.com/{owner}/{repo}/raw/{ref}/{path}    →  Contents API
+//
+// Any URL on raw.githubusercontent.com / api.github.com / non-GitHub hosts is
+// passed through unchanged. Malformed URLs are also passed through so the
+// caller can attempt the request and surface a normal HTTP error.
+//
+// useRawAccept is true when the rewritten URL is the Contents API form, in
+// which case the request must carry `Accept: application/vnd.github.raw` to
+// receive raw file bytes instead of the default JSON metadata wrapper.
+func normalizeGitHubURL(rawURL string) (newURL string, useRawAccept bool) {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Host == "" {
+		return rawURL, false
+	}
+	if strings.ToLower(u.Host) != "github.com" {
+		return rawURL, false
+	}
+	// /{owner}/{repo}/blob|raw/{ref}/{path...}
+	parts := strings.Split(strings.TrimPrefix(u.Path, "/"), "/")
+	if len(parts) < 5 || (parts[2] != "blob" && parts[2] != "raw") {
+		return rawURL, false
+	}
+	owner, repo, ref := parts[0], parts[1], parts[3]
+	path := strings.Join(parts[4:], "/")
+
+	api := &url.URL{
+		Scheme: "https",
+		Host:   "api.github.com",
+		Path:   "/repos/" + owner + "/" + repo + "/contents/" + path,
+	}
+	q := api.Query()
+	q.Set("ref", ref)
+	api.RawQuery = q.Encode()
+
+	return api.String(), true
+}

--- a/marketplace/github_url_test.go
+++ b/marketplace/github_url_test.go
@@ -1,0 +1,182 @@
+package marketplace
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeGitHubURL(t *testing.T) {
+	cases := []struct {
+		name          string
+		in            string
+		wantURL       string
+		wantRawAccept bool
+	}{
+		{
+			name:          "blob_html_url_rewritten_to_contents_api",
+			in:            "https://github.com/teamcurri/switchboard_plugins/blob/main/manifest.json",
+			wantURL:       "https://api.github.com/repos/teamcurri/switchboard_plugins/contents/manifest.json?ref=main",
+			wantRawAccept: true,
+		},
+		{
+			name:          "raw_html_url_rewritten_to_contents_api",
+			in:            "https://github.com/teamcurri/switchboard_plugins/raw/main/dist/curri.wasm",
+			wantURL:       "https://api.github.com/repos/teamcurri/switchboard_plugins/contents/dist/curri.wasm?ref=main",
+			wantRawAccept: true,
+		},
+		{
+			name:          "blob_url_master_branch",
+			in:            "https://github.com/teamcurri/switchboard_plugins/blob/master/manifest.json",
+			wantURL:       "https://api.github.com/repos/teamcurri/switchboard_plugins/contents/manifest.json?ref=master",
+			wantRawAccept: true,
+		},
+		{
+			name:          "blob_url_nested_path",
+			in:            "https://github.com/o/r/blob/dev/sub/dir/file.json",
+			wantURL:       "https://api.github.com/repos/o/r/contents/sub/dir/file.json?ref=dev",
+			wantRawAccept: true,
+		},
+		{
+			name:          "raw_cdn_left_untouched",
+			in:            "https://raw.githubusercontent.com/teamcurri/switchboard_plugins/main/manifest.json",
+			wantURL:       "https://raw.githubusercontent.com/teamcurri/switchboard_plugins/main/manifest.json",
+			wantRawAccept: false,
+		},
+		{
+			name:          "contents_api_left_untouched",
+			in:            "https://api.github.com/repos/o/r/contents/manifest.json?ref=main",
+			wantURL:       "https://api.github.com/repos/o/r/contents/manifest.json?ref=main",
+			wantRawAccept: false,
+		},
+		{
+			name:          "non_github_url_passthrough",
+			in:            "https://example.com/foo/manifest.json",
+			wantURL:       "https://example.com/foo/manifest.json",
+			wantRawAccept: false,
+		},
+		{
+			name:          "github_release_download_passthrough",
+			in:            "https://github.com/o/r/releases/download/v1/plugin.wasm",
+			wantURL:       "https://github.com/o/r/releases/download/v1/plugin.wasm",
+			wantRawAccept: false,
+		},
+		{
+			name:          "malformed_url_passthrough",
+			in:            "::not-a-url",
+			wantURL:       "::not-a-url",
+			wantRawAccept: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotURL, gotRaw := normalizeGitHubURL(tc.in)
+			assert.Equal(t, tc.wantURL, gotURL)
+			assert.Equal(t, tc.wantRawAccept, gotRaw)
+		})
+	}
+}
+
+// TestFetchManifest_RewritesBlobURL verifies a user-pasted GitHub HTML
+// /blob/ URL is rewritten to the Contents API and accompanied by the bearer
+// token and raw-bytes Accept header so private-repo manifests fetch successfully.
+func TestFetchManifest_RewritesBlobURL(t *testing.T) {
+	var (
+		gotPath   string
+		gotAuth   string
+		gotAccept string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path + "?" + r.URL.RawQuery
+		gotAuth = r.Header.Get("Authorization")
+		gotAccept = r.Header.Get("Accept")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"schema_version":1,"name":"private-mf","plugins":[]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	// Hijack the api.github.com host by pointing the manager's HTTP client
+	// at our test server. Use a custom transport rather than a global rewrite.
+	mgr := NewManager(Config{}, t.TempDir(), nil, WithTokenFunc(func(host string) string {
+		if host == "api.github.com" {
+			return "ghp_secret"
+		}
+		return ""
+	}))
+	mgr.client = srv.Client()
+	mgr.client.Transport = &rewriteTransport{
+		match:   "api.github.com",
+		target:  srv.URL,
+		wrapped: http.DefaultTransport,
+	}
+
+	manifest, err := mgr.FetchManifest(context.Background(),
+		"https://github.com/teamcurri/switchboard_plugins/blob/main/manifest.json")
+	require.NoError(t, err)
+	assert.Equal(t, "private-mf", manifest.Name)
+	assert.Equal(t, "/repos/teamcurri/switchboard_plugins/contents/manifest.json?ref=main", gotPath)
+	assert.Equal(t, "Bearer ghp_secret", gotAuth)
+	assert.Equal(t, "application/vnd.github.raw", gotAccept)
+}
+
+// TestDownloadWasm_RewritesBlobURL ensures the same normalization applies to
+// WASM downloads, so a /raw/ HTML URL in manifest.json works for private repos.
+func TestDownloadWasm_RewritesBlobURL(t *testing.T) {
+	wasmBytes := []byte("\x00asm\x01\x00\x00\x00")
+	var (
+		gotAuth   string
+		gotAccept string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotAccept = r.Header.Get("Accept")
+		_, _ = w.Write(wasmBytes)
+	}))
+	t.Cleanup(srv.Close)
+
+	mgr := NewManager(Config{}, t.TempDir(), nil, WithTokenFunc(func(host string) string {
+		if host == "api.github.com" {
+			return "ghp_secret"
+		}
+		return ""
+	}))
+	mgr.client = srv.Client()
+	mgr.client.Transport = &rewriteTransport{
+		match:   "api.github.com",
+		target:  srv.URL,
+		wrapped: http.DefaultTransport,
+	}
+
+	data, err := mgr.downloadWasm(context.Background(),
+		"https://github.com/teamcurri/switchboard_plugins/raw/main/dist/here.wasm")
+	require.NoError(t, err)
+	assert.Equal(t, wasmBytes, data)
+	assert.Equal(t, "Bearer ghp_secret", gotAuth)
+	assert.Equal(t, "application/vnd.github.raw", gotAccept)
+}
+
+// rewriteTransport rewrites requests whose Host matches `match` to point at
+// `target` (a test server URL), so we can intercept api.github.com calls.
+type rewriteTransport struct {
+	match   string
+	target  string
+	wrapped http.RoundTripper
+}
+
+func (t *rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL.Host == t.match {
+		targetURL, err := req.URL.Parse(t.target)
+		if err != nil {
+			return nil, err
+		}
+		req.URL.Scheme = targetURL.Scheme
+		req.URL.Host = targetURL.Host
+		req.Host = targetURL.Host
+	}
+	return t.wrapped.RoundTrip(req)
+}

--- a/marketplace/github_url_test.go
+++ b/marketplace/github_url_test.go
@@ -174,6 +174,7 @@ func (t *rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 		if err != nil {
 			return nil, err
 		}
+		req = req.Clone(req.Context())
 		req.URL.Scheme = targetURL.Scheme
 		req.URL.Host = targetURL.Host
 		req.Host = targetURL.Host

--- a/marketplace/marketplace.go
+++ b/marketplace/marketplace.go
@@ -162,12 +162,17 @@ func (m *Manager) Config() Config {
 }
 
 // FetchManifest downloads and parses a manifest from a URL.
-func (m *Manager) FetchManifest(ctx context.Context, url string) (*Manifest, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+func (m *Manager) FetchManifest(ctx context.Context, rawURL string) (*Manifest, error) {
+	effectiveURL, useRawAccept := normalizeGitHubURL(rawURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, effectiveURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
 	}
-	req.Header.Set("Accept", "application/json")
+	if useRawAccept {
+		req.Header.Set("Accept", "application/vnd.github.raw")
+	} else {
+		req.Header.Set("Accept", "application/json")
+	}
 	req.Header.Set("User-Agent", "Switchboard-Plugin-Manager/1.0")
 	m.applyAuth(req)
 
@@ -196,7 +201,7 @@ func (m *Manager) FetchManifest(ctx context.Context, url string) (*Manifest, err
 	}
 
 	m.mu.Lock()
-	m.manifests[url] = &manifest
+	m.manifests[rawURL] = &manifest
 	m.mu.Unlock()
 
 	return &manifest, nil
@@ -740,12 +745,16 @@ func (m *Manager) downloadAndInstall(ctx context.Context, name string, ver *Plug
 	return &ip, nil
 }
 
-func (m *Manager) downloadWasm(ctx context.Context, url string) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+func (m *Manager) downloadWasm(ctx context.Context, rawURL string) ([]byte, error) {
+	effectiveURL, useRawAccept := normalizeGitHubURL(rawURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, effectiveURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
 	}
 	req.Header.Set("User-Agent", "Switchboard-Plugin-Manager/1.0")
+	if useRawAccept {
+		req.Header.Set("Accept", "application/vnd.github.raw")
+	}
 	m.applyAuth(req)
 
 	resp, err := m.client.Do(req)


### PR DESCRIPTION
## Summary

- Manifest sources pasted as the familiar `https://github.com/{owner}/{repo}/blob/{ref}/manifest.json` HTML link now succeed instead of returning HTTP 404 / HTML — the URL is rewritten to `https://api.github.com/repos/{owner}/{repo}/contents/{path}?ref={ref}` and accompanied by `Accept: application/vnd.github.raw`.
- Combined with the existing `GitHubTokenFunc` wiring in `cmd/server/main.go` (which attaches the GitHub integration's PAT as a bearer token for GitHub hosts), **private-repo manifests and WASM downloads now work transparently** without any new UI or per-source token config.
- `raw.githubusercontent.com`, `api.github.com`, public repos, and non-GitHub URLs are unaffected.

## Why

Internal Curri plugin manifest at `teamcurri/switchboard_plugins` (private) couldn't be fetched: pasting the HTML `/blob/main/manifest.json` link returned a 404 even with the integration token configured, because GitHub serves HTML at that path. The fix normalizes that exact URL form into a Contents API request that the existing bearer-token logic already authenticates correctly.

## Implementation

- New `marketplace/github_url.go`: pure `normalizeGitHubURL(rawURL) → (effectiveURL, useRawAccept)`.
- `FetchManifest` and `downloadWasm` call the normalizer and conditionally set the `Accept: application/vnd.github.raw` header. Everything else (auth header, retries, caching) is unchanged.

## Test plan

- [x] `TestNormalizeGitHubURL` — 9 cases: blob/raw HTML, master/main branches, nested paths, raw.githubusercontent passthrough, API form passthrough, non-GitHub passthrough, `/releases/download/` passthrough, malformed URL passthrough.
- [x] `TestFetchManifest_RewritesBlobURL` — end-to-end: paste blob URL → server receives Contents API path + bearer + `application/vnd.github.raw` Accept.
- [x] `TestDownloadWasm_RewritesBlobURL` — same end-to-end check for WASM downloads.
- [x] `go test ./marketplace/... -race` passes; `go vet`, `go build ./...`, and `golangci-lint run ./marketplace/...` all clean.
- [x] Unrelated pre-existing `browser.TestPage_Evaluate` failure on `main` is **not** introduced by this change.