### PR TITLE
feat(server): allow integrations to raise the response cap per-tool

### DIFF
--- a/integrations/github/github.go
+++ b/integrations/github/github.go
@@ -20,10 +20,19 @@ var maxBytesByTool = compactResult.MaxBytes
 
 // Compile-time interface assertions.
 var (
-	_ mcp.Integration                = (*integration)(nil)
-	_ mcp.FieldCompactionIntegration = (*integration)(nil)
-	_ mcp.ToolMaxBytesIntegration    = (*integration)(nil)
+	_ mcp.Integration                        = (*integration)(nil)
+	_ mcp.FieldCompactionIntegration         = (*integration)(nil)
+	_ mcp.ToolMaxBytesIntegration            = (*integration)(nil)
+	_ mcp.PerToolMaxResponseBytesIntegration = (*integration)(nil)
 )
+
+// githubPullDiffMaxResponseBytes raises the integration-wide response cap for
+// the github_get_pull_diff tool only. Raw unified diffs for real-world PRs
+// routinely exceed the 50KB default (a single 21-file/5k-line PR is already
+// ~200KB), and the diff endpoint has no projection or pagination knob the
+// agent can use to shrink the response. Other GitHub tools still operate
+// under the default safety net.
+const githubPullDiffMaxResponseBytes = 1024 * 1024 // 1MB
 
 type integration struct {
 	token  string
@@ -62,6 +71,18 @@ func (g *integration) CompactSpec(toolName mcp.ToolName) ([]mcp.CompactField, bo
 func (g *integration) MaxBytes(toolName mcp.ToolName) (int, bool) {
 	n, ok := maxBytesByTool[toolName]
 	return n, ok
+}
+
+// MaxResponseBytesForTool raises the integration-wide response cap for tools
+// whose responses are not amenable to compaction or pagination. github_get_pull_diff
+// returns a raw unified diff that has no projection or per-file knob — the only
+// way to keep PR review usable is to give it more headroom.
+func (g *integration) MaxResponseBytesForTool(toolName mcp.ToolName) (int, bool) {
+	switch toolName {
+	case mcp.ToolName("github_get_pull_diff"):
+		return githubPullDiffMaxResponseBytes, true
+	}
+	return 0, false
 }
 
 func (g *integration) Execute(ctx context.Context, toolName mcp.ToolName, args map[string]any) (*mcp.ToolResult, error) {

--- a/integrations/github/github_test.go
+++ b/integrations/github/github_test.go
@@ -398,3 +398,18 @@ func TestListIssues_MilestonePassthrough(t *testing.T) {
 		})
 	}
 }
+
+func TestMaxResponseBytesForTool(t *testing.T) {
+	g := New().(*integration)
+
+	v, ok := g.MaxResponseBytesForTool(mcp.ToolName("github_get_pull_diff"))
+	assert.True(t, ok, "github_get_pull_diff should declare a per-tool cap")
+	assert.Equal(t, githubPullDiffMaxResponseBytes, v)
+	assert.Greater(t, v, 50*1024, "per-tool cap must exceed the server default to take effect")
+
+	_, ok = g.MaxResponseBytesForTool(mcp.ToolName("github_get_pull"))
+	assert.False(t, ok, "github_get_pull should not declare a per-tool cap")
+
+	_, ok = g.MaxResponseBytesForTool(mcp.ToolName("github_list_issues"))
+	assert.False(t, ok, "unrelated tools should not declare a per-tool cap")
+}

--- a/mcp.go
+++ b/mcp.go
@@ -308,6 +308,29 @@ type MaxResponseBytesIntegration interface {
 	MaxResponseBytes() int
 }
 
+// PerToolMaxResponseBytesIntegration is an optional interface that integrations can
+// implement to raise the response size cap above the server's default for a single
+// tool, without lifting the cap for every tool in the integration. Use this when
+// only a handful of tools legitimately produce large responses (e.g. raw GitHub
+// PR diffs) and you want to keep the safety net low for everything else.
+//
+// Distinguished from MaxResponseBytesIntegration: that interface returns one cap
+// for the entire integration; this one returns a cap per tool. When both interfaces
+// are implemented, the per-tool value takes precedence for tools it returns true
+// for, and the integration-wide value is used as a fallback for the rest.
+//
+// Distinguished from ToolMaxBytesIntegration: that interface declares a stricter
+// per-tool cap that triggers a response_too_large envelope on the post-compaction
+// JSON body; it cannot raise the cap above the integration-wide check. This
+// interface raises the integration-wide cap, applies to both JSON and plain-text
+// responses, and runs before the integration-wide cap check.
+type PerToolMaxResponseBytesIntegration interface {
+	// MaxResponseBytesForTool returns the response size cap for a specific tool.
+	// Returns (0, false) for tools that should use the integration-wide cap.
+	// Returned values at or below the server default are ignored.
+	MaxResponseBytesForTool(toolName ToolName) (int, bool)
+}
+
 // ToolMaxBytesIntegration is an optional interface that integrations can implement
 // to declare per-tool response size caps. When the post-compaction response for a
 // tool exceeds its declared cap, the server replaces the body with a structured

