### PR TITLE
feat(notion): add v1 OAuth backend alongside v3 cookie path

### DIFF
--- a/integrations/notion/compact_v1.yaml
+++ b/integrations/notion/compact_v1.yaml
@@ -1,0 +1,302 @@
+# Switchboard compaction specs for the notion v1 (OAuth / api.notion.com) backend.
+#
+# Schema: see compact.yaml (the v3 specs) for the full intro. Same syntax,
+# same `version: 1`, same RenderKey wiring — this file just describes the
+# different JSON shape v1 returns.
+#
+# Why a separate file: v1 and v3 share tool names but produce structurally
+# incompatible responses. v3 is record-map-shaped (parent_id, parent_table,
+# properties.title as a flat string), v1 is object-shaped (parent.type +
+# parent.page_id, properties.<name>.title[].plain_text). A single spec
+# can't match both. notion.CompactSpec / MaxBytes / Views switch on
+# n.v1 != nil at request time and pick this set when v1 is configured.
+#
+# Field selection notes (per Notion v1 docs):
+#   - Drop universally: object, type wrappers, request_status, public_url,
+#     cover, icon, created_by, last_edited_by full objects.
+#   - Drop on list responses: per-result created_time/last_edited_time
+#     unless we're in a forensic view.
+#   - Keep: id, parent, properties, url (where present), rich_text content.
+#   - in_trash vs archived: keep `in_trash` (newer spelling); drop the
+#     deprecated `archived` alias.
+#
+# When adding a v1 tool: also wire it in dispatchV1, and consider whether
+# the response is large enough to justify a `views:` block (default rule:
+# if any field path returns a tree, add a slim default view).
+
+version: 1
+tools:
+  # ── List/search tools ────────────────────────────────────────────
+  # v1 search returns {object:"list", results:[{object:"page"|"data_source", id, parent,
+  # properties, url, created_time, last_edited_time, created_by, last_edited_by,
+  # icon, cover, public_url, in_trash, is_archived, is_locked}], next_cursor, has_more}.
+  #
+  # titles (default): id + parent + url + the title rich-text array, so the
+  # LLM has enough to pick a result. ~1–2KB for 20 results.
+  # full: above + properties (in case the LLM wants other column values) +
+  # timestamps for ordering. Still drops cover/icon/public_url/created_by/
+  # last_edited_by/locked metadata — that stuff is never useful to an LLM.
+  notion_search:
+    views:
+      titles:
+        spec:
+          - results[].id
+          - results[].parent
+          - results[].url
+          - results[].properties.title
+          - next_cursor
+          - has_more
+        hint: "Result id, parent, url, and title rich-text. Use to pick a result before drilling in."
+        formats: [json]
+      full:
+        spec:
+          - results[].id
+          - results[].parent
+          - results[].url
+          - results[].properties
+          - results[].created_time
+          - results[].last_edited_time
+          - next_cursor
+          - has_more
+        hint: "All result properties + timestamps. Use after picking a result."
+        formats: [json]
+    default:
+      view: titles
+      format: json
+
+  # v1 query_data_source returns {object:"list", results:[<page>], next_cursor, has_more}.
+  # Each row is a full v1 page object (same shape as search results).
+  #
+  # summary (default): id + last_edited_time + the title column rich-text.
+  # full: every property + timestamps. Drops cover/icon/user objects/url.
+  notion_query_data_source:
+    views:
+      summary:
+        spec:
+          - results[].id
+          - results[].properties.title
+          - results[].last_edited_time
+          - next_cursor
+          - has_more
+        hint: "Row id + title + last_edited per row. Use to find the row, then view=full for properties."
+        formats: [json]
+      full:
+        spec:
+          - results[].id
+          - results[].properties
+          - results[].created_time
+          - results[].last_edited_time
+          - next_cursor
+          - has_more
+        hint: "All properties per row. Use after picking the row(s) you need."
+        formats: [json]
+    default:
+      view: summary
+      format: json
+
+  # v1 /users returns {object:"list", results:[{id, name, type, avatar_url,
+  # person:{email}, bot:{}}], next_cursor, has_more}. Drop avatar_url and
+  # the wrapper object/type/has_more+cursor — for a workspace member list
+  # the LLM almost always just wants id + name + email.
+  notion_list_users:
+    spec:
+      - results[].id
+      - results[].name
+      - results[].person.email
+
+  # v1 /comments returns {object:"list", results:[{id, parent, discussion_id,
+  # rich_text:[{plain_text, ...}], created_time, created_by, display_name,
+  # attachments}], ...}. Comments don't have the v3-style discussion
+  # grouping; the discussion_id is per-comment.
+  #
+  # topics (default): rich_text content + discussion_id grouping key.
+  # Keeps the conversation, drops author/timestamps/attachments.
+  # full: everything including attachments.
+  notion_retrieve_comments:
+    views:
+      topics:
+        spec:
+          - results[].id
+          - results[].discussion_id
+          - results[].rich_text
+          - next_cursor
+          - has_more
+        hint: "Comment id, discussion_id, and rich-text content. Use to scan what's been said."
+        formats: [json]
+      full:
+        spec:
+          - results[].id
+          - results[].parent
+          - results[].discussion_id
+          - results[].rich_text
+          - results[].created_time
+          - results[].created_by.id
+          - results[].display_name
+          - results[].attachments
+          - next_cursor
+          - has_more
+        hint: "Full thread metadata: author id, display name, attachments, timestamps."
+        formats: [json]
+    default:
+      view: topics
+      format: json
+
+  # v1 has no "list data source templates" endpoint — v1ListDataSourceTemplates
+  # returns the synthetic shape {results:[], note:"..."}. Whitelist both
+  # so the explanatory note isn't stripped out.
+  notion_list_data_source_templates:
+    spec:
+      - results
+      - note
+
+  # ── Composite read tools ─────────────────────────────────────────
+  # v1 notion_get_page_content returns {page:<v1 page>, blocks:[<v1 block>],
+  # has_more, next_cursor}, built by our handler. The page object is the
+  # full v1 page (object, id, parent, properties, url, cover, icon,
+  # created_*, last_edited_*, archived, in_trash). Block objects each
+  # have {object, id, type, parent, has_children, archived, in_trash,
+  # created_*, last_edited_*, <type>:{...}}.
+  #
+  # toc (default): page id + parent + title property + per-block id/type +
+  # the type-specific payload (paragraph, heading_*, bulleted_list_item,
+  # etc. each live under a key matching `type`). Compaction keeps anything
+  # under `blocks[].<type>` paths if listed; since the type key varies
+  # per block, we whitelist `blocks[].id`, `blocks[].type`, and
+  # `blocks[].has_children` — the rich_text payload lives at
+  # `blocks[].paragraph.rich_text`, etc. The framework doesn't currently
+  # support dynamic per-type field selection, so `toc` deliberately omits
+  # block bodies; for the body, use view=full.
+  # full: page properties + every block field. Big but accurate.
+  #
+  # markdown rendering is JSON-only on v1 — the existing renderPageContentMD
+  # is shaped for v3 record-map block trees, not v1's typed-object blocks.
+  # Adding a v1 markdown renderer is a future PR.
+  notion_get_page_content:
+    views:
+      toc:
+        spec:
+          - page.id
+          - page.parent
+          - page.url
+          - page.properties.title
+          - blocks[].id
+          - blocks[].type
+          - blocks[].has_children
+          - has_more
+          - next_cursor
+        hint: "Page id/parent/title + per-block id/type/has_children. Use to navigate before reading."
+        formats: [json]
+      full:
+        spec:
+          - page.id
+          - page.parent
+          - page.url
+          - page.properties
+          - page.created_time
+          - page.last_edited_time
+          - blocks
+          - has_more
+          - next_cursor
+        hint: "Full page properties + entire block list. Use when you need the content."
+        formats: [json]
+    default:
+      view: toc
+      format: json
+
+  # v1 /blocks/{id}/children returns a list of v1 block objects. Keep id,
+  # type, has_children, parent, archived/in_trash status, and the
+  # type-specific payload via the whole-result-object fallthrough. Drop
+  # created_by/last_edited_by full user objects.
+  notion_get_block_children:
+    spec:
+      - results[].id
+      - results[].type
+      - results[].has_children
+      - results[].parent
+      - results[].in_trash
+      - results[].created_time
+      - results[].last_edited_time
+      - next_cursor
+      - has_more
+
+  # ── Single-record get tools ──────────────────────────────────────
+  # v1 GET /pages/{id} — drop cover/icon/public_url/created_by/last_edited_by
+  # full user objects and the deprecated `archived` alias.
+  notion_retrieve_page:
+    spec:
+      - id
+      - parent
+      - properties
+      - url
+      - in_trash
+      - created_time
+      - last_edited_time
+
+  # v1 GET /blocks/{id} — drop created_by/last_edited_by full user objects.
+  notion_retrieve_block:
+    spec:
+      - id
+      - type
+      - parent
+      - has_children
+      - in_trash
+      - created_time
+      - last_edited_time
+
+  # v1 GET /databases/{id} — drop cover/icon/created_by/last_edited_by/
+  # public_url/url. Keep id + title + parent + description + properties
+  # (the schema) + data_sources (the 2025-09-03 split list).
+  notion_retrieve_database:
+    spec:
+      - id
+      - title
+      - description
+      - parent
+      - properties
+      - data_sources
+      - in_trash
+
+  # v1 GET /data_sources/{id} — same drops as retrieve_database. The
+  # 2025-09-03 split moved the schema under data_source while the
+  # container metadata stays on the database.
+  #
+  # full stays default for the same reason it does on v3: most callers
+  # hit retrieve_data_source to learn columns before query_data_source.
+  notion_retrieve_data_source:
+    views:
+      summary:
+        spec:
+          - id
+          - name
+          - parent
+        hint: "Data source id + name + parent only. Use to verify it exists."
+        formats: [json]
+      full:
+        spec:
+          - id
+          - name
+          - description
+          - parent
+          - properties
+          - in_trash
+        hint: "id + name + description + full property schema. Use before query_data_source."
+        formats: [json]
+    default:
+      view: full
+      format: json
+
+  # v1 GET /users/{id} — drop avatar_url, type, bot/person discriminator
+  # body (we surface person.email but the bot object has nothing useful).
+  notion_retrieve_user:
+    spec:
+      - id
+      - name
+      - person.email
+
+  # v1 GET /users/me — same shape as retrieve_user but the response is
+  # always a bot user (the integration itself). Email is rarely populated.
+  notion_get_self:
+    spec:
+      - id
+      - name
+      - bot.workspace_name

