### PR TITLE
fix(wasm): serialize Module calls and guard against use-after-close

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/daltoniam/switchboard
 
-go 1.26.3
+go 1.26.4
 
 require (
 	cloud.google.com/go/compute v1.38.0

--- a/wasm/concurrent_test.go
+++ b/wasm/concurrent_test.go
@@ -1,0 +1,193 @@
+package wasm
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+// TestModule_ConcurrentExecute verifies that concurrent calls into a single
+// *Module do not panic or corrupt guest memory. Wazero's api.Function.Call is
+// not goroutine-safe, so Module must serialize calls internally.
+//
+// Reproduces the production panic at wasm/memory.go:51 where Goja scripts
+// firing many api.call() invocations in parallel hit nil pointer derefs
+// inside readFromGuest.
+func TestModule_ConcurrentExecute(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"id":"item-1","name":"widget"}]`))
+	}))
+	defer srv.Close()
+
+	mod := loadTestModule(t)
+	if err := mod.Configure(context.Background(), mcp.Credentials{
+		"base_url": srv.URL,
+		"api_key":  "test-key",
+	}); err != nil {
+		t.Fatalf("Configure: %v", err)
+	}
+
+	const goroutines = 32
+	const iterations = 8
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, goroutines*iterations)
+	for g := range goroutines {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := range iterations {
+				result, err := mod.Execute(context.Background(), "example_echo", map[string]any{
+					"message": "hello",
+				})
+				if err != nil {
+					errCh <- err
+					return
+				}
+				if result.IsError {
+					errCh <- &execErr{data: result.Data}
+					return
+				}
+				if !strings.Contains(result.Data, "hello") {
+					errCh <- &execErr{data: result.Data}
+					return
+				}
+				_ = id
+				_ = i
+			}
+		}(g)
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Errorf("concurrent Execute error: %v", err)
+	}
+}
+
+// TestModule_ConcurrentMixed exercises Execute, Tools, Name, Healthy in parallel.
+// All of these touch m.mod and must be serialized.
+func TestModule_ConcurrentMixed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			_, _ = w.Write([]byte(`{"status":"ok"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`[{"id":"item-1","name":"widget"}]`))
+	}))
+	defer srv.Close()
+
+	mod := loadTestModule(t)
+	if err := mod.Configure(context.Background(), mcp.Credentials{
+		"base_url": srv.URL,
+		"api_key":  "test-key",
+	}); err != nil {
+		t.Fatalf("Configure: %v", err)
+	}
+
+	const goroutines = 16
+	var wg sync.WaitGroup
+	for g := range goroutines {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			switch id % 4 {
+			case 0:
+				_, _ = mod.Execute(context.Background(), "example_echo", map[string]any{"message": "x"})
+			case 1:
+				_ = mod.Tools()
+			case 2:
+				_ = mod.Name()
+			case 3:
+				_ = mod.Healthy(context.Background())
+			}
+		}(g)
+	}
+	wg.Wait()
+}
+
+// TestModule_ExecuteAfterClose verifies that calls into a closed module return
+// a clean error instead of panicking with a nil pointer deref.
+func TestModule_ExecuteAfterClose(t *testing.T) {
+	mod := loadTestModule(t)
+	ctx := context.Background()
+	if err := mod.Configure(ctx, mcp.Credentials{
+		"base_url": "https://example.com",
+		"api_key":  "test-key",
+	}); err != nil {
+		t.Fatalf("Configure: %v", err)
+	}
+
+	if err := mod.Close(ctx); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Subsequent calls must not panic.
+	result, err := mod.Execute(ctx, "example_echo", map[string]any{"message": "x"})
+	if err == nil && (result == nil || !result.IsError) {
+		t.Fatal("expected Execute after Close to return an error")
+	}
+
+	if mod.Healthy(ctx) {
+		t.Error("Healthy() should return false after Close")
+	}
+	if tools := mod.Tools(); tools != nil {
+		t.Errorf("Tools() should return nil after Close, got %d tools", len(tools))
+	}
+}
+
+// TestModule_ConcurrentExecuteAndClose races Close against in-flight Execute calls.
+// The Execute caller must receive either a valid result or a clean error — never a panic.
+func TestModule_ConcurrentExecuteAndClose(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`[{"id":"item-1","name":"widget"}]`))
+	}))
+	defer srv.Close()
+
+	mod := loadTestModule(t)
+	if err := mod.Configure(context.Background(), mcp.Credentials{
+		"base_url": srv.URL,
+		"api_key":  "test-key",
+	}); err != nil {
+		t.Fatalf("Configure: %v", err)
+	}
+
+	const callers = 8
+	var wg sync.WaitGroup
+	var panicked atomic.Bool
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					panicked.Store(true)
+					t.Errorf("Execute panicked: %v", r)
+				}
+			}()
+			for range 50 {
+				_, _ = mod.Execute(context.Background(), "example_echo", map[string]any{
+					"message": "hello",
+				})
+			}
+		}()
+	}
+
+	// Close concurrently with the in-flight callers.
+	_ = mod.Close(context.Background())
+	wg.Wait()
+
+	if panicked.Load() {
+		t.Fatal("at least one goroutine panicked")
+	}
+}
+
+type execErr struct{ data string }
+
+func (e *execErr) Error() string { return e.data }

