### PR TITLE
Surface plugin live-load failures in marketplace UI

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -29,7 +29,7 @@ type WebServer struct {
 	port        int
 	health      *healthCache
 	marketplace *marketplace.Manager
-	wasmLoader  *wasmmod.Loader
+	wasmLoader  pluginLoader
 }
 
 // New returns a WebServer that provides a browser-based config UI.
@@ -39,7 +39,9 @@ func New(services *mcp.Services, port int, mp *marketplace.Manager, wl *wasmmod.
 		port:        port,
 		health:      newHealthCache(services),
 		marketplace: mp,
-		wasmLoader:  wl,
+	}
+	if wl != nil {
+		ws.wasmLoader = wl
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/web/web_marketplace.go
+++ b/web/web_marketplace.go
@@ -99,7 +99,10 @@ func (w *WebServer) handlePluginInstall(rw http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	_ = w.liveLoadPlugin(r.Context(), ip.Path, "")
+	if err := w.liveLoadPlugin(r.Context(), ip.Path, ""); err != nil {
+		http.Redirect(rw, r, fmt.Sprintf("/plugins?error=Installed+%s+but+load+failed:+%s", ip.Name, urlEncode(err.Error())), http.StatusSeeOther)
+		return
+	}
 	http.Redirect(rw, r, fmt.Sprintf("/plugins?success=Installed+and+loaded+%s@%s.", ip.Name, ip.Version), http.StatusSeeOther)
 }
 
@@ -127,7 +130,10 @@ func (w *WebServer) handlePluginInstallURL(rw http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	_ = w.liveLoadPlugin(r.Context(), ip.Path, "")
+	if err := w.liveLoadPlugin(r.Context(), ip.Path, ""); err != nil {
+		http.Redirect(rw, r, fmt.Sprintf("/plugins?error=Installed+%s+but+load+failed:+%s", ip.Name, urlEncode(err.Error())), http.StatusSeeOther)
+		return
+	}
 	http.Redirect(rw, r, fmt.Sprintf("/plugins?success=Installed+and+loaded+%s.", ip.Name), http.StatusSeeOther)
 }
 
@@ -162,7 +168,10 @@ func (w *WebServer) handlePluginUpload(rw http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	_ = w.liveLoadPlugin(r.Context(), ip.Path, "")
+	if err := w.liveLoadPlugin(r.Context(), ip.Path, ""); err != nil {
+		http.Redirect(rw, r, fmt.Sprintf("/plugins?error=Uploaded+%s+but+load+failed:+%s", ip.Name, urlEncode(err.Error())), http.StatusSeeOther)
+		return
+	}
 	http.Redirect(rw, r, fmt.Sprintf("/plugins?success=Uploaded+and+loaded+%s.", ip.Name), http.StatusSeeOther)
 }
 
@@ -212,7 +221,10 @@ func (w *WebServer) handlePluginUpdate(rw http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	_ = w.liveLoadPlugin(r.Context(), ip.Path, "")
+	if err := w.liveLoadPlugin(r.Context(), ip.Path, ""); err != nil {
+		http.Redirect(rw, r, fmt.Sprintf("/plugins?error=Updated+%s+but+load+failed:+%s", ip.Name, urlEncode(err.Error())), http.StatusSeeOther)
+		return
+	}
 	http.Redirect(rw, r, fmt.Sprintf("/plugins?success=Updated+and+reloaded+%s+to+%s.", ip.Name, ip.Version), http.StatusSeeOther)
 }
 

--- a/web/web_marketplace.go
+++ b/web/web_marketplace.go
@@ -6,12 +6,20 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
 	"github.com/daltoniam/switchboard/marketplace"
 	"github.com/daltoniam/switchboard/web/templates/pages"
 )
+
+// pluginLoader is the subset of *wasm.Loader the marketplace handlers depend
+// on, extracted so tests can inject a stub that returns errors from LoadPlugin.
+type pluginLoader interface {
+	LoadPlugin(ctx context.Context, path, nameOverride string) error
+	UnloadPlugin(ctx context.Context, name string) error
+}
 
 func (w *WebServer) handlePluginMarketplace(rw http.ResponseWriter, r *http.Request) {
 	page := w.pageData(r, "Plugin Marketplace", "/plugins")
@@ -100,10 +108,10 @@ func (w *WebServer) handlePluginInstall(rw http.ResponseWriter, r *http.Request)
 	}
 
 	if err := w.liveLoadPlugin(r.Context(), ip.Path, ""); err != nil {
-		http.Redirect(rw, r, fmt.Sprintf("/plugins?error=Installed+%s+but+load+failed:+%s", ip.Name, urlEncode(err.Error())), http.StatusSeeOther)
+		http.Redirect(rw, r, fmt.Sprintf("/plugins?error=Installed+%s+but+load+failed:+%s", urlEncode(ip.Name), urlEncode(err.Error())), http.StatusSeeOther)
 		return
 	}