--- a/integrations/notion/notion.go
+++ b/integrations/notion/notion.go
@@ -21,6 +21,9 @@ const maxResponseSize = 512 << 10 // 512 KB — largest real response ~230KB, ca
 //go:embed compact.yaml
 var compactYAML []byte
 
+//go:embed compact_v1.yaml
+var compactV1YAML []byte
+
 // renderFullPageContentMD bridges the legacy raw-bytes markdown renderer
 // (renderPageContentMD in markdown.go) into the new typed Renderer
 // shape. Used as the custom renderer for
@@ -62,6 +65,19 @@ var compactResult = compact.MustLoadWithOverlay("notion", compactYAML, compact.O
 var fieldCompactionSpecs = compactResult.Specs
 var maxBytesByTool = compactResult.MaxBytes
 var viewSets = compactResult.Views
+
+// compact_v1.yaml uses the same per-tool schema but matches the
+// public-API response shapes (parent objects, nested properties,
+// has_more/next_cursor, etc.). No custom markdown renderers — the
+// existing renderers are v3 record-map specific and would mis-render
+// v1 data; v1 stays JSON-only until a v1 renderer lands.
+var compactV1Result = compact.MustLoadWithOverlay("notion_v1", compactV1YAML, compact.Options{
+	Strict: false,
+})
+
+var v1FieldCompactionSpecs = compactV1Result.Specs
+var v1MaxBytesByTool = compactV1Result.MaxBytes
+var v1ViewSets = compactV1Result.Views
 
 var (
 	_ mcp.Integration                = (*notion)(nil)
@@ -202,11 +218,19 @@ func (n *notion) Tools() []mcp.ToolDefinition {
 }
 
 func (n *notion) CompactSpec(toolName mcp.ToolName) ([]mcp.CompactField, bool) {
+	if n.v1 != nil {
+		fields, ok := v1FieldCompactionSpecs[toolName]
+		return fields, ok
+	}
 	fields, ok := fieldCompactionSpecs[toolName]
 	return fields, ok
 }
 
 func (n *notion) MaxBytes(toolName mcp.ToolName) (int, bool) {
+	if n.v1 != nil {
+		n2, ok := v1MaxBytesByTool[toolName]
+		return n2, ok
+	}
 	n2, ok := maxBytesByTool[toolName]
 	return n2, ok
 }
@@ -214,7 +238,15 @@ func (n *notion) MaxBytes(toolName mcp.ToolName) (int, bool) {
 // Views returns the multi-view config for tools that declared one.
 // Tools without a `views:` block in compact.yaml return (zero, false)
 // and the server falls back to today's single-spec compaction path.
+//
+// When the v1 (OAuth) backend is active we serve specs from
+// compact_v1.yaml — the shapes are different enough that the v3 specs
+// would project the wrong paths.
 func (n *notion) Views(toolName mcp.ToolName) (compact.ViewSet, bool) {
+	if n.v1 != nil {
+		vs, ok := v1ViewSets[toolName]
+		return vs, ok
+	}
 	vs, ok := viewSets[toolName]
 	return vs, ok
 }

--- a/integrations/notion/notion.go
+++ b/integrations/notion/notion.go
@@ -71,12 +71,29 @@ var (
 	_ compact.ToolViewsIntegration   = (*notion)(nil)
 )
 
+// notion is the integration's top-level type. It holds the v3 cookie
+// backend state inline (for backward compatibility with existing
+// self-hosters) and a non-nil v1 if the user supplied an OAuth access
+// token instead. When v1 is non-nil, Execute/Healthy delegate to it
+// and the v3 fields are unused.
+//
+// Backend selection happens in Configure() based on which credential
+// keys are present:
+//
+//	access_token → v1 (api.notion.com/v1, OAuth bearer, Notion-Version header)
+//	token_v2     → v3 (www.notion.so/api/v3, browser session cookie)
+//
+// If both are present, v1 wins (OAuth is the recommended, supported
+// path; v3 only sticks around for users who set it up before OAuth
+// existed).
 type notion struct {
 	tokenV2 string
 	spaceID string
 	userID  string
 	baseURL string
 	client  *http.Client
+
+	v1 *notionV1
 }
 
 func New() mcp.Integration {
@@ -97,9 +114,25 @@ func New() mcp.Integration {
 func (n *notion) Name() string { return "notion" }
 
 func (n *notion) Configure(ctx context.Context, creds mcp.Credentials) error {
+	// Prefer v1 OAuth if an access token is present.
+	if tok := creds["access_token"]; tok != "" {
+		v1 := newV1Backend(tok)
+		if v := creds["base_url"]; v != "" {
+			v1.baseURL = strings.TrimRight(v, "/")
+		}
+		if v := creds["notion_version"]; v != "" {
+			v1.apiVersion = v
+		}
+		if err := v1.configure(ctx); err != nil {
+			return err
+		}
+		n.v1 = v1
+		return nil
+	}
+
 	n.tokenV2 = creds["token_v2"]
 	if n.tokenV2 == "" {
-		return fmt.Errorf("notion: token_v2 is required")
+		return fmt.Errorf("notion: access_token (OAuth) or token_v2 (cookie) is required")
 	}
 	if v := creds["base_url"]; v != "" {
 		n.baseURL = strings.TrimRight(v, "/")
@@ -154,6 +187,9 @@ func (n *notion) resolveSpaceAndUser(ctx context.Context) (string, string, error
 }
 
 func (n *notion) Healthy(ctx context.Context) bool {
+	if n.v1 != nil {
+		return n.v1.healthy(ctx)
+	}
 	if n.client == nil || n.tokenV2 == "" {
 		return false
 	}
@@ -184,6 +220,16 @@ func (n *notion) Views(toolName mcp.ToolName) (compact.ViewSet, bool) {
 }
 
 func (n *notion) Execute(ctx context.Context, toolName mcp.ToolName, args map[string]any) (*mcp.ToolResult, error) {
+	if n.v1 != nil {
+		fn, ok := dispatchV1[toolName]
+		if !ok {
+			return &mcp.ToolResult{
+				Data:    fmt.Sprintf("tool %q is not yet supported on the Notion OAuth (v1) backend; see switchboard repo issues", toolName),
+				IsError: true,
+			}, nil
+		}
+		return fn(ctx, n.v1, args)
+	}
 	fn, ok := dispatch[toolName]
 	if !ok {
 		return &mcp.ToolResult{Data: fmt.Sprintf("unknown tool: %s", toolName), IsError: true}, nil

--- a/integrations/notion/notion_test.go
+++ b/integrations/notion/notion_test.go
@@ -122,7 +122,10 @@ func TestConfigure_RejectsEmptyTokenV2(t *testing.T) {
 	i := New()
 	err := i.Configure(context.Background(), mcp.Credentials{"token_v2": ""})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "token_v2 is required")
+	// Two creds are accepted now (v3 token_v2 OR v1 access_token); the
+	// error message should mention both paths so users know which to set.
+	assert.Contains(t, err.Error(), "access_token")
+	assert.Contains(t, err.Error(), "token_v2")
 }
 
 func TestConfigure_TrimsTrailingSlashFromCustomBaseURL(t *testing.T) {

--- a/integrations/notion/v1.go
+++ b/integrations/notion/v1.go
@@ -1,0 +1,188 @@
+package notion
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+// notionV1 is the public-API backend (api.notion.com/v1 with OAuth bearer
+// tokens). It is selected by Configure when creds["access_token"] is set.
+//
+// Unlike the v3 backend (which talks to www.notion.so/api/v3 via a session
+// cookie), the v1 backend uses Notion's documented REST API and a versioned
+// header. Pages must be explicitly shared with the integration by the user
+// during the OAuth install flow (or via Add Connections later) — there is
+// no implicit workspace-wide visibility.
+type notionV1 struct {
+	accessToken string
+	baseURL     string
+	apiVersion  string
+	client      *http.Client
+}
+
+// defaultV1APIVersion is the date-stamped Notion API version we send in
+// the Notion-Version header. 2025-09-03 introduced the data_sources model
+// that matches the v3 backend's split between "database container" and
+// "data source schema", so the public surface aligns naturally.
+const defaultV1APIVersion = "2025-09-03"
+
+func newV1Backend(accessToken string) *notionV1 {
+	return &notionV1{
+		accessToken: accessToken,
+		baseURL:     "https://api.notion.com/v1",
+		apiVersion:  defaultV1APIVersion,
+		client: &http.Client{
+			Timeout: 30 * time.Second,
+			Transport: &http.Transport{
+				MaxConnsPerHost: 10,
+			},
+		},
+	}
+}
+
+// configure runs any one-time setup against the API. For v1 there is no
+// space-resolution step (every request is scoped by the OAuth token), so
+// configure just confirms the token works by hitting /users/me.
+func (n *notionV1) configure(ctx context.Context) error {
+	if n.accessToken == "" {
+		return fmt.Errorf("notion: access_token is required")
+	}
+	if _, err := n.doRequest(ctx, http.MethodGet, "/users/me", nil); err != nil {
+		return fmt.Errorf("notion: token check failed: %w", err)
+	}
+	return nil
+}
+
+func (n *notionV1) healthy(ctx context.Context) bool {
+	if n.client == nil || n.accessToken == "" {
+		return false
+	}
+	_, err := n.doRequest(ctx, http.MethodGet, "/users/me", nil)
+	return err == nil
+}
+
+// doRequest sends a JSON request to api.notion.com/v1 with the OAuth bearer
+// token and the required Notion-Version header. 429/5xx responses surface
+// as *mcp.RetryableError so the runtime backs off; other 4xx codes return
+// a formatted error.
+//
+// pathAndQuery may include a query string; the caller is responsible for
+// url-encoding it.
+func (n *notionV1) doRequest(ctx context.Context, method, pathAndQuery string, body any) (json.RawMessage, error) {
+	var bodyReader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return nil, err
+		}
+		bodyReader = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, n.baseURL+pathAndQuery, bodyReader)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+n.accessToken)
+	req.Header.Set("Notion-Version", n.apiVersion)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := n.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respData, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode == 429 || resp.StatusCode >= 500 {
+		re := &mcp.RetryableError{
+			StatusCode: resp.StatusCode,
+			Err:        formatV1APIError(resp.StatusCode, respData),
+		}
+		re.RetryAfter = mcp.ParseRetryAfter(resp.Header.Get("Retry-After"))
+		return nil, re
+	}
+	if resp.StatusCode >= 400 {
+		return nil, formatV1APIError(resp.StatusCode, respData)
+	}
+	if resp.StatusCode == http.StatusNoContent || len(respData) == 0 {
+		return json.RawMessage(`{"status":"success"}`), nil
+	}
+	return json.RawMessage(respData), nil
+}
+
+// Verb shortcuts mirror the Sentry/Vercel pattern; pathFmt may contain
+// fmt-style placeholders for path segments.
+func (n *notionV1) get(ctx context.Context, pathFmt string, args ...any) (json.RawMessage, error) {
+	return n.doRequest(ctx, http.MethodGet, fmt.Sprintf(pathFmt, args...), nil)
+}
+
+func (n *notionV1) post(ctx context.Context, path string, body any) (json.RawMessage, error) {
+	return n.doRequest(ctx, http.MethodPost, path, body)
+}
+
+func (n *notionV1) patch(ctx context.Context, path string, body any) (json.RawMessage, error) {
+	return n.doRequest(ctx, http.MethodPatch, path, body)
+}
+
+func (n *notionV1) del(ctx context.Context, pathFmt string, args ...any) (json.RawMessage, error) {
+	return n.doRequest(ctx, http.MethodDelete, fmt.Sprintf(pathFmt, args...), nil)
+}
+
+// formatV1APIError parses Notion's documented error envelope:
+//
+//	{ "object": "error", "status": 400, "code": "validation_error", "message": "..." }
+//
+// Falls back to the truncated raw body for anything that doesn't match.
+func formatV1APIError(statusCode int, body []byte) error {
+	var errResp struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	}
+	if json.Unmarshal(body, &errResp) == nil && errResp.Code != "" {
+		return fmt.Errorf("notion API error (%d): %s: %s", statusCode, errResp.Code, errResp.Message)
+	}
+	s := string(body)
+	if len(s) > maxErrorLen {
+		s = s[:maxErrorLen] + "... (truncated)"
+	}
+	return fmt.Errorf("notion API error (%d): %s", statusCode, s)
+}
+
+// v1HandlerFunc is the signature for v1 tool handlers. Mirrors handlerFunc
+// (v3) but takes *notionV1 instead of *notion.
+type v1HandlerFunc func(ctx context.Context, n *notionV1, args map[string]any) (*mcp.ToolResult, error)
+
+// queryEncode is a small helper for building "?a=1&b=2" suffixes without
+// dragging url.Values into every handler. Empty values are skipped.
+func queryEncode(params map[string]string) string {
+	if len(params) == 0 {
+		return ""
+	}
+	v := url.Values{}
+	for k, val := range params {
+		if val == "" {
+			continue
+		}
+		v.Set(k, val)
+	}
+	enc := v.Encode()
+	if enc == "" {
+		return ""
+	}
+	return "?" + enc
+}

--- a/integrations/notion/v1_blocks.go
+++ b/integrations/notion/v1_blocks.go
@@ -1,0 +1,181 @@
+package notion
+
+import (
+	"context"
+	"fmt"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+// --- Blocks (v1) ---
+
+func v1RetrieveBlock(ctx context.Context, n *notionV1, args map[string]any) (*mcp.ToolResult, error) {
+	blockID, err := mcp.ArgStr(args, "block_id")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	if blockID == "" {
+		return mcp.ErrResult(fmt.Errorf("block_id is required"))
+	}
+	data, err := n.get(ctx, "/blocks/%s", blockID)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+// v1UpdateBlock translates the v3 `type_content` payload into the v1 shape.
+// v3 callers send: {"properties": {"title": [["new text"]]}}
+// v1 expects: {"<block_type>": {"rich_text": [{"type":"text","text":{"content":"new text"}}]}}
+//
+// To translate we need to know the block's current type, so we fetch it
+// first. Power-users can bypass the translation by providing a pre-shaped
+// v1 payload with the block type as the top-level key (e.g.
+// {"paragraph": {"rich_text": [...]}}) — that pass-through preserves the
+// full v1 expressiveness (annotations, links, mentions, etc).
+func v1UpdateBlock(ctx context.Context, n *notionV1, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	blockID := r.Str("block_id")
+	typeContent := r.Map("type_content")
+	archived := r.Bool("archived")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if blockID == "" {
+		return mcp.ErrResult(fmt.Errorf("block_id is required"))
+	}
+
+	body := map[string]any{}
+	if archived {
+		body["archived"] = true
+	}
+
+	if typeContent != nil {
+		// Pass-through: caller supplied a v1-shaped payload.
+		passedThrough := false
+		for k, v := range typeContent {
+			if k == "properties" || k == "format" {
+				continue
+			}
+			body[k] = v
+			passedThrough = true
+		}
+
+		// Legacy v3 path: translate properties.title to v1 rich_text.
+		if !passedThrough {
+			blockType, err := v1FetchBlockType(ctx, n, blockID)
+			if err != nil {
+				return mcp.ErrResult(err)
+			}
+			text := v1ExtractV3TitleText(map[string]any{"properties": typeContent["properties"]})
+			payload := map[string]any{"rich_text": v1RichTextFromString(text)}
+			body[blockType] = payload
+		}
+	}
+
+	if len(body) == 0 {
+		return mcp.ErrResult(fmt.Errorf("at least one of type_content or archived must be set"))
+	}
+
+	data, err := n.patch(ctx, "/blocks/"+blockID, body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func v1DeleteBlock(ctx context.Context, n *notionV1, args map[string]any) (*mcp.ToolResult, error) {
+	blockID, err := mcp.ArgStr(args, "block_id")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	if blockID == "" {
+		return mcp.ErrResult(fmt.Errorf("block_id is required"))
+	}
+	data, err := n.del(ctx, "/blocks/%s", blockID)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func v1GetBlockChildren(ctx context.Context, n *notionV1, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	blockID := r.Str("block_id")
+	startCursor := r.Str("start_cursor")
+	pageSize := r.Int("page_size")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if blockID == "" {
+		return mcp.ErrResult(fmt.Errorf("block_id is required"))
+	}
+	if pageSize <= 0 || pageSize > 100 {
+		pageSize = 100
+	}
+	qs := queryEncode(map[string]string{
+		"start_cursor": startCursor,
+		"page_size":    fmt.Sprintf("%d", pageSize),
+	})
+	data, err := n.get(ctx, "/blocks/%s/children%s", blockID, qs)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func v1AppendBlockChildren(ctx context.Context, n *notionV1, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	blockID := r.Str("block_id")
+	after := r.Str("after")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if blockID == "" {
+		return mcp.ErrResult(fmt.Errorf("block_id is required"))
+	}
+	childrenAny, ok := args["children"].([]any)
+	if !ok || len(childrenAny) == 0 {
+		return mcp.ErrResult(fmt.Errorf("children is required"))
+	}
+	if len(childrenAny) > 100 {
+		return mcp.ErrResult(fmt.Errorf("v1 append_block_children accepts up to 100 children per call; got %d. Split into multiple calls", len(childrenAny)))
+	}
+
+	normalized := make([]any, 0, len(childrenAny))
+	for _, c := range childrenAny {
+		if cm, ok := c.(map[string]any); ok {
+			normalized = append(normalized, v1NormalizeBlock(cm))
+		}
+	}
+
+	body := map[string]any{"children": normalized}
+	if after != "" {
+		body["after"] = after
+	}
+	data, err := n.patch(ctx, "/blocks/"+blockID+"/children", body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+// v1FetchBlockType issues a GET /blocks/{id} and returns the block's
+// "type" field. Used by update_block to translate the v3 properties.title
+// payload into a v1 rich_text payload keyed by the block's type.
+func v1FetchBlockType(ctx context.Context, n *notionV1, blockID string) (string, error) {
+	data, err := n.get(ctx, "/blocks/%s", blockID)
+	if err != nil {
+		return "", err
+	}
+	var b struct {
+		Type string `json:"type"`
+	}
+	if err := jsonUnmarshalLite(data, &b); err != nil {
+		return "", err
+	}
+	if b.Type == "" {
+		return "", fmt.Errorf("could not determine block type for %s", blockID)
+	}
+	return b.Type, nil
+}

--- a/integrations/notion/v1_blocks.go
+++ b/integrations/notion/v1_blocks.go
@@ -2,6 +2,7 @@ package notion
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	mcp "github.com/daltoniam/switchboard"
@@ -171,7 +172,7 @@ func v1FetchBlockType(ctx context.Context, n *notionV1, blockID string) (string,
 	var b struct {
 		Type string `json:"type"`
 	}
-	if err := jsonUnmarshalLite(data, &b); err != nil {
+	if err := json.Unmarshal(data, &b); err != nil {
 		return "", err
 	}
 	if b.Type == "" {

--- a/integrations/notion/v1_data_sources.go
+++ b/integrations/notion/v1_data_sources.go
@@ -1,0 +1,209 @@
+package notion
+
+import (
+	"context"
+	"fmt"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+// --- Databases & Data Sources (v1) ---
+//
+// Notion's 2025-09-03 API split each "database" into a container (which
+// owns metadata, title, parent, multiple views) and one or more "data
+// sources" (each owns a schema and rows). Older callers using
+// `database_id` continue to work — Notion routes them to the database's
+// first data source automatically.
+//
+// Tool-name mapping:
+//   notion_create_database            → POST   /v1/databases
+//   notion_retrieve_data_source       → GET    /v1/data_sources/{id}    (falls back to /v1/databases/{id})
+//   notion_update_data_source         → PATCH  /v1/data_sources/{id}    (falls back to /v1/databases/{id})
+//   notion_query_data_source          → POST   /v1/data_sources/{id}/query  (falls back to /v1/databases/{id}/query)
+//   notion_list_data_source_templates → not directly supported; emulated via search
+//   notion_retrieve_database          → GET    /v1/databases/{id}
+
+func v1CreateDatabase(ctx context.Context, n *notionV1, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	parent := r.Map("parent")
+	properties := r.Map("properties")
+	title := r.Str("title")
+	isInline := r.Bool("is_inline")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if parent == nil {
+		return mcp.ErrResult(fmt.Errorf("parent is required"))
+	}
+
+	parentObj, err := v1BuildParentObject(parent)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	schema := properties
+	if schema == nil {
+		schema = map[string]any{
+			"Name": map[string]any{"title": map[string]any{}},
+		}
+	}
+
+	body := map[string]any{
+		"parent":     parentObj,
+		"properties": schema,
+		"is_inline":  isInline,
+	}
+	if title != "" {
+		body["title"] = []any{
+			map[string]any{
+				"type": "text",
+				"text": map[string]any{"content": title},
+			},
+		}
+	}
+
+	data, err := n.post(ctx, "/databases", body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func v1RetrieveDataSource(ctx context.Context, n *notionV1, args map[string]any) (*mcp.ToolResult, error) {
+	id, err := mcp.ArgStr(args, "data_source_id")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	if id == "" {
+		return mcp.ErrResult(fmt.Errorf("data_source_id is required"))
+	}
+	return v1FetchDatabaseOrDataSource(ctx, n, id)
+}
+
+func v1RetrieveDatabase(ctx context.Context, n *notionV1, args map[string]any) (*mcp.ToolResult, error) {
+	id, err := mcp.ArgStr(args, "database_id")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	if id == "" {
+		return mcp.ErrResult(fmt.Errorf("database_id is required"))
+	}
+	return v1FetchDatabaseOrDataSource(ctx, n, id)
+}
+
+func v1UpdateDataSource(ctx context.Context, n *notionV1, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("data_source_id")
+	title := r.Str("title")
+	properties := r.Map("properties")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if id == "" {
+		return mcp.ErrResult(fmt.Errorf("data_source_id is required"))
+	}
+
+	body := map[string]any{}
+	if title != "" {
+		body["title"] = []any{
+			map[string]any{
+				"type": "text",
+				"text": map[string]any{"content": title},
+			},
+		}
+	}
+	if properties != nil {
+		body["properties"] = properties
+	}
+	if len(body) == 0 {
+		return mcp.ErrResult(fmt.Errorf("at least one of title or properties must be set"))
+	}
+
+	// Prefer data_sources; fall back to databases for older IDs.
+	data, err := n.patch(ctx, "/data_sources/"+id, body)
+	if err != nil {
+		data, err = n.patch(ctx, "/databases/"+id, body)
+		if err != nil {
+			return mcp.ErrResult(err)
+		}
+	}
+	return mcp.RawResult(data)
+}
+
+func v1QueryDataSource(ctx context.Context, n *notionV1, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("data_source_id")
+	filter := r.Map("filter")
+	startCursor := r.Str("start_cursor")
+	pageSize := r.Int("page_size")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if id == "" {
+		return mcp.ErrResult(fmt.Errorf("data_source_id is required"))
+	}
+
+	body := map[string]any{}
+	if filter != nil {
+		body["filter"] = filter
+	}
+	if sorts, ok := args["sorts"].([]any); ok && len(sorts) > 0 {
+		body["sorts"] = sorts
+	}
+	if startCursor != "" {
+		body["start_cursor"] = startCursor
+	}
+	if pageSize > 0 {
+		if pageSize > 100 {
+			pageSize = 100
+		}
+		body["page_size"] = pageSize
+	}
+
+	data, err := n.post(ctx, "/data_sources/"+id+"/query", body)
+	if err != nil {
+		// Older callers may pass a database_id under data_source_id.
+		data, err = n.post(ctx, "/databases/"+id+"/query", body)
+		if err != nil {
+			return mcp.ErrResult(err)
+		}
+	}
+	return mcp.RawResult(data)
+}
+
+// v1ListDataSourceTemplates is a best-effort port. Notion's public v1 API
+// does NOT expose a "list database templates" endpoint — the templates
+// model is partially internal. We return an empty result with an
+// explanatory note rather than fail, so workflows that branch on
+// "templates exist?" keep working.
+func v1ListDataSourceTemplates(ctx context.Context, n *notionV1, args map[string]any) (*mcp.ToolResult, error) {
+	id, err := mcp.ArgStr(args, "data_source_id")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	if id == "" {
+		return mcp.ErrResult(fmt.Errorf("data_source_id is required"))
+	}
+	_ = ctx
+	_ = n
+	return mcp.JSONResult(map[string]any{
+		"results": []any{},
+		"note":    "Notion v1 API does not expose database templates; this tool returns an empty list on the OAuth backend.",
+	})
+}
+
+// v1FetchDatabaseOrDataSource tries /data_sources/{id} first (the
+// 2025-09-03 endpoint), falls back to /databases/{id} for IDs that pre-date
+// the split or for callers that pass the container ID interchangeably.
+func v1FetchDatabaseOrDataSource(ctx context.Context, n *notionV1, id string) (*mcp.ToolResult, error) {
+	data, err := n.get(ctx, "/data_sources/%s", id)
+	if err == nil {
+		return mcp.RawResult(data)
+	}
+	data, err2 := n.get(ctx, "/databases/%s", id)
+	if err2 != nil {
+		// Surface the original error since it's the more likely path.
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}

--- a/integrations/notion/v1_data_sources.go
+++ b/integrations/notion/v1_data_sources.go
@@ -2,6 +2,7 @@ package notion
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	mcp "github.com/daltoniam/switchboard"
@@ -120,8 +121,16 @@ func v1UpdateDataSource(ctx context.Context, n *notionV1, args map[string]any) (
 	}
 
 	// Prefer data_sources; fall back to databases for older IDs.
+	// Only fall back on non-retryable failures — if Notion rate-limits us
+	// (429) or 5xx's, doRequest returns a *mcp.RetryableError that the
+	// runtime knows how to back off on. Swallowing that and immediately
+	// firing a second request would double the load and lose the signal.
 	data, err := n.patch(ctx, "/data_sources/"+id, body)
 	if err != nil {
+		var re *mcp.RetryableError
+		if errors.As(err, &re) {
+			return mcp.ErrResult(err)
+		}
 		data, err = n.patch(ctx, "/databases/"+id, body)
 		if err != nil {
 			return mcp.ErrResult(err)
@@ -162,6 +171,10 @@ func v1QueryDataSource(ctx context.Context, n *notionV1, args map[string]any) (*
 
 	data, err := n.post(ctx, "/data_sources/"+id+"/query", body)
 	if err != nil {
+		var re *mcp.RetryableError
+		if errors.As(err, &re) {
+			return mcp.ErrResult(err)
+		}
 		// Older callers may pass a database_id under data_source_id.
 		data, err = n.post(ctx, "/databases/"+id+"/query", body)
 		if err != nil {
@@ -199,6 +212,12 @@ func v1FetchDatabaseOrDataSource(ctx context.Context, n *notionV1, id string) (*
 	data, err := n.get(ctx, "/data_sources/%s", id)
 	if err == nil {
 		return mcp.RawResult(data)
+	}
+	// Don't swallow rate-limit / 5xx — those need to bubble up as
+	// retryable so the runtime backs off.
+	var re *mcp.RetryableError
+	if errors.As(err, &re) {
+		return mcp.ErrResult(err)
 	}
 	data, err2 := n.get(ctx, "/databases/%s", id)
 	if err2 != nil {

--- a/integrations/notion/v1_dispatch.go
+++ b/integrations/notion/v1_dispatch.go
@@ -1,0 +1,51 @@
+package notion
+
+import mcp "github.com/daltoniam/switchboard"
+
+// dispatchV1 is the v1 backend's tool routing table. Mirrors the v3
+// `dispatch` map; same tool names, different handlers. When the
+// integration is configured with an OAuth access token, notion.Execute
+// looks tools up here.
+//
+// Tools that have no v1 equivalent (none today, but reserved for future
+// v3-only surfaces) should be left out — notion.Execute returns a
+// "not supported on v1 backend" error for missing entries.
+var dispatchV1 = map[mcp.ToolName]v1HandlerFunc{
+	// Data Sources / Databases
+	mcp.ToolName("notion_create_database"):            v1CreateDatabase,
+	mcp.ToolName("notion_retrieve_data_source"):       v1RetrieveDataSource,
+	mcp.ToolName("notion_update_data_source"):         v1UpdateDataSource,
+	mcp.ToolName("notion_query_data_source"):          v1QueryDataSource,
+	mcp.ToolName("notion_list_data_source_templates"): v1ListDataSourceTemplates,
+	mcp.ToolName("notion_retrieve_database"):          v1RetrieveDatabase,
+
+	// Pages
+	mcp.ToolName("notion_create_page"):            v1CreatePage,
+	mcp.ToolName("notion_retrieve_page"):          v1RetrievePage,
+	mcp.ToolName("notion_update_page"):            v1UpdatePage,
+	mcp.ToolName("notion_move_page"):              v1MovePage,
+	mcp.ToolName("notion_retrieve_page_property"): v1RetrievePageProperty,
+
+	// Blocks
+	mcp.ToolName("notion_retrieve_block"):        v1RetrieveBlock,
+	mcp.ToolName("notion_update_block"):          v1UpdateBlock,
+	mcp.ToolName("notion_delete_block"):          v1DeleteBlock,
+	mcp.ToolName("notion_get_block_children"):    v1GetBlockChildren,
+	mcp.ToolName("notion_append_block_children"): v1AppendBlockChildren,
+
+	// Search
+	mcp.ToolName("notion_search"): v1Search,
+
+	// Users
+	mcp.ToolName("notion_list_users"):    v1ListUsers,
+	mcp.ToolName("notion_retrieve_user"): v1RetrieveUser,
+	mcp.ToolName("notion_get_self"):      v1GetSelf,
+
+	// Comments
+	mcp.ToolName("notion_create_comment"):    v1CreateComment,
+	mcp.ToolName("notion_retrieve_comments"): v1RetrieveComments,
+
+	// Convenience
+	mcp.ToolName("notion_get_page_content"):         v1GetPageContent,
+	mcp.ToolName("notion_create_page_with_content"): v1CreatePageWithContent,
+}

--- a/integrations/notion/v1_other.go
+++ b/integrations/notion/v1_other.go
@@ -2,7 +2,6 @@ package notion
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	mcp "github.com/daltoniam/switchboard"
@@ -150,14 +149,4 @@ func v1RetrieveComments(ctx context.Context, n *notionV1, args map[string]any) (
 		return mcp.ErrResult(err)
 	}
 	return mcp.RawResult(data)
-}
-
-// --- Tiny shared helper ---
-//
-// jsonUnmarshalLite is the smallest possible wrapper around json.Unmarshal
-// so v1 handlers don't have to reach for the legacy unmarshalJSON helper
-// (which exists in the v3 codepath but has no special semantics worth
-// sharing).
-func jsonUnmarshalLite(data []byte, v any) error {
-	return json.Unmarshal(data, v)
 }

--- a/integrations/notion/v1_other.go
+++ b/integrations/notion/v1_other.go
@@ -1,0 +1,163 @@
+package notion
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+// --- Search (v1) ---
+//
+// v1 search is scoped to pages that have been shared with the integration
+// — there is no implicit workspace-wide visibility like the v3 cookie
+// backend has. Callers querying "is page X here?" need to either pre-share
+// it or instruct the user to do so via Notion's "Add Connections" menu.
+
+func v1Search(ctx context.Context, n *notionV1, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	query := r.Str("query")
+	typeFilter := r.Str("type")
+	limit := r.Int("limit")
+	sortArg := r.Map("sort")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	body := map[string]any{}
+	if query != "" {
+		body["query"] = query
+	}
+	if typeFilter != "" {
+		// Notion v1 expects: filter: {property: "object", value: "page" | "data_source"}
+		// The v3 tool accepted "page" or "data_source" — translate.
+		value := typeFilter
+		if value == "database" {
+			value = "data_source"
+		}
+		body["filter"] = map[string]any{"property": "object", "value": value}
+	}
+	if sortArg != nil {
+		// v1 sort accepts {direction: "ascending"|"descending", timestamp: "last_edited_time"}
+		body["sort"] = sortArg
+	} else {
+		body["sort"] = map[string]any{"direction": "descending", "timestamp": "last_edited_time"}
+	}
+	if limit > 0 {
+		if limit > 100 {
+			limit = 100
+		}
+		body["page_size"] = limit
+	}
+
+	data, err := n.post(ctx, "/search", body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+// --- Users (v1) ---
+
+func v1ListUsers(ctx context.Context, n *notionV1, args map[string]any) (*mcp.ToolResult, error) {
+	_ = args
+	data, err := n.get(ctx, "/users")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func v1RetrieveUser(ctx context.Context, n *notionV1, args map[string]any) (*mcp.ToolResult, error) {
+	userID, err := mcp.ArgStr(args, "user_id")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	if userID == "" {
+		return mcp.ErrResult(fmt.Errorf("user_id is required"))
+	}
+	data, err := n.get(ctx, "/users/%s", userID)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func v1GetSelf(ctx context.Context, n *notionV1, args map[string]any) (*mcp.ToolResult, error) {
+	_ = args
+	data, err := n.get(ctx, "/users/me")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+// --- Comments (v1) ---
+
+func v1CreateComment(ctx context.Context, n *notionV1, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	text := r.Str("text")
+	pageID := r.Str("page_id")
+	discussionID := r.Str("discussion_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if text == "" {
+		return mcp.ErrResult(fmt.Errorf("text is required"))
+	}
+	if pageID == "" && discussionID == "" {
+		return mcp.ErrResult(fmt.Errorf("page_id or discussion_id is required"))
+	}
+
+	body := map[string]any{
+		"rich_text": v1RichTextFromString(text),
+	}
+	if discussionID != "" {
+		body["discussion_id"] = discussionID
+	} else {
+		body["parent"] = map[string]any{"page_id": pageID}
+	}
+
+	data, err := n.post(ctx, "/comments", body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func v1RetrieveComments(ctx context.Context, n *notionV1, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	blockID := r.Str("block_id")
+	startCursor := r.Str("start_cursor")
+	pageSize := r.Int("page_size")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if blockID == "" {
+		return mcp.ErrResult(fmt.Errorf("block_id is required"))
+	}
+	if pageSize <= 0 || pageSize > 100 {
+		pageSize = 100
+	}
+	qs := queryEncode(map[string]string{
+		"block_id":     blockID,
+		"start_cursor": startCursor,
+		"page_size":    fmt.Sprintf("%d", pageSize),
+	})
+	data, err := n.get(ctx, "/comments%s", qs)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+// --- Tiny shared helper ---
+//
+// jsonUnmarshalLite is the smallest possible wrapper around json.Unmarshal
+// so v1 handlers don't have to reach for the legacy unmarshalJSON helper
+// (which exists in the v3 codepath but has no special semantics worth
+// sharing).
+func jsonUnmarshalLite(data []byte, v any) error {
+	return json.Unmarshal(data, v)
+}

--- a/integrations/notion/v1_pages.go
+++ b/integrations/notion/v1_pages.go
@@ -1,0 +1,463 @@
+package notion
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+// --- Pages (v1) ---
+//
+// Notion v1 page semantics:
+//   - parent.page_id      → subpage under a page
+//   - parent.database_id  → row in a database (v1 alias for data_source_id)
+//   - parent.data_source_id (2025-09-03) → row in a specific data source
+//   - parent.workspace    → workspace-level page (public OAuth apps only)
+//
+// The v3 backend used a single "parent" arg with page_id OR database_id.
+// The v1 backend accepts the same shape and translates: database_id is
+// passed through as-is so callers don't have to relearn the schema, but
+// callers using the newer model may also pass data_source_id directly.
+
+func v1CreatePage(ctx context.Context, n *notionV1, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	parent := r.Map("parent")
+	properties := r.Map("properties")
+	title := r.Str("title")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if parent == nil {
+		return mcp.ErrResult(fmt.Errorf("parent is required"))
+	}
+
+	body, err := v1BuildPageBody(parent, properties, title, nil)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	data, err := n.post(ctx, "/pages", body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func v1RetrievePage(ctx context.Context, n *notionV1, args map[string]any) (*mcp.ToolResult, error) {
+	pageID, err := mcp.ArgStr(args, "page_id")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	if pageID == "" {
+		return mcp.ErrResult(fmt.Errorf("page_id is required"))
+	}
+	data, err := n.get(ctx, "/pages/%s", pageID)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func v1UpdatePage(ctx context.Context, n *notionV1, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	pageID := r.Str("page_id")
+	props := r.Map("properties")
+	archived := r.Bool("archived")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if pageID == "" {
+		return mcp.ErrResult(fmt.Errorf("page_id is required"))
+	}
+
+	body := map[string]any{}
+	if props != nil {
+		body["properties"] = props
+	}
+	if archived {
+		// Notion accepts both keys; "archived" is the older field name
+		// (2022-06-28) and "in_trash" is the 2025-09-03 spelling. Send
+		// "archived" for broadest compatibility — both versions of the
+		// API accept it.
+		body["archived"] = true
+	}
+	if len(body) == 0 {
+		return mcp.ErrResult(fmt.Errorf("at least one of properties or archived must be set"))
+	}
+
+	data, err := n.patch(ctx, "/pages/"+pageID, body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func v1MovePage(ctx context.Context, n *notionV1, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	pageID := r.Str("page_id")
+	newParent := r.Map("parent")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if pageID == "" {
+		return mcp.ErrResult(fmt.Errorf("page_id is required"))
+	}
+	if newParent == nil {
+		return mcp.ErrResult(fmt.Errorf("parent is required"))
+	}
+
+	parentObj, err := v1BuildParentObject(newParent)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := n.patch(ctx, "/pages/"+pageID, map[string]any{"parent": parentObj})
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+// v1RetrievePageProperty hits the dedicated property-retrieval endpoint
+// rather than fetching the whole page. This matches the v3 handler's
+// contract (returns just the requested property value) but is more
+// efficient for paginated relations/rollups that exceed 25 references.
+func v1RetrievePageProperty(ctx context.Context, n *notionV1, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	pageID := r.Str("page_id")
+	propertyID := r.Str("property_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if pageID == "" {
+		return mcp.ErrResult(fmt.Errorf("page_id is required"))
+	}
+	if propertyID == "" {
+		return mcp.ErrResult(fmt.Errorf("property_id is required"))
+	}
+	data, err := n.get(ctx, "/pages/%s/properties/%s", pageID, propertyID)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+// v1GetPageContent fetches a page plus its child blocks in one logical
+// call. Internally it issues GET /pages/{id} + GET /blocks/{id}/children,
+// paginating up to `limit` blocks (default 100, capped at one page of
+// block children to avoid runaway requests).
+func v1GetPageContent(ctx context.Context, n *notionV1, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	pageID := r.Str("page_id")
+	limit := r.Int("limit")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if pageID == "" {
+		return mcp.ErrResult(fmt.Errorf("page_id is required"))
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	if limit > 100 {
+		limit = 100 // single page; callers needing more should paginate get_block_children
+	}
+
+	pageRaw, err := n.get(ctx, "/pages/%s", pageID)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	var page map[string]any
+	if err := json.Unmarshal(pageRaw, &page); err != nil {
+		return mcp.ErrResult(fmt.Errorf("parse page: %w", err))
+	}
+
+	childrenRaw, err := n.get(ctx, "/blocks/%s/children?page_size=%d", pageID, limit)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	var childrenResp struct {
+		Results    []map[string]any `json:"results"`
+		HasMore    bool             `json:"has_more"`
+		NextCursor string           `json:"next_cursor"`
+	}
+	if err := json.Unmarshal(childrenRaw, &childrenResp); err != nil {
+		return mcp.ErrResult(fmt.Errorf("parse block children: %w", err))
+	}
+
+	return mcp.JSONResult(map[string]any{
+		"page":        page,
+		"blocks":      childrenResp.Results,
+		"has_more":    childrenResp.HasMore,
+		"next_cursor": childrenResp.NextCursor,
+	})
+}
+
+func v1CreatePageWithContent(ctx context.Context, n *notionV1, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	parent := r.Map("parent")
+	properties := r.Map("properties")
+	title := r.Str("title")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if parent == nil {
+		return mcp.ErrResult(fmt.Errorf("parent is required"))
+	}
+
+	childrenAny, ok := args["children"].([]any)
+	if !ok || len(childrenAny) == 0 {
+		return mcp.ErrResult(fmt.Errorf("children is required"))
+	}
+	children := make([]map[string]any, 0, len(childrenAny))
+	for _, c := range childrenAny {
+		if cm, ok := c.(map[string]any); ok {
+			children = append(children, v1NormalizeBlock(cm))
+		}
+	}
+
+	body, err := v1BuildPageBody(parent, properties, title, children)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	if len(children) > 100 {
+		// /v1/pages caps children at 100; rather than silently truncate,
+		// surface so the caller can split.
+		return mcp.ErrResult(fmt.Errorf("v1 create_page_with_content accepts up to 100 children; got %d. Create the page first, then call append_block_children for the remainder", len(children)))
+	}
+
+	data, err := n.post(ctx, "/pages", body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+// --- helpers ---
+
+// v1BuildPageBody builds the POST /pages request body shared by
+// create_page and create_page_with_content. Children may be nil.
+func v1BuildPageBody(parent, properties map[string]any, title string, children []map[string]any) (map[string]any, error) {
+	parentObj, err := v1BuildParentObject(parent)
+	if err != nil {
+		return nil, err
+	}
+
+	body := map[string]any{"parent": parentObj}
+
+	props := map[string]any{}
+	for k, v := range properties {
+		props[k] = v
+	}
+	if title != "" {
+		// Whether the title property is named "title" or "Name" or
+		// something custom depends on the parent. For page-parented
+		// pages the property key is "title"; for data_source rows it's
+		// the user-defined title column. We default to "title" — the
+		// caller can override via the properties map.
+		titleKey := v1TitleKeyForParent(parentObj)
+		if _, exists := props[titleKey]; !exists {
+			props[titleKey] = v1TitleRichText(title)
+		}
+	}
+	if len(props) > 0 {
+		body["properties"] = props
+	}
+
+	if len(children) > 0 {
+		anyChildren := make([]any, len(children))
+		for i, c := range children {
+			anyChildren[i] = c
+		}
+		body["children"] = anyChildren
+	}
+
+	return body, nil
+}
+
+// v1BuildParentObject converts the caller-facing parent map into the
+// shape Notion v1 expects. Inputs accepted:
+//
+//	{"page_id": "..."}        → {"type": "page_id", "page_id": "..."}
+//	{"database_id": "..."}    → {"type": "database_id", "database_id": "..."}
+//	{"data_source_id": "..."} → {"type": "data_source_id", "data_source_id": "..."}
+//	{"workspace": true}       → {"type": "workspace", "workspace": true}
+//
+// If the caller already provided a "type" field, pass through.
+func v1BuildParentObject(parent map[string]any) (map[string]any, error) {
+	if t, ok := parent["type"].(string); ok && t != "" {
+		return parent, nil
+	}
+	if v, ok := parent["page_id"].(string); ok && v != "" {
+		return map[string]any{"type": "page_id", "page_id": v}, nil
+	}
+	if v, ok := parent["data_source_id"].(string); ok && v != "" {
+		return map[string]any{"type": "data_source_id", "data_source_id": v}, nil
+	}
+	if v, ok := parent["database_id"].(string); ok && v != "" {
+		return map[string]any{"type": "database_id", "database_id": v}, nil
+	}
+	if v, ok := parent["workspace"].(bool); ok && v {
+		return map[string]any{"type": "workspace", "workspace": true}, nil
+	}
+	return nil, fmt.Errorf("parent must contain page_id, database_id, data_source_id, or workspace:true")
+}
+
+// v1TitleKeyForParent returns the property key under which to write a
+// convenience title. Page-parented pages use the literal "title"; rows
+// in a database use whatever the database's title column is named, but
+// the caller must specify that — we default to "title" if unknown.
+func v1TitleKeyForParent(parent map[string]any) string {
+	if t, _ := parent["type"].(string); t == "page_id" || t == "workspace" {
+		return "title"
+	}
+	return "title"
+}
+
+// v1TitleRichText builds the standard {title: [{type:text, text:{content:s}}]}
+// shape used for the title property.
+func v1TitleRichText(s string) map[string]any {
+	return map[string]any{
+		"title": []any{
+			map[string]any{
+				"type": "text",
+				"text": map[string]any{"content": s},
+			},
+		},
+	}
+}
+
+// v1NormalizeBlock translates the legacy v3-shaped block descriptors
+// that current tool docs advertise:
+//
+//	{"type": "text", "properties": {"title": [["hello"]]}}
+//
+// into v1-shaped blocks:
+//
+//	{"object":"block","type":"paragraph","paragraph":{"rich_text":[{"type":"text","text":{"content":"hello"}}]}}
+//
+// Pure v1 blocks (those already containing `object`, or a top-level key
+// matching their type like "paragraph", "heading_1", etc.) pass through
+// unchanged so power-users can hand-roll v1 block JSON.
+func v1NormalizeBlock(b map[string]any) map[string]any {
+	if _, ok := b["object"]; ok {
+		return b
+	}
+	blockType, _ := b["type"].(string)
+	if blockType == "" {
+		return b
+	}
+	// If the v1 type-keyed payload is already present, pass through.
+	if _, ok := b[blockType]; ok {
+		out := map[string]any{"object": "block"}
+		for k, v := range b {
+			out[k] = v
+		}
+		return out
+	}
+	// Map legacy v3 shape → v1.
+	v3Type := blockType
+	v1Type := v1BlockTypeMap[v3Type]
+	if v1Type == "" {
+		v1Type = "paragraph"
+	}
+	text := v1ExtractV3TitleText(b)
+	payload := map[string]any{"rich_text": v1RichTextFromString(text)}
+
+	// Code blocks need a language field.
+	if v1Type == "code" {
+		lang := "plain text"
+		if format, ok := b["format"].(map[string]any); ok {
+			if l, ok := format["code_language"].(string); ok && l != "" {
+				lang = l
+			}
+		}
+		payload["language"] = lang
+	}
+	// to_do needs a checked field.
+	if v1Type == "to_do" {
+		payload["checked"] = v1ExtractV3Checked(b)
+	}
+
+	return map[string]any{
+		"object": "block",
+		"type":   v1Type,
+		v1Type:   payload,
+	}
+}
+
+// v1BlockTypeMap maps the v3 block-type names that current tool docs
+// advertise to v1 block-type names. Unmapped types fall back to
+// "paragraph" (a safe text block).
+var v1BlockTypeMap = map[string]string{
+	"text":           "paragraph",
+	"header":         "heading_1",
+	"sub_header":     "heading_2",
+	"sub_sub_header": "heading_3",
+	"bulleted_list":  "bulleted_list_item",
+	"numbered_list":  "numbered_list_item",
+	"to_do":          "to_do",
+	"quote":          "quote",
+	"callout":        "callout",
+	"code":           "code",
+	"divider":        "divider",
+	"toggle":         "toggle",
+}
+
+// v1ExtractV3TitleText pulls the plain text out of a v3 properties.title
+// structure: [[ "hello", [["b"]] ], [ " world" ]]. Returns the concatenated
+// plain text.
+func v1ExtractV3TitleText(b map[string]any) string {
+	props, ok := b["properties"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	title, ok := props["title"].([]any)
+	if !ok {
+		return ""
+	}
+	var out string
+	for _, run := range title {
+		runArr, ok := run.([]any)
+		if !ok || len(runArr) == 0 {
+			continue
+		}
+		s, _ := runArr[0].(string)
+		out += s
+	}
+	return out
+}
+
+// v1ExtractV3Checked reads the legacy v3 to_do "checked" flag. v3
+// encodes it as properties.checked = [["Yes"]] (or absent for unchecked);
+// anything else (or missing) is false.
+func v1ExtractV3Checked(b map[string]any) bool {
+	props, ok := b["properties"].(map[string]any)
+	if !ok {
+		return false
+	}
+	checked, ok := props["checked"].([]any)
+	if !ok || len(checked) == 0 {
+		return false
+	}
+	pair, ok := checked[0].([]any)
+	if !ok || len(pair) == 0 {
+		return false
+	}
+	v, ok := pair[0].(string)
+	if !ok {
+		return false
+	}
+	return v == "Yes" || v == "true"
+}
+
+// v1RichTextFromString wraps a plain string in the v1 rich_text shape.
+func v1RichTextFromString(s string) []any {
+	return []any{
+		map[string]any{
+			"type": "text",
+			"text": map[string]any{"content": s},
+		},
+	}
+}

--- a/integrations/notion/v1_pages.go
+++ b/integrations/notion/v1_pages.go
@@ -251,12 +251,12 @@ func v1BuildPageBody(parent, properties map[string]any, title string, children [
 		props[k] = v
 	}
 	if title != "" {
-		// Whether the title property is named "title" or "Name" or
-		// something custom depends on the parent. For page-parented
-		// pages the property key is "title"; for data_source rows it's
-		// the user-defined title column. We default to "title" — the
-		// caller can override via the properties map.
-		titleKey := v1TitleKeyForParent(parentObj)
+		// Notion's title property is conventionally keyed "title". For
+		// rows in a database the actual title column may be user-named
+		// (e.g. "Name"), in which case the caller is expected to supply
+		// the property explicitly via the properties map — we only
+		// auto-fill when nothing collides with "title".
+		const titleKey = "title"
 		if _, exists := props[titleKey]; !exists {
 			props[titleKey] = v1TitleRichText(title)
 		}
@@ -302,17 +302,6 @@ func v1BuildParentObject(parent map[string]any) (map[string]any, error) {
 		return map[string]any{"type": "workspace", "workspace": true}, nil
 	}
 	return nil, fmt.Errorf("parent must contain page_id, database_id, data_source_id, or workspace:true")
-}
-
-// v1TitleKeyForParent returns the property key under which to write a
-// convenience title. Page-parented pages use the literal "title"; rows
-// in a database use whatever the database's title column is named, but
-// the caller must specify that — we default to "title" if unknown.
-func v1TitleKeyForParent(parent map[string]any) string {
-	if t, _ := parent["type"].(string); t == "page_id" || t == "workspace" {
-		return "title"
-	}
-	return "title"
 }
 
 // v1TitleRichText builds the standard {title: [{type:text, text:{content:s}}]}

--- a/integrations/notion/v1_test.go
+++ b/integrations/notion/v1_test.go
@@ -1,0 +1,465 @@
+package notion
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newV1WithServer wires a *notionV1 against a test HTTP server and runs
+// Configure (which hits /users/me). Returns the configured backend so
+// tests can call handlers directly.
+func newV1WithServer(t *testing.T, handler http.HandlerFunc) (*notionV1, *httptest.Server) {
+	t.Helper()
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+	v1 := newV1Backend("test-access-token")
+	v1.baseURL = ts.URL
+	v1.client = ts.Client()
+	return v1, ts
+}
+
+func TestV1_ConfigureHitsUsersMe(t *testing.T) {
+	var path string
+	var authHeader string
+	var versionHeader string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path = r.URL.Path
+		authHeader = r.Header.Get("Authorization")
+		versionHeader = r.Header.Get("Notion-Version")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"user","id":"u1","type":"bot"}`))
+	}))
+	defer ts.Close()
+
+	n := New().(*notion)
+	// Point the v1 client to the test server. New() wires the v3 client
+	// but Configure builds the v1 backend lazily, so we have to inject
+	// after Configure rejects (or override baseURL via creds).
+	err := n.Configure(context.Background(), mcp.Credentials{
+		"access_token": "sk-test",
+		"base_url":     ts.URL,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, n.v1, "v1 backend should be selected when access_token is present")
+	assert.Equal(t, "/users/me", path)
+	assert.Equal(t, "Bearer sk-test", authHeader)
+	assert.Equal(t, defaultV1APIVersion, versionHeader)
+}
+
+func TestV1_PreferredOverTokenV2WhenBothPresent(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"user","id":"u1"}`))
+	}))
+	defer ts.Close()
+
+	n := New().(*notion)
+	err := n.Configure(context.Background(), mcp.Credentials{
+		"access_token": "sk-test",
+		"token_v2":     "should-be-ignored",
+		"base_url":     ts.URL,
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, n.v1, "OAuth backend should win when both creds are set")
+	// tokenV2 field should be untouched (v3 path skipped entirely).
+	assert.Empty(t, n.tokenV2, "v3 fields should not be populated when v1 wins")
+}
+
+func TestV1_ExecuteRoutesToV1Dispatch(t *testing.T) {
+	var hitPath string
+	v1, _ := newV1WithServer(t, func(w http.ResponseWriter, r *http.Request) {
+		hitPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"page","id":"page-1"}`))
+	})
+
+	n := &notion{v1: v1}
+	res, err := n.Execute(context.Background(), mcp.ToolName("notion_retrieve_page"), map[string]any{
+		"page_id": "page-1",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.False(t, res.IsError)
+	assert.Equal(t, "/pages/page-1", hitPath)
+	assert.Contains(t, res.Data, `"object":"page"`)
+}
+
+func TestV1_RetrievePage(t *testing.T) {
+	v1, _ := newV1WithServer(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/pages/abc-123", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"page","id":"abc-123"}`))
+	})
+	res, err := v1RetrievePage(context.Background(), v1, map[string]any{"page_id": "abc-123"})
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+	assert.Contains(t, res.Data, `"id":"abc-123"`)
+}
+
+func TestV1_CreatePageBuildsBody(t *testing.T) {
+	var gotBody map[string]any
+	v1, _ := newV1WithServer(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/pages", r.URL.Path)
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"page","id":"new"}`))
+	})
+
+	res, err := v1CreatePage(context.Background(), v1, map[string]any{
+		"parent": map[string]any{"page_id": "parent-1"},
+		"title":  "Hello",
+	})
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	parent, _ := gotBody["parent"].(map[string]any)
+	assert.Equal(t, "page_id", parent["type"])
+	assert.Equal(t, "parent-1", parent["page_id"])
+
+	props, _ := gotBody["properties"].(map[string]any)
+	require.NotNil(t, props, "title convenience should populate properties.title")
+	titleArr, _ := props["title"].(map[string]any)["title"].([]any)
+	require.NotEmpty(t, titleArr)
+	first, _ := titleArr[0].(map[string]any)
+	text, _ := first["text"].(map[string]any)
+	assert.Equal(t, "Hello", text["content"])
+}
+
+func TestV1_UpdatePagePartialUpdates(t *testing.T) {
+	var gotBody map[string]any
+	v1, _ := newV1WithServer(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PATCH", r.Method)
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"page","id":"p1"}`))
+	})
+
+	_, err := v1UpdatePage(context.Background(), v1, map[string]any{
+		"page_id":  "p1",
+		"archived": true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, true, gotBody["archived"])
+}
+
+func TestV1_UpdatePageRejectsNoFields(t *testing.T) {
+	v1 := newV1Backend("tok")
+	res, err := v1UpdatePage(context.Background(), v1, map[string]any{"page_id": "p1"})
+	require.NoError(t, err)
+	require.True(t, res.IsError)
+	assert.Contains(t, res.Data, "at least one of properties or archived")
+}
+
+func TestV1_MovePageSendsParentObject(t *testing.T) {
+	var gotBody map[string]any
+	v1, _ := newV1WithServer(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"page","id":"p1"}`))
+	})
+	_, err := v1MovePage(context.Background(), v1, map[string]any{
+		"page_id": "p1",
+		"parent":  map[string]any{"page_id": "new-parent"},
+	})
+	require.NoError(t, err)
+	parent, _ := gotBody["parent"].(map[string]any)
+	assert.Equal(t, "page_id", parent["type"])
+	assert.Equal(t, "new-parent", parent["page_id"])
+}
+
+func TestV1_AppendBlockChildrenTranslatesV3Shape(t *testing.T) {
+	var gotBody map[string]any
+	v1, _ := newV1WithServer(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PATCH", r.Method)
+		assert.Equal(t, "/blocks/parent-page/children", r.URL.Path)
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"list","results":[]}`))
+	})
+
+	// Caller passes legacy v3-shaped blocks.
+	_, err := v1AppendBlockChildren(context.Background(), v1, map[string]any{
+		"block_id": "parent-page",
+		"children": []any{
+			map[string]any{
+				"type": "header",
+				"properties": map[string]any{
+					"title": []any{[]any{"Section 1"}},
+				},
+			},
+			map[string]any{
+				"type": "text",
+				"properties": map[string]any{
+					"title": []any{[]any{"A paragraph."}},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	children, _ := gotBody["children"].([]any)
+	require.Len(t, children, 2)
+
+	// First child: heading_1
+	b1, _ := children[0].(map[string]any)
+	assert.Equal(t, "block", b1["object"])
+	assert.Equal(t, "heading_1", b1["type"])
+	h1, _ := b1["heading_1"].(map[string]any)
+	rt, _ := h1["rich_text"].([]any)
+	require.NotEmpty(t, rt)
+	first, _ := rt[0].(map[string]any)
+	txt, _ := first["text"].(map[string]any)
+	assert.Equal(t, "Section 1", txt["content"])
+
+	// Second child: paragraph
+	b2, _ := children[1].(map[string]any)
+	assert.Equal(t, "paragraph", b2["type"])
+}
+
+func TestV1_AppendBlockChildrenPassesThroughV1Shape(t *testing.T) {
+	var gotBody map[string]any
+	v1, _ := newV1WithServer(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"list","results":[]}`))
+	})
+
+	// Caller passes a fully-formed v1 block — should pass through with
+	// nothing beyond the {"object":"block"} wrapper added.
+	_, err := v1AppendBlockChildren(context.Background(), v1, map[string]any{
+		"block_id": "parent",
+		"children": []any{
+			map[string]any{
+				"type": "paragraph",
+				"paragraph": map[string]any{
+					"rich_text": []any{
+						map[string]any{
+							"type": "text",
+							"text": map[string]any{"content": "Bold!"},
+							"annotations": map[string]any{
+								"bold": true,
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	children, _ := gotBody["children"].([]any)
+	require.Len(t, children, 1)
+	b, _ := children[0].(map[string]any)
+	p, _ := b["paragraph"].(map[string]any)
+	rt, _ := p["rich_text"].([]any)
+	first, _ := rt[0].(map[string]any)
+	ann, _ := first["annotations"].(map[string]any)
+	assert.Equal(t, true, ann["bold"], "annotations on the rich_text run should pass through untouched")
+}
+
+func TestV1_QueryDataSourcePrefersDataSourcesEndpoint(t *testing.T) {
+	var paths []string
+	v1, _ := newV1WithServer(t, func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"list","results":[]}`))
+	})
+	_, err := v1QueryDataSource(context.Background(), v1, map[string]any{
+		"data_source_id": "ds-1",
+	})
+	require.NoError(t, err)
+	require.Len(t, paths, 1)
+	assert.Equal(t, "/data_sources/ds-1/query", paths[0])
+}
+
+func TestV1_QueryDataSourceFallsBackToDatabases(t *testing.T) {
+	var paths []string
+	v1, _ := newV1WithServer(t, func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasPrefix(r.URL.Path, "/data_sources/") {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"object":"error","code":"object_not_found","message":"not a data source"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"object":"list","results":[{"id":"row1"}]}`))
+	})
+	res, err := v1QueryDataSource(context.Background(), v1, map[string]any{
+		"data_source_id": "old-db-id",
+	})
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+	require.Len(t, paths, 2)
+	assert.Equal(t, "/data_sources/old-db-id/query", paths[0])
+	assert.Equal(t, "/databases/old-db-id/query", paths[1])
+	assert.Contains(t, res.Data, `"row1"`)
+}
+
+func TestV1_SearchTranslatesDatabaseTypeToDataSource(t *testing.T) {
+	var gotBody map[string]any
+	v1, _ := newV1WithServer(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/search", r.URL.Path)
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"list","results":[]}`))
+	})
+	_, err := v1Search(context.Background(), v1, map[string]any{
+		"query": "roadmap",
+		"type":  "database",
+	})
+	require.NoError(t, err)
+	filter, _ := gotBody["filter"].(map[string]any)
+	assert.Equal(t, "object", filter["property"])
+	assert.Equal(t, "data_source", filter["value"], "type=database should be translated to data_source for v1")
+	assert.Equal(t, "roadmap", gotBody["query"])
+}
+
+func TestV1_RetryableErrorFor429(t *testing.T) {
+	v1, _ := newV1WithServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "3")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"object":"error","code":"rate_limited","message":"slow down"}`))
+	})
+	_, err := v1.get(context.Background(), "/users/me")
+	require.Error(t, err)
+	var re *mcp.RetryableError
+	require.ErrorAs(t, err, &re)
+	assert.Equal(t, http.StatusTooManyRequests, re.StatusCode)
+	assert.Contains(t, err.Error(), "rate_limited")
+}
+
+func TestV1_FormattedErrorOn400(t *testing.T) {
+	v1, _ := newV1WithServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"object":"error","code":"validation_error","message":"bad parent"}`))
+	})
+	_, err := v1.get(context.Background(), "/pages/x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "400")
+	assert.Contains(t, err.Error(), "validation_error")
+	assert.Contains(t, err.Error(), "bad parent")
+}
+
+func TestV1_GetPageContentCombinesPageAndChildren(t *testing.T) {
+	v1, _ := newV1WithServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/pages/p1":
+			_, _ = w.Write([]byte(`{"object":"page","id":"p1","properties":{}}`))
+		case "/blocks/p1/children":
+			_, _ = w.Write([]byte(`{"object":"list","results":[{"id":"b1","type":"paragraph"}],"has_more":false}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	res, err := v1GetPageContent(context.Background(), v1, map[string]any{"page_id": "p1"})
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+	assert.Contains(t, res.Data, `"id":"p1"`)
+	assert.Contains(t, res.Data, `"id":"b1"`)
+	assert.Contains(t, res.Data, `"blocks"`)
+	assert.Contains(t, res.Data, `"page"`)
+}
+
+func TestV1_ExecuteUnknownToolErrors(t *testing.T) {
+	n := &notion{v1: newV1Backend("tok")}
+	res, err := n.Execute(context.Background(), mcp.ToolName("nope_does_not_exist"), nil)
+	require.NoError(t, err)
+	require.True(t, res.IsError)
+	assert.Contains(t, res.Data, "not yet supported on the Notion OAuth (v1) backend")
+}
+
+func TestV1_ListUsersHitsCorrectEndpoint(t *testing.T) {
+	v1, _ := newV1WithServer(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/users", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"list","results":[{"id":"u1"}]}`))
+	})
+	res, err := v1ListUsers(context.Background(), v1, nil)
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+	assert.Contains(t, res.Data, `"u1"`)
+}
+
+func TestV1_CreateCommentNewDiscussion(t *testing.T) {
+	var gotBody map[string]any
+	v1, _ := newV1WithServer(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/comments", r.URL.Path)
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"comment","id":"c1"}`))
+	})
+	_, err := v1CreateComment(context.Background(), v1, map[string]any{
+		"page_id": "page-1",
+		"text":    "first!",
+	})
+	require.NoError(t, err)
+	parent, _ := gotBody["parent"].(map[string]any)
+	assert.Equal(t, "page-1", parent["page_id"])
+	rt, _ := gotBody["rich_text"].([]any)
+	require.NotEmpty(t, rt)
+}
+
+func TestV1_CreateCommentReply(t *testing.T) {
+	var gotBody map[string]any
+	v1, _ := newV1WithServer(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"comment","id":"c2"}`))
+	})
+	_, err := v1CreateComment(context.Background(), v1, map[string]any{
+		"discussion_id": "disc-1",
+		"text":          "replying",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "disc-1", gotBody["discussion_id"])
+	_, hasParent := gotBody["parent"]
+	assert.False(t, hasParent, "discussion_id reply should not set parent")
+}
+
+func TestV1BuildParentObjectVariants(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      map[string]any
+		wantKey string
+		wantVal any
+	}{
+		{"page", map[string]any{"page_id": "p"}, "page_id", "p"},
+		{"database", map[string]any{"database_id": "d"}, "database_id", "d"},
+		{"data_source", map[string]any{"data_source_id": "ds"}, "data_source_id", "ds"},
+		{"workspace", map[string]any{"workspace": true}, "workspace", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := v1BuildParentObject(tc.in)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantKey, out["type"])
+			assert.Equal(t, tc.wantVal, out[tc.wantKey])
+		})
+	}
+}
+
+func TestV1BuildParentObjectRejectsEmpty(t *testing.T) {
+	_, err := v1BuildParentObject(map[string]any{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "page_id")
+}

--- a/integrations/notion/v1_test.go
+++ b/integrations/notion/v1_test.go
@@ -463,3 +463,29 @@ func TestV1BuildParentObjectRejectsEmpty(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "page_id")
 }
+
+// --- Dispatch parity (v1) ---
+//
+// Mirror the v3 dispatch parity tests so a misspelled handler name or a
+// new tool added to Tools() without a v1 implementation fails at test
+// time rather than silently routing to the "not yet supported on v1
+// backend" error at runtime.
+
+func TestDispatchV1_EveryToolHasHandler(t *testing.T) {
+	i := New()
+	for _, tool := range i.Tools() {
+		_, ok := dispatchV1[tool.Name]
+		assert.True(t, ok, "tool %s has no v1 dispatch handler", tool.Name)
+	}
+}
+
+func TestDispatchV1_NoOrphanHandlers(t *testing.T) {
+	i := New()
+	toolNames := make(map[mcp.ToolName]bool)
+	for _, tool := range i.Tools() {
+		toolNames[tool.Name] = true
+	}
+	for name := range dispatchV1 {
+		assert.True(t, toolNames[name], "v1 dispatch handler %s has no tool definition", name)
+	}
+}

--- a/integrations/notion/v1_test.go
+++ b/integrations/notion/v1_test.go
@@ -10,8 +10,10 @@ import (
 	"testing"
 
 	mcp "github.com/daltoniam/switchboard"
+	"github.com/daltoniam/switchboard/compact"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 // newV1WithServer wires a *notionV1 against a test HTTP server and runs
@@ -488,4 +490,105 @@ func TestDispatchV1_NoOrphanHandlers(t *testing.T) {
 	for name := range dispatchV1 {
 		assert.True(t, toolNames[name], "v1 dispatch handler %s has no tool definition", name)
 	}
+}
+
+// --- v1 compact specs (compact_v1.yaml) ---
+
+// configuredV1 returns a *notion already pointed at a v1 backend with a
+// stub HTTP client. Used by CompactSpec/MaxBytes/Views tests so they
+// exercise the v1 branch rather than the default v3 one.
+func configuredV1(t *testing.T) *notion {
+	t.Helper()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"user","id":"u1","type":"bot"}`))
+	}))
+	t.Cleanup(ts.Close)
+	n := New().(*notion)
+	v1 := newV1Backend("test-token")
+	v1.baseURL = ts.URL
+	v1.client = ts.Client()
+	require.NoError(t, v1.configure(context.Background()))
+	n.v1 = v1
+	return n
+}
+
+func TestV1FieldCompactionSpecs_AllParse(t *testing.T) {
+	require.NotEmpty(t, v1FieldCompactionSpecs, "v1FieldCompactionSpecs should not be empty")
+}
+
+// TestV1FieldCompactionSpecs_NoDuplicateTools confirms the YAML loader
+// kept every tool entry — parse losslessness check.
+func TestV1FieldCompactionSpecs_NoDuplicateTools(t *testing.T) {
+	var sf compact.SpecFile
+	require.NoError(t, yaml.Unmarshal(compactV1YAML, &sf))
+	// Multi-view tools register their default-view spec under Specs in
+	// addition to Views, so Specs == Tools always (Tools count == top-level
+	// keys, regardless of which form they use).
+	assert.Equal(t, len(sf.Tools), len(v1FieldCompactionSpecs))
+}
+
+func TestV1FieldCompactionSpecs_NoOrphanSpecs(t *testing.T) {
+	for tool := range v1FieldCompactionSpecs {
+		_, ok := dispatchV1[tool]
+		assert.True(t, ok, "v1 compaction spec %s has no dispatch handler", tool)
+	}
+}
+
+func TestV1FieldCompactionSpecs_NoMutationTools(t *testing.T) {
+	mutationPrefixes := []string{"create", "update", "delete", "move", "append"}
+	for toolName := range v1FieldCompactionSpecs {
+		for _, prefix := range mutationPrefixes {
+			assert.NotContains(t, string(toolName), "_"+prefix+"_",
+				"mutation tool %q should not have a v1 field compaction spec", toolName)
+		}
+	}
+}
+
+// TestV1FieldCompactionSpecs_ParityWithV3 asserts every tool with a v3
+// spec has a v1 spec, and vice versa. Without this, a tool added to
+// compact.yaml but forgotten in compact_v1.yaml would silently fall
+// through to "no compaction" on the OAuth backend — losing the savings
+// users on Notion v1 are paying for.
+func TestV1FieldCompactionSpecs_ParityWithV3(t *testing.T) {
+	for tool := range fieldCompactionSpecs {
+		_, ok := v1FieldCompactionSpecs[tool]
+		assert.True(t, ok, "tool %s has a v3 spec but no v1 spec in compact_v1.yaml", tool)
+	}
+	for tool := range v1FieldCompactionSpecs {
+		_, ok := fieldCompactionSpecs[tool]
+		assert.True(t, ok, "tool %s has a v1 spec but no v3 spec in compact.yaml", tool)
+	}
+}
+
+// TestCompactSpec_SwitchesOnBackend verifies CompactSpec routes to the
+// v1 spec map when a v1 backend is configured. The two maps are *not*
+// equal byte-for-byte (different JSON shapes mean different paths), so
+// any field present in the v1 spec for a tool but absent from v3 (e.g.
+// `results[].properties.title` on search, which uses different parent
+// keys in v3) is enough to distinguish them.
+func TestCompactSpec_SwitchesOnBackend(t *testing.T) {
+	n3 := New().(*notion) // v1 == nil → v3 specs
+	n1 := configuredV1(t) // v1 != nil → v1 specs
+
+	v3Spec, ok := n3.CompactSpec("notion_search")
+	require.True(t, ok)
+	v1Spec, ok := n1.CompactSpec("notion_search")
+	require.True(t, ok)
+
+	// Same tool, different specs.
+	assert.NotEqual(t, v3Spec, v1Spec, "v1 and v3 CompactSpec should return distinct specs for the same tool")
+}
+
+func TestViews_SwitchesOnBackend(t *testing.T) {
+	n3 := New().(*notion)
+	n1 := configuredV1(t)
+
+	// notion_search has views in both files; the spec contents differ.
+	v3Views, ok3 := n3.Views("notion_search")
+	require.True(t, ok3)
+	v1Views, ok1 := n1.Views("notion_search")
+	require.True(t, ok1)
+	assert.NotEqual(t, v3Views.Views["titles"].Spec, v1Views.Views["titles"].Spec,
+		"v1 and v3 should publish distinct titles-view specs")
 }


### PR DESCRIPTION
## Summary

The current notion integration talks to `www.notion.so/api/v3` with a browser session cookie (`token_v2`). That path still works for users who set it up before OAuth existed, but it's brittle (cookies expire, Notion can change v3 without notice) and unusable for hosted SaaS.

This adds a parallel `notionV1` backend that uses Notion's documented public REST API (`api.notion.com/v1`) with an OAuth bearer token and the date-stamped `Notion-Version` header. I picked `2025-09-03` — that's the version that introduced the `data_sources` model, so the public surface matches the v3 backend's database/data-source split naturally and we don't need a translation layer.

Backend selection happens in `Configure()` based on which credential key is set:

- `access_token` → v1 (OAuth, hosted-friendly)
- `token_v2` → v3 (cookie, self-host legacy)

If both are present, v1 wins. `Execute()` and `Healthy()` delegate to v1 when it's configured; otherwise the existing v3 path runs unchanged. **No behavior change for existing `token_v2` users.**

All tools the v3 backend exposes have a v1 equivalent (data sources, pages, blocks, search, users, comments, plus the convenience helpers `notion_get_page_content` / `notion_create_page_with_content`). Routing lives in `dispatchV1`. If a tool ends up v3-only in the future, `Execute` returns a clear "not supported on the Notion OAuth (v1) backend" error rather than a generic unknown-tool error.

## Test plan

- [x] `go test ./integrations/notion/...` — new `v1_test.go` covers the configure handshake (auth + version headers), and each handler family with httptest servers asserting URL paths, request bodies, and response shaping.
- [x] `go test ./...` — full suite green.
- [x] `golangci-lint run ./integrations/notion/...` — clean.
- [ ] Smoke-test end-to-end against a real Notion OAuth install (wired in Switchboard-hosted, separate PR).