### PR TITLE
Add Intercom integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Any integration with credentials provided via env vars will auto-enable without 
 | Datadog | `app_key` | `DD_APP_KEY` |
 | Datadog | `site` | `DD_SITE` |
 | Linear | `api_key` | `LINEAR_API_KEY` |
+| Intercom | `access_token` | `INTERCOM_ACCESS_TOKEN` |
 | Sentry | `auth_token` | `SENTRY_AUTH_TOKEN` |
 | Sentry | `organization` | `SENTRY_ORG` (optional — auto-detected from API) |
 | Slack | `token` | `SLACK_TOKEN` |

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/daltoniam/switchboard/integrations/gsheets"
 	"github.com/daltoniam/switchboard/integrations/gslides"
 	"github.com/daltoniam/switchboard/integrations/gtasks"
+	"github.com/daltoniam/switchboard/integrations/intercom"
 	"github.com/daltoniam/switchboard/integrations/jira"
 	"github.com/daltoniam/switchboard/integrations/linear"
 	"github.com/daltoniam/switchboard/integrations/metabase"
@@ -233,6 +234,7 @@ func runServer(stdioMode bool, port int, discoverAll bool) {
 		github.New(),
 		datadog.New(),
 		linear.New("https://mcp.linear.app"),
+		intercom.New(),
 		sentry.New(),
 		slackInt.New(),
 		metabase.New(),

--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,9 @@ var envMapping = map[string]map[string]string{
 	"linear": {
 		"api_key": "LINEAR_API_KEY",
 	},
+	"intercom": {
+		"access_token": "INTERCOM_ACCESS_TOKEN",
+	},
 	"sentry": {
 		"auth_token":   "SENTRY_AUTH_TOKEN",
 		"organization": "SENTRY_ORG",
@@ -201,6 +204,10 @@ func defaultConfig() *mcp.Config {
 			"linear": {
 				Enabled:     false,
 				Credentials: mcp.Credentials{"api_key": "", "mcp_access_token": "", mcp.CredKeyTokenSource: ""},
+			},
+			"intercom": {
+				Enabled:     false,
+				Credentials: mcp.Credentials{"access_token": ""},
 			},
 			"sentry": {
 				Enabled:     false,

--- a/integrations/intercom/intercom.go
+++ b/integrations/intercom/intercom.go
@@ -1,0 +1,53 @@
+// Package intercom proxies Intercom's official remote MCP server
+// (https://mcp.intercom.com) as a Switchboard integration. All tool
+// discovery and execution is delegated to remotemcp; this wrapper exists
+// so the integration has a stable Name(), a single registration point in
+// cmd/server/main.go, and a seam for future native handlers if Intercom's
+// MCP coverage proves insufficient.
+package intercom
+
+import (
+	"context"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/daltoniam/switchboard/remotemcp"
+)
+
+// defaultMCPServerURL is Intercom's hosted MCP endpoint. remotemcp
+// appends "/mcp" automatically when connecting.
+const defaultMCPServerURL = "https://mcp.intercom.com"
+
+var _ mcp.Integration = (*intercom)(nil)
+
+type intercom struct {
+	remote mcp.Integration
+}
+
+// New creates an Intercom integration backed by Intercom's official MCP
+// server. An optional URL override is accepted to support tests and
+// custom endpoints; production callers should pass nothing.
+func New(mcpServerURL ...string) mcp.Integration {
+	url := defaultMCPServerURL
+	if len(mcpServerURL) > 0 && mcpServerURL[0] != "" {
+		url = mcpServerURL[0]
+	}
+	return &intercom{remote: remotemcp.New("intercom", url)}
+}
+
+func (i *intercom) Name() string { return "intercom" }
+
+func (i *intercom) Configure(ctx context.Context, creds mcp.Credentials) error {
+	return i.remote.Configure(ctx, creds)
+}
+
+func (i *intercom) Healthy(ctx context.Context) bool {
+	return i.remote.Healthy(ctx)
+}
+
+func (i *intercom) Tools() []mcp.ToolDefinition {
+	return i.remote.Tools()
+}
+
+func (i *intercom) Execute(ctx context.Context, toolName mcp.ToolName, args map[string]any) (*mcp.ToolResult, error) {
+	return i.remote.Execute(ctx, toolName, args)
+}

--- a/integrations/intercom/intercom_test.go
+++ b/integrations/intercom/intercom_test.go
@@ -1,0 +1,63 @@
+package intercom
+
+import (
+	"context"
+	"testing"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew_DefaultServer(t *testing.T) {
+	i := New()
+	require.NotNil(t, i)
+	assert.Equal(t, "intercom", i.Name())
+}
+
+func TestNew_OverrideServerURL(t *testing.T) {
+	i := New("https://custom.example.com")
+	require.NotNil(t, i)
+	assert.Equal(t, "intercom", i.Name())
+}
+
+func TestNew_EmptyOverrideUsesDefault(t *testing.T) {
+	i := New("")
+	require.NotNil(t, i)
+	assert.Equal(t, "intercom", i.Name())
+}
+
+func TestConfigure_DelegatesAccessToken(t *testing.T) {
+	i := New("https://example.com")
+	err := i.Configure(context.Background(), mcp.Credentials{"access_token": "dG9rOmFiYw=="})
+	assert.NoError(t, err)
+}
+
+func TestConfigure_MissingAccessToken(t *testing.T) {
+	i := New("https://example.com")
+	err := i.Configure(context.Background(), mcp.Credentials{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "access_token")
+}
+
+func TestConfigure_EmptyAccessToken(t *testing.T) {
+	i := New("https://example.com")
+	err := i.Configure(context.Background(), mcp.Credentials{"access_token": ""})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "access_token")
+}
+
+func TestHealthy_NoConfigure(t *testing.T) {
+	i := New("https://example.com")
+	assert.False(t, i.Healthy(context.Background()))
+}
+
+func TestExecute_NoConnection(t *testing.T) {
+	i := New("https://invalid.example.com")
+	require.NoError(t, i.Configure(context.Background(), mcp.Credentials{"access_token": "tok"}))
+
+	result, err := i.Execute(context.Background(), mcp.ToolName("intercom_search_conversations"), nil)
+	assert.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.IsError)
+}


### PR DESCRIPTION
## Summary

Adds an `intercom` integration that proxies [Intercom's official remote MCP server](https://mcp.intercom.com) via the existing `remotemcp` package. Same pattern as `linear.New("https://mcp.linear.app")` (and the pganalyze migration in #156): a thin wrapper so tools are auto-prefixed `intercom_*`, and `configure` / `tools` / `execute` / `healthy` delegate to the upstream server.

Intercom's MCP currently exposes 13 tools — universal (`search`, `fetch`), conversations (`search_conversations`, `get_conversation`), contacts (`search_contacts`, `get_contact`), companies (`list_companies`, `get_company`), and articles (`list_articles`, `search_articles`, `get_article`, `create_article`, `update_article`). They'll surface automatically through `search` / `execute` and follow upstream as Intercom expands tool coverage.

## Changes

- `integrations/intercom/intercom.go` — ~50-line wrapper around `remotemcp.New("intercom", "https://mcp.intercom.com")`. Optional URL override for tests.
- `integrations/intercom/intercom_test.go` — constructor, name, configure delegation (incl. missing/empty token), healthy without config, execute against unreachable host.
- `cmd/server/main.go` — register `intercom.New()` in the integration list (placed next to `linear.New` since both are remote MCP proxies).
- `config/config.go` — `defaultConfig` entry with `access_token` credential, `INTERCOM_ACCESS_TOKEN` env mapping.
- `README.md` — env-vars table entry.

## Auth

Workspace Access Token from [Intercom's developer hub](https://developers.intercom.com/docs/build-an-integration/learn-more/authentication) — passed to `remotemcp` as `creds["access_token"]`, which wires it into `Authorization: Bearer <token>` via the existing `bearerTransport`. Required scopes per Intercom's [MCP docs](https://developers.intercom.com/docs/guides/mcp): read users/companies, read conversations, and read/write articles if the article tools are used. OAuth not wired (Intercom MCP supports both PAT and OAuth; PAT is sufficient for first-party data access — happy to follow up with an OAuth flow if useful).

## Test plan

- [x] CI green (build, vet, test-race, lint, security)
- [x] Local smoke: `INTERCOM_ACCESS_TOKEN=... ./switchboard` then call `search` with `intercom` filter — confirm 13 tools surface
- [x] `execute` `intercom_search_articles` with a query and verify a response


Made with [Cursor](https://cursor.com)