--- a/wasm/concurrent_test.go
+++ b/wasm/concurrent_test.go
@@ -72,8 +72,8 @@ func TestModule_ConcurrentExecute(t *testing.T) {
 	}
 }
 
-// TestModule_ConcurrentMixed exercises Execute, Tools, Name, Healthy in parallel.
-// All of these touch m.mod and must be serialized.
+// TestModule_ConcurrentMixed exercises Execute, Tools, Name, Healthy, and
+// Metadata in parallel. All of these touch m.mod and must be serialized.
 func TestModule_ConcurrentMixed(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/health" {
@@ -92,13 +92,13 @@ func TestModule_ConcurrentMixed(t *testing.T) {
 		t.Fatalf("Configure: %v", err)
 	}
 
-	const goroutines = 16
+	const goroutines = 20
 	var wg sync.WaitGroup
 	for g := range goroutines {
 		wg.Add(1)
 		go func(id int) {
 			defer wg.Done()
-			switch id % 4 {
+			switch id % 5 {
 			case 0:
 				_, _ = mod.Execute(context.Background(), "example_echo", map[string]any{"message": "x"})
 			case 1:
@@ -107,6 +107,8 @@ func TestModule_ConcurrentMixed(t *testing.T) {
 				_ = mod.Name()
 			case 3:
 				_ = mod.Healthy(context.Background())
+			case 4:
+				_ = mod.Metadata()
 			}
 		}(g)
 	}
@@ -152,6 +154,9 @@ func TestModule_ExecuteAfterClose(t *testing.T) {
 	}
 	if tools := mod.Tools(); tools != nil {
 		t.Errorf("Tools() should return nil after Close, got %d tools", len(tools))
+	}
+	if meta := mod.Metadata(); meta != nil {
+		t.Errorf("Metadata() should return nil after Close, got %v", meta)
 	}
 }
 

--- a/wasm/concurrent_test.go
+++ b/wasm/concurrent_test.go
@@ -2,6 +2,7 @@ package wasm
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -128,12 +129,24 @@ func TestModule_ExecuteAfterClose(t *testing.T) {
 		t.Fatalf("Close: %v", err)
 	}
 
-	// Subsequent calls must not panic.
+	// Subsequent calls must not panic. Each entry point has its own
+	// after-close contract; assert them explicitly so a future refactor
+	// that changes one path can't silently regress the others.
 	result, err := mod.Execute(ctx, "example_echo", map[string]any{"message": "x"})
-	if err == nil && (result == nil || !result.IsError) {
-		t.Fatal("expected Execute after Close to return an error")
+	if err != nil {
+		t.Fatalf("Execute after Close returned unexpected Go error: %v", err)
+	}
+	if result == nil || !result.IsError {
+		t.Fatal("expected Execute after Close to return an IsError result")
 	}
 
+	if err := mod.Configure(ctx, mcp.Credentials{"base_url": "https://example.com", "api_key": "k"}); !errors.Is(err, ErrModuleClosed) {
+		t.Errorf("Configure after Close: got %v, want ErrModuleClosed", err)
+	}
+
+	if got := mod.Name(); got != "unknown" {
+		t.Errorf("Name() after Close = %q, want %q", got, "unknown")
+	}
 	if mod.Healthy(ctx) {
 		t.Error("Healthy() should return false after Close")
 	}

--- a/wasm/module.go
+++ b/wasm/module.go
@@ -21,6 +21,14 @@ func (m *Module) Name() string {
 	if m.nameOverride != "" {
 		return m.nameOverride
 	}
+	if m.closed.Load() {
+		return "unknown"
+	}
+	m.callMu.Lock()
+	defer m.callMu.Unlock()
+	if m.closed.Load() {
+		return "unknown"
+	}
 	ctx := context.Background()
 	results, err := m.fnName.Call(ctx)
 	if err != nil {
@@ -44,6 +52,15 @@ func (m *Module) Configure(ctx context.Context, creds mcp.Credentials) error {
 	credsJSON, err := json.Marshal(creds)
 	if err != nil {
 		return fmt.Errorf("wasm: marshal credentials: %w", err)
+	}
+
+	if m.closed.Load() {
+		return ErrModuleClosed
+	}
+	m.callMu.Lock()
+	defer m.callMu.Unlock()
+	if m.closed.Load() {
+		return ErrModuleClosed
 	}
 
 	ptr, size, err := writeToGuest(ctx, m.mod, credsJSON)
@@ -77,6 +94,14 @@ func (m *Module) Configure(ctx context.Context, creds mcp.Credentials) error {
 
 // Tools implements mcp.Integration.
 func (m *Module) Tools() []mcp.ToolDefinition {
+	if m.closed.Load() {
+		return nil
+	}
+	m.callMu.Lock()
+	defer m.callMu.Unlock()
+	if m.closed.Load() {
+		return nil
+	}
 	ctx := context.Background()
 	results, err := m.fnTools.Call(ctx)
 	if err != nil {
@@ -115,6 +140,15 @@ func (m *Module) Execute(ctx context.Context, toolName mcp.ToolName, args map[st
 		return &mcp.ToolResult{Data: err.Error(), IsError: true}, nil
 	}
 
+	if m.closed.Load() {
+		return &mcp.ToolResult{Data: ErrModuleClosed.Error(), IsError: true}, nil
+	}
+	m.callMu.Lock()
+	defer m.callMu.Unlock()
+	if m.closed.Load() {
+		return &mcp.ToolResult{Data: ErrModuleClosed.Error(), IsError: true}, nil
+	}
+
 	ptr, size, err := writeToGuest(ctx, m.mod, reqJSON)
 	if err != nil {
 		return &mcp.ToolResult{Data: err.Error(), IsError: true}, nil
@@ -145,6 +179,14 @@ func (m *Module) Execute(ctx context.Context, toolName mcp.ToolName, args map[st
 
 // Healthy implements mcp.Integration.
 func (m *Module) Healthy(ctx context.Context) bool {
+	if m.closed.Load() {
+		return false
+	}
+	m.callMu.Lock()
+	defer m.callMu.Unlock()
+	if m.closed.Load() {
+		return false
+	}
 	results, err := m.fnHealthy.Call(ctx)
 	if err != nil {
 		return false
@@ -157,6 +199,14 @@ func (m *Module) Healthy(ctx context.Context) bool {
 
 // Metadata returns plugin metadata from the WASM module's `metadata()` export.
 func (m *Module) Metadata() *marketplace.PluginMetadata {
+	if m.closed.Load() {
+		return nil
+	}
+	m.callMu.Lock()
+	defer m.callMu.Unlock()
+	if m.closed.Load() {
+		return nil
+	}
 	ctx := context.Background()
 	results, err := m.fnMetadata.Call(ctx)
 	if err != nil {

--- a/wasm/runtime.go
+++ b/wasm/runtime.go
@@ -3,14 +3,23 @@ package wasm
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
+	"sync"
+	"sync/atomic"
 
 	mcp "github.com/daltoniam/switchboard"
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 )
+
+// ErrModuleClosed is returned when a Module method is invoked after Close.
+// Callers should treat this as a clean error and not retry against the same
+// module instance. It is also returned to Execute callers that lose the race
+// against a concurrent Loader-driven reload.
+var ErrModuleClosed = errors.New("wasm: module closed")
 
 // Runtime manages the wazero WebAssembly runtime and compiles/instantiates modules.
 type Runtime struct {
@@ -86,7 +95,18 @@ func (r *Runtime) Close(ctx context.Context) error {
 }
 
 // Module wraps an instantiated WASM module and implements mcp.Integration.
+//
+// Concurrency: wazero's api.Function.Call is explicitly not goroutine-safe
+// (see api.Function.Call docs). A single Module instance shares one linear
+// memory and one malloc/free heap, so every host -> guest call sequence
+// (malloc -> Memory().Write -> Call -> Memory().Read -> free) must run as
+// one atomic critical section. callMu serializes all exported methods that
+// touch m.mod or m.fn*. closed is set by Close so racing callers return
+// ErrModuleClosed instead of dereferencing a freed memory instance.
 type Module struct {
+	callMu sync.Mutex
+	closed atomic.Bool
+
 	mod          api.Module
 	nameOverride string
 	fnName       api.Function
@@ -185,7 +205,18 @@ func (m *Module) CompactSpec(toolName mcp.ToolName) ([]mcp.CompactField, bool) {
 	return fields, ok
 }
 
-// Close releases the WASM module instance.
+// Close releases the WASM module instance. Safe to call multiple times.
+// After Close, all other Module methods return ErrModuleClosed (or, for the
+// nil-returning interface methods, an empty result) without touching the
+// underlying wazero module.
 func (m *Module) Close(ctx context.Context) error {
+	// Set the flag before acquiring the lock so in-flight callers fail fast
+	// when they re-check it. The lock then waits for any active Call to
+	// complete before we hand the module to wazero for teardown.
+	if !m.closed.CompareAndSwap(false, true) {
+		return nil
+	}
+	m.callMu.Lock()
+	defer m.callMu.Unlock()
 	return m.mod.Close(ctx)
 }


### PR DESCRIPTION
## Summary

- Fixes the two recent production crashes — a `nil pointer dereference` at `wasm/memory.go:51` and a `fatal error: traceback / unexpected SPWRITE function runtime.morestack` — both rooted in concurrent invocation of a single wazero `api.Module`.
- Adds a per-`Module` call mutex around every entry point that touches `m.mod` or `m.fn*` (`Execute`, `Configure`, `Tools`, `Name`, `Healthy`, `Metadata`) and an `atomic.Bool` `closed` flag so racing callers get a clean `ErrModuleClosed` instead of dereferencing a freed wazero memory instance.

## Why

Wazero documents (`api/wasm.go:378-381`) that `Function.Call` is **not goroutine-safe** and must not be reentered until the previous call returns. A single `Module` shares one linear memory and one malloc/free heap, so each `malloc -> Memory().Write -> Call -> Memory().Read -> free` sequence must run as one atomic critical section.

Goja scripts fire many `api.call()` invocations from a single tool call, and the MCP server handles concurrent JSON-RPC requests against shared wasm-backed integrations. Without serialization, malloc/free interleaved with `Memory().Read` and produced the nil-pointer panic in `readFromGuest`. When that panic crossed Goja's `runTryInner` protected boundary while another panic was active, the runtime re-panicked and aborted with the `morestack` traceback.

`Loader.LoadPlugin` also closes the old module while another goroutine may be mid-call. The new `closed` flag makes those callers fail with `ErrModuleClosed` rather than touching a freed memory instance.

## Test plan

- [x] New `TestModule_ConcurrentExecute` (32 goroutines × 8 iterations) — reproduces the panic without the fix; passes with `-race` after the fix.
- [x] New `TestModule_ConcurrentMixed` exercises `Execute`/`Tools`/`Name`/`Healthy` in parallel.
- [x] New `TestModule_ExecuteAfterClose` — calls after `Close` return error, never panic.
- [x] New `TestModule_ConcurrentExecuteAndClose` races `Close` against in-flight `Execute` calls; asserts no goroutine panics.
- [x] `make ci` (build + vet + test-race + lint + gosec + govulncheck) clean.

## Follow-ups (out of scope)

- For higher parallelism we could instantiate one wazero module per concurrent caller (pool). Correctness is now sound with serialization; per-instance pooling is a perf optimization for a future PR.