--- a/server/project_server.go
+++ b/server/project_server.go
@@ -334,7 +334,7 @@ func (pr *ProjectRouter) makeExecuteHandler(def *project.Definition, scopeRule *
 
 		applyResultProcessing(integration, tool, compact.ParseViewArgs(args.Arguments), result, pr.services.Metrics)
 		if !result.IsError {
-			limit := responseLimitFor(integration)
+			limit := responseLimitFor(integration, tool)
 			if len(result.Data) > limit {
 				if pr.services.Metrics != nil {
 					pr.services.Metrics.RecordTruncation()

--- a/server/project_server_test.go
+++ b/server/project_server_test.go
@@ -332,6 +332,75 @@ func TestProjectRouter_ExecutePerIntegrationCap(t *testing.T) {
 	})
 }
 
+func TestProjectRouter_ExecutePerToolCap(t *testing.T) {
+	// Pins the project router's tool-aware responseLimitFor lookup so a future
+	// refactor can't silently drop the per-tool override branch.
+	def := &project.Definition{Version: "1", Name: "per-tool-cap-test"}
+
+	buildIntegration := func(toolName mcp.ToolName, payload string) *mockProjectIntegrationWithPerToolCap {
+		_ = toolName // Reserved for future per-tool variations; keeps the call sites self-documenting.
+		return &mockProjectIntegrationWithPerToolCap{
+			mockIntegration: &mockIntegration{
+				name:    "bigint",
+				healthy: true,
+				tools: []mcp.ToolDefinition{
+					{Name: "bigint_get_diff", Description: "Returns raw diff"},
+					{Name: "bigint_get_thing", Description: "Returns a normal payload"},
+				},
+				execFn: func(_ context.Context, _ mcp.ToolName, _ map[string]any) (*mcp.ToolResult, error) {
+					return &mcp.ToolResult{Data: payload}, nil
+				},
+			},
+			perTool: map[mcp.ToolName]int{"bigint_get_diff": 1024 * 1024},
+		}
+	}
+
+	execute := func(t *testing.T, mi *mockProjectIntegrationWithPerToolCap, toolName string) *mcpsdk.CallToolResult {
+		t.Helper()
+		router, _ := setupProjectRouterWithIntegration(t, def, mi)
+		scopeRule := project.GetEffectiveRule(def, "switchboard", "")
+		handler := router.makeExecuteHandler(def, scopeRule)
+		result, err := handler(context.Background(), projectToolRequest("execute", map[string]any{
+			"tool_name": toolName,
+			"arguments": map[string]any{},
+		}))
+		require.NoError(t, err)
+		return result
+	}
+
+	t.Run("per-tool override allows oversize for declared tool", func(t *testing.T) {
+		payload := strings.Repeat("a", 600*1024) // 600KB plain text, above default
+		result := execute(t, buildIntegration("bigint_get_diff", payload), "bigint_get_diff")
+
+		assert.False(t, result.IsError, "response within per-tool cap should succeed")
+		tc := result.Content[0].(*mcpsdk.TextContent)
+		assert.Equal(t, payload, tc.Text)
+	})
+
+	t.Run("per-tool override does not leak to other tools", func(t *testing.T) {
+		payload := fmt.Sprintf(`{"data":"%s"}`, strings.Repeat("y", 60*1024)) // 60KB, above default
+		result := execute(t, buildIntegration("bigint_get_thing", payload), "bigint_get_thing")
+
+		assert.True(t, result.IsError, "tools without an override must use the default cap")
+		tc := result.Content[0].(*mcpsdk.TextContent)
+		capKB := fmt.Sprintf("%dKB", defaultMaxResponseBytes/1024)
+		assert.Contains(t, tc.Text, capKB, "error should report the default cap")
+	})
+}
+
+// mockProjectIntegrationWithPerToolCap implements PerToolMaxResponseBytesIntegration
+// on top of *mockIntegration so the project router tests can register a fake
+// integration that raises the cap for one specific tool.
+type mockProjectIntegrationWithPerToolCap struct {
+	*mockIntegration
+	perTool map[mcp.ToolName]int
+}
+
+func (m *mockProjectIntegrationWithPerToolCap) MaxResponseBytesForTool(name mcp.ToolName) (int, bool) {
+	v, ok := m.perTool[name]
+	return v, ok
+}
+
 func TestProjectRouter_ContextManifest(t *testing.T) {
 	dir := t.TempDir()
 	repoDir := filepath.Join(dir, "repo")

--- a/server/server.go
+++ b/server/server.go
@@ -25,10 +25,18 @@ import (
 const defaultSearchLimit = 20
 const defaultMaxResponseBytes = 50 * 1024 // 50KB
 
-// responseLimitFor returns the effective response byte cap for an integration.
-// Integrations that implement MaxResponseBytesIntegration may declare a higher
-// cap; values at or below the default are ignored.
-func responseLimitFor(integration mcp.Integration) int {
+// responseLimitFor returns the effective response byte cap for an integration
+// and tool. Tools whose integration implements PerToolMaxResponseBytesIntegration
+// and returns a value above the default take priority; otherwise the
+// integration-wide MaxResponseBytesIntegration override applies; otherwise the
+// server default. Values at or below the default are always ignored so the
+// safety net cannot be lowered by an integration.
+func responseLimitFor(integration mcp.Integration, toolName mcp.ToolName) int {
+	if pti, ok := integration.(mcp.PerToolMaxResponseBytesIntegration); ok {
+		if v, ok := pti.MaxResponseBytesForTool(toolName); ok && v > defaultMaxResponseBytes {
+			return v
+		}
+	}
 	if mri, ok := integration.(mcp.MaxResponseBytesIntegration); ok {
 		if v := mri.MaxResponseBytes(); v > defaultMaxResponseBytes {
 			return v
@@ -754,7 +762,7 @@ func (s *Server) handleExecute(ctx context.Context, req *mcpsdk.CallToolRequest)
 		}, nil
 	}
 	applyResultProcessing(integration, args.ToolName, compact.ParseViewArgs(args.Arguments), result, s.services.Metrics)
-	limit := responseLimitFor(integration)
+	limit := responseLimitFor(integration, args.ToolName)
 	if len(result.Data) > limit {
 		if s.services.Metrics != nil {
 			s.services.Metrics.RecordTruncation()

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1694,6 +1694,118 @@ func TestHandleExecute_PerIntegrationCapStillEnforced(t *testing.T) {
 	assert.Contains(t, tc.Text, "256KB", "error should report the integration's own cap")
 }
 
+// mockIntegrationWithPerToolCap also implements
+// mcp.PerToolMaxResponseBytesIntegration, raising the cap for one specific
+// tool only.
+type mockIntegrationWithPerToolCap struct {
+	*mockIntegration
+	perTool map[mcp.ToolName]int
+}
+
+func (m *mockIntegrationWithPerToolCap) MaxResponseBytesForTool(name mcp.ToolName) (int, bool) {
+	v, ok := m.perTool[name]
+	return v, ok
+}
+
+func TestHandleExecute_PerToolCapHonored(t *testing.T) {
+	// 600KB raw response for the diff-style tool — over the default and over a
+	// hypothetical 256KB integration cap, but under the 1MB per-tool override.
+	bigDiff := strings.Repeat("a", 600*1024)
+	mi := &mockIntegrationWithPerToolCap{
+		mockIntegration: &mockIntegration{
+			name:    "bigint",
+			healthy: true,
+			tools: []mcp.ToolDefinition{
+				{Name: "bigint_get_diff", Description: "Returns raw diff"},
+				{Name: "bigint_get_thing", Description: "Returns a normal payload"},
+			},
+			execFn: func(_ context.Context, _ mcp.ToolName, _ map[string]any) (*mcp.ToolResult, error) {
+				return &mcp.ToolResult{Data: bigDiff}, nil
+			},
+		},
+		perTool: map[mcp.ToolName]int{"bigint_get_diff": 1024 * 1024},
+	}
+
+	s := setupTestServerWithIntegration(mi)
+	result, err := s.handleExecute(context.Background(), executeRequest("bigint_get_diff", nil))
+	require.NoError(t, err)
+	assert.False(t, result.IsError, "response within per-tool cap should succeed")
+
+	tc := result.Content[0].(*mcpsdk.TextContent)
+	assert.Equal(t, bigDiff, tc.Text)
+}
+
+func TestHandleExecute_PerToolCapDoesNotLeakToOtherTools(t *testing.T) {
+	// Same integration declares a per-tool override only for bigint_get_diff.
+	// A different tool on the same integration must still be rejected at the
+	// 50KB default — the per-tool cap is not contagious.
+	bigPayload := `{"data":"` + strings.Repeat("y", 60*1024) + `"}`
+	mi := &mockIntegrationWithPerToolCap{
+		mockIntegration: &mockIntegration{
+			name:    "bigint",
+			healthy: true,
+			tools: []mcp.ToolDefinition{
+				{Name: "bigint_get_diff", Description: "Returns raw diff"},
+				{Name: "bigint_get_thing", Description: "Returns a normal payload"},
+			},
+			execFn: func(_ context.Context, _ mcp.ToolName, _ map[string]any) (*mcp.ToolResult, error) {
+				return &mcp.ToolResult{Data: bigPayload}, nil
+			},
+		},
+		perTool: map[mcp.ToolName]int{"bigint_get_diff": 1024 * 1024},
+	}
+
+	s := setupTestServerWithIntegration(mi)
+	result, err := s.handleExecute(context.Background(), executeRequest("bigint_get_thing", nil))
+	require.NoError(t, err)
+	assert.True(t, result.IsError, "other tools on the same integration must use the default cap")
+
+	tc := result.Content[0].(*mcpsdk.TextContent)
+	capKB := fmt.Sprintf("%dKB", defaultMaxResponseBytes/1024)
+	assert.Contains(t, tc.Text, capKB, "error should report the default cap, not the per-tool override")
+}
+
+// mockIntegrationWithBothCaps implements both the integration-wide cap and the
+// per-tool cap to verify that per-tool overrides take precedence for tools
+// that declare one, while the integration-wide value still covers the rest.
+type mockIntegrationWithBothCaps struct {
+	*mockIntegration
+	integrationCap int
+	perTool        map[mcp.ToolName]int
+}
+
+func (m *mockIntegrationWithBothCaps) MaxResponseBytes() int { return m.integrationCap }
+func (m *mockIntegrationWithBothCaps) MaxResponseBytesForTool(name mcp.ToolName) (int, bool) {
+	v, ok := m.perTool[name]
+	return v, ok
+}
+
+func TestHandleExecute_PerToolCapWinsOverIntegrationCap(t *testing.T) {
+	// Integration declares a 256KB cap and a 1MB per-tool override.
+	// A 600KB response would be rejected under the integration cap but must
+	// be accepted under the per-tool override.
+	bigDiff := strings.Repeat("z", 600*1024)
+	mi := &mockIntegrationWithBothCaps{
+		mockIntegration: &mockIntegration{
+			name:    "bigint",
+			healthy: true,
+			tools: []mcp.ToolDefinition{
+				{Name: "bigint_get_diff", Description: "Returns raw diff"},
+			},
+			execFn: func(_ context.Context, _ mcp.ToolName, _ map[string]any) (*mcp.ToolResult, error) {
+				return &mcp.ToolResult{Data: bigDiff}, nil
+			},
+		},
+		integrationCap: 256 * 1024,
+		perTool:        map[mcp.ToolName]int{"bigint_get_diff": 1024 * 1024},
+	}
+
+	s := setupTestServerWithIntegration(mi)
+	result, err := s.handleExecute(context.Background(), executeRequest("bigint_get_diff", nil))
+	require.NoError(t, err)
+	assert.False(t, result.IsError, "per-tool cap should take precedence over integration cap")
+}
+
 func TestToolResultJSON(t *testing.T) {
 	result := &mcp.ToolResult{Data: `{"count":5}`, IsError: false}
 	data, err := json.Marshal(result)


### PR DESCRIPTION

## Summary

- Adds `PerToolMaxResponseBytesIntegration`, an optional interface that lets an integration raise the 50KB default response cap for a single tool without loosening the safety net for the rest of its surface. The integration-wide `MaxResponseBytesIntegration` override remains the fallback when no per-tool value is declared.
- Threads the tool name through both `responseLimitFor` callsites (`server.handleExecute` and `ProjectRouter.makeExecuteHandler`) so the new interface runs on both the standard and project-scoped paths.
- Puts the interface to use on `github_get_pull_diff` (raw unified diff, no projection/pagination knob, 1MB cap). The agents PR review flow has been hitting "Response exceeded 50KB" for normal-sized PRs (a 21-file/5k-line PR is ~200KB); this unblocks it without touching the other 195 GitHub tools.

## Motivation

The model kept calling `github_get_pull_diff`, Switchboard kept rejecting the 193KB diff response, and the agent ran out of recovery moves. Switchboard already had a per-integration cap override (Confluence at 256KB), but raising the cap integration-wide for GitHub would weaken the safety net for the other 195 tools that should stay compact. The per-tool override targets the one tool that legitimately needs more headroom.

## Test plan

- [x] `gofmt -w . && go vet ./...`
- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `golangci-lint run` (0 issues)
- [x] New unit tests pin both callsites: `TestHandleExecute_PerToolCap{Honored,DoesNotLeakToOtherTools,WinsOverIntegrationCap}` on the server path; `TestProjectRouter_ExecutePerToolCap` on the project router path; `TestMaxResponseBytesForTool` on the GitHub integration.


💘 Generated with Crush