-	http.Redirect(rw, r, fmt.Sprintf("/plugins?success=Installed+and+loaded+%s@%s.", ip.Name, ip.Version), http.StatusSeeOther)
+	http.Redirect(rw, r, fmt.Sprintf("/plugins?success=Installed+and+loaded+%s@%s.", urlEncode(ip.Name), urlEncode(ip.Version)), http.StatusSeeOther)
 }
 
 func (w *WebServer) handlePluginInstallURL(rw http.ResponseWriter, r *http.Request) {
@@ -131,10 +139,10 @@ func (w *WebServer) handlePluginInstallURL(rw http.ResponseWriter, r *http.Reque
 	}
 
 	if err := w.liveLoadPlugin(r.Context(), ip.Path, ""); err != nil {
-		http.Redirect(rw, r, fmt.Sprintf("/plugins?error=Installed+%s+but+load+failed:+%s", ip.Name, urlEncode(err.Error())), http.StatusSeeOther)
+		http.Redirect(rw, r, fmt.Sprintf("/plugins?error=Installed+%s+but+load+failed:+%s", urlEncode(ip.Name), urlEncode(err.Error())), http.StatusSeeOther)
 		return
 	}
-	http.Redirect(rw, r, fmt.Sprintf("/plugins?success=Installed+and+loaded+%s.", ip.Name), http.StatusSeeOther)
+	http.Redirect(rw, r, fmt.Sprintf("/plugins?success=Installed+and+loaded+%s.", urlEncode(ip.Name)), http.StatusSeeOther)
 }
 
 func (w *WebServer) handlePluginUpload(rw http.ResponseWriter, r *http.Request) {
@@ -169,10 +177,10 @@ func (w *WebServer) handlePluginUpload(rw http.ResponseWriter, r *http.Request) 
 	}
 
 	if err := w.liveLoadPlugin(r.Context(), ip.Path, ""); err != nil {
-		http.Redirect(rw, r, fmt.Sprintf("/plugins?error=Uploaded+%s+but+load+failed:+%s", ip.Name, urlEncode(err.Error())), http.StatusSeeOther)
+		http.Redirect(rw, r, fmt.Sprintf("/plugins?error=Uploaded+%s+but+load+failed:+%s", urlEncode(ip.Name), urlEncode(err.Error())), http.StatusSeeOther)
 		return
 	}
-	http.Redirect(rw, r, fmt.Sprintf("/plugins?success=Uploaded+and+loaded+%s.", ip.Name), http.StatusSeeOther)
+	http.Redirect(rw, r, fmt.Sprintf("/plugins?success=Uploaded+and+loaded+%s.", urlEncode(ip.Name)), http.StatusSeeOther)
 }
 
 func (w *WebServer) handlePluginUninstall(rw http.ResponseWriter, r *http.Request) {
@@ -222,10 +230,10 @@ func (w *WebServer) handlePluginUpdate(rw http.ResponseWriter, r *http.Request) 
 	}
 
 	if err := w.liveLoadPlugin(r.Context(), ip.Path, ""); err != nil {
-		http.Redirect(rw, r, fmt.Sprintf("/plugins?error=Updated+%s+but+load+failed:+%s", ip.Name, urlEncode(err.Error())), http.StatusSeeOther)
+		http.Redirect(rw, r, fmt.Sprintf("/plugins?error=Updated+%s+but+load+failed:+%s", urlEncode(ip.Name), urlEncode(err.Error())), http.StatusSeeOther)
 		return
 	}
