### PR TITLE
Defer browser startup until needed

### DIFF
--- a/browser/browser_test.go
+++ b/browser/browser_test.go
@@ -105,7 +105,7 @@ func TestPage_Evaluate(t *testing.T) {
 
 	result, err := pg.Evaluate(ctx, "1 + 1")
 	require.NoError(t, err)
-	assert.Equal(t, float64(2), result)
+	assert.EqualValues(t, 2, result)
 }
 
 func TestPage_Screenshot(t *testing.T) {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"sync"
 	"syscall"
 	"time"
 
@@ -201,16 +202,18 @@ func runServer(stdioMode bool, port int, discoverAll bool) {
 		log.Fatalf("Failed to load config: %v", err)
 	}
 
-	browserDone := make(chan struct{})
-	var browserSvc mcp.BrowserService
-	go func() {
-		defer close(browserDone)
+	browserSvc := newLazyBrowserService(func(ctx context.Context) (mcp.BrowserService, error) {
 		svc, err := browser.New(true /* headless */)
 		if err != nil {
-			log.Printf("browser service unavailable (%v) — browser-based integrations disabled", err)
-			return
+			return nil, fmt.Errorf("browser service unavailable: %w", err)
 		}
-		browserSvc = svc
+		log.Println("browser service ready — Amazon browser features enabled")
+		return svc, nil
+	})
+	defer func() {
+		if err := browserSvc.Close(); err != nil {
+			log.Printf("browser service close failed: %v", err)
+		}
 	}()
 
 	gmailIntegration := gmail.New()
@@ -344,13 +347,7 @@ func runServer(stdioMode bool, port int, discoverAll bool) {
 	gchat.SetConfigService(gchatIntegration, cfgMgr)
 	gpeople.SetConfigService(gpeopleIntegration, cfgMgr)
 	gmeet.SetConfigService(gmeetIntegration, cfgMgr)
-	go func() {
-		<-browserDone
-		if browserSvc != nil {
-			amazon.SetBrowserService(amazonIntegration, browserSvc)
-			log.Println("browser service ready — Amazon browser features enabled")
-		}
-	}()
+	amazon.SetBrowserService(amazonIntegration, browserSvc)
 
 	var serverOpts []server.Option
 	if discoverAll {
@@ -482,10 +479,49 @@ func runServer(stdioMode bool, port int, discoverAll bool) {
 		log.Fatalf("HTTP server error: %v", err)
 	}
 
-	<-browserDone
-	if browserSvc != nil {
-		browserSvc.Close() //nolint:errcheck
+}
+
+type lazyBrowserService struct {
+	mu      sync.Mutex
+	new     func(ctx context.Context) (mcp.BrowserService, error)
+	service mcp.BrowserService
+	closed  bool
+}
+
+func newLazyBrowserService(newFn func(ctx context.Context) (mcp.BrowserService, error)) *lazyBrowserService {
+	return &lazyBrowserService{new: newFn}
+}
+
+func (s *lazyBrowserService) NewSession(ctx context.Context) (mcp.BrowserSession, error) {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil, fmt.Errorf("browser service closed")
 	}
+	if s.service == nil {
+		svc, err := s.new(ctx)
+		if err != nil {
+			s.mu.Unlock()
+			return nil, err
+		}
+		s.service = svc
+	}
+	svc := s.service
+	s.mu.Unlock()
+	return svc.NewSession(ctx)
+}
+
+func (s *lazyBrowserService) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	if s.service == nil {
+		return nil
+	}
+	return s.service.Close()
 }
 
 // metricsPath returns the on-disk path for persisted lifetime metrics.

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLazyBrowserService_DoesNotStartUntilFirstSession(t *testing.T) {
+	starts := 0
+	svc := newLazyBrowserService(func(context.Context) (mcp.BrowserService, error) {
+		starts++
+		return &fakeBrowserService{}, nil
+	})
+
+	require.NoError(t, svc.Close())
+	assert.Equal(t, 0, starts)
+}
+
+func TestLazyBrowserService_ReusesStartedService(t *testing.T) {
+	starts := 0
+	browser := &fakeBrowserService{}
+	svc := newLazyBrowserService(func(context.Context) (mcp.BrowserService, error) {
+		starts++
+		return browser, nil
+	})
+
+	_, err := svc.NewSession(context.Background())
+	require.NoError(t, err)
+	_, err = svc.NewSession(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, starts)
+	assert.Equal(t, 2, browser.sessions)
+}
+
+func TestLazyBrowserService_NewSessionAfterClose(t *testing.T) {
+	svc := newLazyBrowserService(func(context.Context) (mcp.BrowserService, error) {
+		return &fakeBrowserService{}, nil
+	})
+
+	require.NoError(t, svc.Close())
+	_, err := svc.NewSession(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "browser service closed")
+}
+
+func TestLazyBrowserService_CloseForwardsToInner(t *testing.T) {
+	inner := &fakeBrowserService{}
+	svc := newLazyBrowserService(func(context.Context) (mcp.BrowserService, error) {
+		return inner, nil
+	})
+
+	_, err := svc.NewSession(context.Background())
+	require.NoError(t, err)
+
+	require.NoError(t, svc.Close())
+	assert.True(t, inner.closed)
+}
+
+func TestLazyBrowserService_DoubleCloseIsNoop(t *testing.T) {
+	inner := &fakeBrowserService{}
+	svc := newLazyBrowserService(func(context.Context) (mcp.BrowserService, error) {
+		return inner, nil
+	})
+
+	_, err := svc.NewSession(context.Background())
+	require.NoError(t, err)
+
+	require.NoError(t, svc.Close())
+	require.NoError(t, svc.Close())
+	assert.Equal(t, 1, inner.closeCount)
+}
+
+func TestLazyBrowserService_FactoryRetryAfterTransientError(t *testing.T) {
+	attempts := 0
+	inner := &fakeBrowserService{}
+	svc := newLazyBrowserService(func(context.Context) (mcp.BrowserService, error) {
+		attempts++
+		if attempts == 1 {
+			return nil, fmt.Errorf("transient error")
+		}
+		return inner, nil
+	})
+
+	_, err := svc.NewSession(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "transient error")
+
+	_, err = svc.NewSession(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 2, attempts)
+}
+
+func TestLazyBrowserService_ConcurrentInitOnce(t *testing.T) {
+	var mu sync.Mutex
+	starts := 0
+	svc := newLazyBrowserService(func(context.Context) (mcp.BrowserService, error) {
+		mu.Lock()
+		starts++
+		mu.Unlock()
+		time.Sleep(10 * time.Millisecond)
+		return &fakeBrowserService{}, nil
+	})
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, 10)
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := svc.NewSession(context.Background())
+			errCh <- err
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		require.NoError(t, err)
+	}
+	assert.Equal(t, 1, starts)
+}
+
+type fakeBrowserService struct {
+	mu         sync.Mutex
+	sessions   int
+	closed     bool
+	closeCount int
+}
+
+func (s *fakeBrowserService) NewSession(context.Context) (mcp.BrowserSession, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sessions++
+	return &fakeBrowserSession{}, nil
+}
+
+func (s *fakeBrowserService) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.closed = true
+	s.closeCount++
+	return nil
+}
+
+type fakeBrowserSession struct{}
+
+func (s *fakeBrowserSession) AddCookies(context.Context, []mcp.BrowserCookie) error { return nil }
+func (s *fakeBrowserSession) NewPage(context.Context) (mcp.BrowserPage, error)      { return nil, nil }
+func (s *fakeBrowserSession) Close() error                                          { return nil }


### PR DESCRIPTION

## Summary

- Defer Playwright startup until a browser-backed integration actually requests a session so server boot doesn't crash in environments without a usable browser runtime.
- Add lazy browser service lifecycle coverage and make the browser evaluate assertion tolerant of numeric return type differences.

## Test plan

- [x] make ci


💘 Generated with Crush