### PR TITLE
Add Vercel base URL environment mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Any integration with credentials provided via env vars will auto-enable without 
 | Vercel | `api_token` | `VERCEL_API_TOKEN` |
 | Vercel | `team_id` | `VERCEL_TEAM_ID` (optional — default team scope) |
 | Vercel | `team_slug` | `VERCEL_TEAM_SLUG` (optional — default team scope) |
+| Vercel | `base_url` | `VERCEL_BASE_URL` (optional — override API endpoint, e.g. tests/proxies) |
 | Stripe | `api_key` | `STRIPE_API_KEY` |
 | Stripe | `account` | `STRIPE_ACCOUNT` (optional — `Stripe-Account` header for Connect) |
 | Stripe | `base_url` | `STRIPE_BASE_URL` (optional — override API endpoint, e.g. stripe-mock) |

--- a/config/config.go
+++ b/config/config.go
@@ -107,6 +107,7 @@ var envMapping = map[string]map[string]string{
 		"api_token": "VERCEL_API_TOKEN",
 		"team_id":   "VERCEL_TEAM_ID",
 		"team_slug": "VERCEL_TEAM_SLUG",
+		"base_url":  "VERCEL_BASE_URL",
 	},
 	"snowflake": {
 		"account":       "SNOWFLAKE_ACCOUNT",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -425,6 +425,7 @@ func TestEnvOverrides_AllIntegrations(t *testing.T) {
 		"VERCEL_API_TOKEN":      "vc_token",
 		"VERCEL_TEAM_ID":        "team_123",
 		"VERCEL_TEAM_SLUG":      "acme",
+		"VERCEL_BASE_URL":       "https://api.vercel.test",
 	}
 
 	m.envLookup = func(key string) string {
@@ -462,6 +463,7 @@ func TestEnvOverrides_AllIntegrations(t *testing.T) {
 	assert.Equal(t, "vc_token", m.cfg.Integrations["vercel"].Credentials["api_token"])
 	assert.Equal(t, "team_123", m.cfg.Integrations["vercel"].Credentials["team_id"])
 	assert.Equal(t, "acme", m.cfg.Integrations["vercel"].Credentials["team_slug"])
+	assert.Equal(t, "https://api.vercel.test", m.cfg.Integrations["vercel"].Credentials["base_url"])
 }
 
 func TestEnvOverrides_DoesNotPersistToFile(t *testing.T) {
@@ -516,6 +518,7 @@ func TestEnvMapping_ReturnsMapping(t *testing.T) {
 	assert.Equal(t, "VERCEL_API_TOKEN", m["vercel"]["api_token"])
 	assert.Equal(t, "VERCEL_TEAM_ID", m["vercel"]["team_id"])
 	assert.Equal(t, "VERCEL_TEAM_SLUG", m["vercel"]["team_slug"])
+	assert.Equal(t, "VERCEL_BASE_URL", m["vercel"]["base_url"])
 	assert.Len(t, m, 27)
 }
 


### PR DESCRIPTION

## Summary

- Add `VERCEL_BASE_URL` support for Vercel `base_url` environment overrides.
- Update config tests and README docs so Vercel settings stay consistent.

## Test plan

- [x] `go test ./config ./integrations/vercel`
- [x] `go test -race ./config ./integrations/vercel`
- [x] `make lint`
- [ ] `make ci` (blocked by existing unrelated `browser/browser_test.go:108` int vs float64 assertion)


💘 Generated with Crush