-	http.Redirect(rw, r, fmt.Sprintf("/plugins?success=Updated+and+reloaded+%s+to+%s.", ip.Name, ip.Version), http.StatusSeeOther)
+	http.Redirect(rw, r, fmt.Sprintf("/plugins?success=Updated+and+reloaded+%s+to+%s.", urlEncode(ip.Name), urlEncode(ip.Version)), http.StatusSeeOther)
 }
 
 func (w *WebServer) handlePluginCheckUpdates(rw http.ResponseWriter, r *http.Request) {
@@ -374,5 +382,5 @@ func (w *WebServer) handlePluginLoadPath(rw http.ResponseWriter, r *http.Request
 }
 
 func urlEncode(s string) string {
-	return strings.ReplaceAll(s, " ", "+")
+	return url.QueryEscape(s)
 }

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -1,15 +1,19 @@
 package web
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	mcp "github.com/daltoniam/switchboard"
+	"github.com/daltoniam/switchboard/marketplace"
 	wasmmod "github.com/daltoniam/switchboard/wasm"
 	"github.com/daltoniam/switchboard/web/templates/pages"
 	"github.com/stretchr/testify/assert"
@@ -376,6 +380,85 @@ func TestPluginLoadPath_InvalidExtension(t *testing.T) {
 	assert.Equal(t, http.StatusSeeOther, rr.Code)
 	assert.Contains(t, rr.Header().Get("Location"), "error")
 	assert.Contains(t, rr.Header().Get("Location"), ".wasm")
+}
+
+// errLoader is a pluginLoader stub that returns the configured error from
+// LoadPlugin. Used to exercise the live-load failure branch in marketplace
+// install/upload/update handlers without spinning up a real wazero runtime.
+type errLoader struct {
+	loadErr error
+}
+
+func (e *errLoader) LoadPlugin(_ context.Context, _, _ string) error { return e.loadErr }
+func (e *errLoader) UnloadPlugin(_ context.Context, _ string) error  { return nil }
+
+// uploadPlugin builds a multipart upload request for POST /plugins/upload.
+func uploadPlugin(t *testing.T, name string, body []byte) *http.Request {
+	t.Helper()
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	require.NoError(t, writer.WriteField("name", name))
+	part, err := writer.CreateFormFile("wasm", "plugin.wasm")
+	require.NoError(t, err)
+	_, err = part.Write(body)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	req := httptest.NewRequest("POST", "/plugins/upload", &buf)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	return req
+}
+
+// TestPluginUpload_LiveLoadError verifies the upload handler surfaces a
+// live-load failure as a flash error instead of a misleading success.
+func TestPluginUpload_LiveLoadError(t *testing.T) {
+	ws, _, _ := setupTestWeb()
+	ws.marketplace = marketplace.NewManager(marketplace.Config{}, t.TempDir(), func(_ marketplace.Config) error { return nil })
+	ws.wasmLoader = &errLoader{loadErr: errors.New("wasm: module does not export 'metadata'")}
+
+	rr := httptest.NewRecorder()
+	ws.Handler().ServeHTTP(rr, uploadPlugin(t, "here", []byte("fake wasm")))
+
+	assert.Equal(t, http.StatusSeeOther, rr.Code)
+	loc := rr.Header().Get("Location")
+	assert.Contains(t, loc, "/plugins?error=")
+	assert.Contains(t, loc, "Uploaded+here+but+load+failed")
+	assert.Contains(t, loc, "module+does+not+export+%27metadata%27")
+	assert.NotContains(t, loc, "success=")
+}
+
+// TestPluginUpload_LiveLoadSuccess verifies the happy path still redirects to
+// the success flash when the loader returns nil.
+func TestPluginUpload_LiveLoadSuccess(t *testing.T) {
+	ws, _, _ := setupTestWeb()
+	ws.marketplace = marketplace.NewManager(marketplace.Config{}, t.TempDir(), func(_ marketplace.Config) error { return nil })
+	ws.wasmLoader = &errLoader{loadErr: nil}
+
+	rr := httptest.NewRecorder()
+	ws.Handler().ServeHTTP(rr, uploadPlugin(t, "here", []byte("fake wasm")))
+
+	assert.Equal(t, http.StatusSeeOther, rr.Code)
+	loc := rr.Header().Get("Location")
+	assert.Contains(t, loc, "/plugins?success=Uploaded+and+loaded+here.")
+}
+
+// TestPluginUpload_NameEscaping verifies that a plugin name containing query
+// metacharacters (&, =) is URL-encoded so it can't smuggle in extra params
+// or override the flash state. Regression test for the case where an
+// attacker-controlled name like "foo&success=Installed" would split into two
+// query parameters in the redirect URL.
+func TestPluginUpload_NameEscaping(t *testing.T) {
+	ws, _, _ := setupTestWeb()
+	ws.marketplace = marketplace.NewManager(marketplace.Config{}, t.TempDir(), func(_ marketplace.Config) error { return nil })
+	ws.wasmLoader = &errLoader{loadErr: errors.New("boom")}
+
+	rr := httptest.NewRecorder()
+	ws.Handler().ServeHTTP(rr, uploadPlugin(t, "evil&success=pwned", []byte("fake wasm")))
+
+	assert.Equal(t, http.StatusSeeOther, rr.Code)
+	loc := rr.Header().Get("Location")
+	assert.Contains(t, loc, "evil%26success%3Dpwned")
+	assert.NotContains(t, loc, "&success=pwned")
 }
 
 func TestDashboard_IntegrationCounts(t *testing.T) {


### PR DESCRIPTION
## Summary

- Marketplace install/upload/update handlers in `web/web_marketplace.go` called `liveLoadPlugin` and silently discarded the error (`_ = w.liveLoadPlugin(...)`), so the UI always showed "Installed and loaded" success — even when the WASM module failed to load (missing required export, ABI mismatch, configure error). The plugin then never appeared at `/integrations` and the user had no signal as to why.
- Forward the load error to the existing flash banner so the install page surfaces what went wrong (e.g. `Installed here but load failed: wasm: module does not export 'metadata'`).

Discovered while debugging a `here` plugin that installed but never registered because its `here.wasm` was missing the required `metadata()` export.

## Test plan

- [x] `go vet ./web/...`
- [x] `go test ./web/...`
- [x] `golangci-lint run ./web/...`
- [ ] Manual: install a plugin whose `.wasm` is missing a required export and confirm the error appears in the flash banner instead of a misleading success.