### PR TITLE
feat(cloudflare): expand coverage with Workers AI, Vectorize, Queues, Zero Trust, and more

### DIFF
--- a/integrations/cloudflare/ai_compute.go
+++ b/integrations/cloudflare/ai_compute.go
@@ -1,0 +1,181 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+// --- Workers AI ---
+
+func listAIModels(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	search, _ := mcp.ArgStr(args, "search")
+	task, _ := mcp.ArgStr(args, "task")
+	source, _ := mcp.ArgStr(args, "source")
+	q := queryEncode(map[string]string{
+		"search":   search,
+		"task":     task,
+		"source":   source,
+		"page":     fmt.Sprintf("%d", mcp.OptInt(args, "page", 1)),
+		"per_page": fmt.Sprintf("%d", mcp.OptInt(args, "per_page", 20)),
+	})
+	data, err := c.get(ctx, "/accounts/%s/ai/models/search%s", acct, q)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func runAIModel(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	modelName := r.Str("model_name")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	// Body is free-form so callers can pass `prompt`, `messages`, `input`, etc.
+	body, _ := mcp.ArgMap(args, "body")
+	if body == nil {
+		// Convenience: if caller passed a top-level `prompt`, wrap it.
+		if prompt, _ := mcp.ArgStr(args, "prompt"); prompt != "" {
+			body = map[string]any{"prompt": prompt}
+		}
+	}
+	if body == nil {
+		return mcp.ErrResult(fmt.Errorf("either `body` (map) or `prompt` (string) is required"))
+	}
+	data, err := c.post(ctx, fmt.Sprintf("/accounts/%s/ai/run/%s", acct, modelName), body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+// --- Vectorize v2 ---
+
+func listVectorizeIndexes(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := c.get(ctx, "/accounts/%s/vectorize/v2/indexes", acct)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func getVectorizeIndex(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	indexName := r.Str("index_name")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := c.get(ctx, "/accounts/%s/vectorize/v2/indexes/%s", acct, indexName)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func createVectorizeIndex(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	name := r.Str("name")
+	metric := r.Str("metric")
+	dimensions := r.Int("dimensions")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	description, _ := mcp.ArgStr(args, "description")
+	body := map[string]any{
+		"name": name,
+		"config": map[string]any{
+			"metric":     metric,
+			"dimensions": dimensions,
+		},
+	}
+	if description != "" {
+		body["description"] = description
+	}
+	data, err := c.post(ctx, fmt.Sprintf("/accounts/%s/vectorize/v2/indexes", acct), body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func deleteVectorizeIndex(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	indexName := r.Str("index_name")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := c.del(ctx, "/accounts/%s/vectorize/v2/indexes/%s", acct, indexName)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func queryVectorizeIndex(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	indexName := r.Str("index_name")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	vec, ok := args["vector"]
+	if !ok || vec == nil {
+		return mcp.ErrResult(fmt.Errorf("vector (array of floats) is required"))
+	}
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	body := map[string]any{"vector": vec}
+	if topK := mcp.OptInt(args, "topK", 0); topK > 0 {
+		body["topK"] = topK
+	}
+	if returnValues, err := mcp.ArgBool(args, "returnValues"); err == nil && hasKey(args, "returnValues") {
+		body["returnValues"] = returnValues
+	}
+	if returnMetadata, _ := mcp.ArgStr(args, "returnMetadata"); returnMetadata != "" {
+		body["returnMetadata"] = returnMetadata
+	}
+	if filter, _ := mcp.ArgMap(args, "filter"); filter != nil {
+		body["filter"] = filter
+	}
+	if ns, _ := mcp.ArgStr(args, "namespace"); ns != "" {
+		body["namespace"] = ns
+	}
+	data, err := c.post(ctx, fmt.Sprintf("/accounts/%s/vectorize/v2/indexes/%s/query", acct, indexName), body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+// hasKey reports whether a key is present (and non-nil) in args.
+func hasKey(args map[string]any, key string) bool {
+	v, ok := args[key]
+	return ok && v != nil
+}

--- a/integrations/cloudflare/cloudflare.go
+++ b/integrations/cloudflare/cloudflare.go
@@ -328,4 +328,86 @@ var dispatch = map[mcp.ToolName]handlerFunc{
 	mcp.ToolName("cloudflare_get_ai_gateway_log"):          getAIGatewayLog,
 	mcp.ToolName("cloudflare_get_ai_gateway_log_request"):  getAIGatewayLogRequest,
 	mcp.ToolName("cloudflare_get_ai_gateway_log_response"): getAIGatewayLogResponse,
+
+	// Workers AI
+	mcp.ToolName("cloudflare_list_ai_models"): listAIModels,
+	mcp.ToolName("cloudflare_run_ai_model"):   runAIModel,
+
+	// Vectorize
+	mcp.ToolName("cloudflare_list_vectorize_indexes"): listVectorizeIndexes,
+	mcp.ToolName("cloudflare_get_vectorize_index"):    getVectorizeIndex,
+	mcp.ToolName("cloudflare_create_vectorize_index"): createVectorizeIndex,
+	mcp.ToolName("cloudflare_delete_vectorize_index"): deleteVectorizeIndex,
+	mcp.ToolName("cloudflare_query_vectorize_index"):  queryVectorizeIndex,
+
+	// Queues
+	mcp.ToolName("cloudflare_list_queues"):         listQueues,
+	mcp.ToolName("cloudflare_get_queue"):           getQueue,
+	mcp.ToolName("cloudflare_create_queue"):        createQueue,
+	mcp.ToolName("cloudflare_delete_queue"):        deleteQueue,
+	mcp.ToolName("cloudflare_send_queue_messages"): sendQueueMessages,
+
+	// Hyperdrive
+	mcp.ToolName("cloudflare_list_hyperdrive_configs"):  listHyperdriveConfigs,
+	mcp.ToolName("cloudflare_get_hyperdrive_config"):    getHyperdriveConfig,
+	mcp.ToolName("cloudflare_create_hyperdrive_config"): createHyperdriveConfig,
+	mcp.ToolName("cloudflare_delete_hyperdrive_config"): deleteHyperdriveConfig,
+
+	// Workers extras
+	mcp.ToolName("cloudflare_list_worker_secrets"):     listWorkerSecrets,
+	mcp.ToolName("cloudflare_list_worker_deployments"): listWorkerDeployments,
+	mcp.ToolName("cloudflare_get_worker_subdomain"):    getWorkerSubdomain,
+	mcp.ToolName("cloudflare_list_worker_tails"):       listWorkerTails,
+
+	// Pages extras
+	mcp.ToolName("cloudflare_create_pages_project"):    createPagesProject,
+	mcp.ToolName("cloudflare_create_pages_deployment"): createPagesDeployment,
+	mcp.ToolName("cloudflare_list_pages_domains"):      listPagesDomains,
+
+	// KV bulk
+	mcp.ToolName("cloudflare_bulk_delete_kv_values"): bulkDeleteKVValues,
+
+	// Stream
+	mcp.ToolName("cloudflare_list_stream_videos"):  listStreamVideos,
+	mcp.ToolName("cloudflare_get_stream_video"):    getStreamVideo,
+	mcp.ToolName("cloudflare_delete_stream_video"): deleteStreamVideo,
+
+	// Images
+	mcp.ToolName("cloudflare_list_images"):  listImages,
+	mcp.ToolName("cloudflare_get_image"):    getImage,
+	mcp.ToolName("cloudflare_delete_image"): deleteImage,
+
+	// Zero Trust Access
+	mcp.ToolName("cloudflare_list_access_apps"):               listAccessApps,
+	mcp.ToolName("cloudflare_list_access_app_policies"):       listAccessAppPolicies,
+	mcp.ToolName("cloudflare_list_access_identity_providers"): listAccessIdentityProviders,
+
+	// Tunnels
+	mcp.ToolName("cloudflare_list_tunnels"):  listTunnels,
+	mcp.ToolName("cloudflare_get_tunnel"):    getTunnel,
+	mcp.ToolName("cloudflare_delete_tunnel"): deleteTunnel,
+
+	// Email Routing
+	mcp.ToolName("cloudflare_list_email_routing_rules"):     listEmailRoutingRules,
+	mcp.ToolName("cloudflare_list_email_routing_addresses"): listEmailRoutingAddresses,
+	mcp.ToolName("cloudflare_get_email_routing_settings"):   getEmailRoutingSettings,
+
+	// Logpush
+	mcp.ToolName("cloudflare_list_logpush_jobs"):  listLogpushJobs,
+	mcp.ToolName("cloudflare_get_logpush_job"):    getLogpushJob,
+	mcp.ToolName("cloudflare_create_logpush_job"): createLogpushJob,
+
+	// Page Rules
+	mcp.ToolName("cloudflare_list_page_rules"):  listPageRules,
+	mcp.ToolName("cloudflare_get_page_rule"):    getPageRule,
+	mcp.ToolName("cloudflare_delete_page_rule"): deletePageRule,
+
+	// Notifications
+	mcp.ToolName("cloudflare_list_notification_policies"): listNotificationPolicies,
+	mcp.ToolName("cloudflare_list_notification_webhooks"): listNotificationWebhooks,
+
+	// API Tokens
+	mcp.ToolName("cloudflare_list_api_tokens"):  listAPITokens,
+	mcp.ToolName("cloudflare_get_api_token"):    getAPIToken,
+	mcp.ToolName("cloudflare_delete_api_token"): deleteAPIToken,
 }

--- a/integrations/cloudflare/compact.yaml
+++ b/integrations/cloudflare/compact.yaml
@@ -326,7 +326,6 @@ tools:
             - result[].dataset
             - result[].enabled
             - result[].name
-            - result[].destination_conf
             - result[].logpull_options
             - result[].last_complete
             - result[].last_error

--- a/integrations/cloudflare/compact.yaml
+++ b/integrations/cloudflare/compact.yaml
@@ -175,3 +175,199 @@ tools:
             - result[].plan.name
             - result[].activated_on
             - result[].modified_on
+    cloudflare_list_ai_models:
+        spec:
+            - result[].id
+            - result[].source
+            - result[].name
+            - result[].description
+            - result[].task.id
+            - result[].task.name
+            - result[].properties[].property_id
+            - result[].properties[].value
+    cloudflare_list_vectorize_indexes:
+        spec:
+            - result[].id
+            - result[].name
+            - result[].description
+            - result[].config.dimensions
+            - result[].config.metric
+            - result[].created_on
+            - result[].modified_on
+    cloudflare_list_queues:
+        spec:
+            - result[].queue_id
+            - result[].queue_name
+            - result[].created_on
+            - result[].modified_on
+            - result[].producers_total_count
+            - result[].consumers_total_count
+    cloudflare_list_hyperdrive_configs:
+        spec:
+            - result[].id
+            - result[].name
+            - result[].origin.host
+            - result[].origin.port
+            - result[].origin.database
+            - result[].origin.scheme
+            - result[].caching.disabled
+            - result[].caching.max_age
+            - result[].caching.stale_while_revalidate
+    cloudflare_list_worker_secrets:
+        spec:
+            - result[].name
+            - result[].type
+    cloudflare_list_worker_deployments:
+        spec:
+            - result[].id
+            - result[].source
+            - result[].strategy
+            - result[].author_email
+            - result[].created_on
+            - result[].versions[].version_id
+            - result[].versions[].percentage
+    cloudflare_list_worker_tails:
+        spec:
+            - result[].id
+            - result[].url
+            - result[].expires_at
+    cloudflare_list_pages_domains:
+        spec:
+            - result[].id
+            - result[].name
+            - result[].status
+            - result[].verification_data.status
+            - result[].validation_data.status
+            - result[].certificate_authority
+            - result[].created_on
+    cloudflare_list_stream_videos:
+        spec:
+            - result[].uid
+            - result[].meta.name
+            - result[].duration
+            - result[].size
+            - result[].status.state
+            - result[].readyToStream
+            - result[].thumbnail
+            - result[].preview
+            - result[].playback.hls
+            - result[].playback.dash
+            - result[].created
+            - result[].modified
+    cloudflare_list_images:
+        spec:
+            - result.images[].id
+            - result.images[].filename
+            - result.images[].meta
+            - result.images[].requireSignedURLs
+            - result.images[].variants
+            - result.images[].uploaded
+    cloudflare_list_access_apps:
+        spec:
+            - result[].id
+            - result[].uid
+            - result[].name
+            - result[].domain
+            - result[].type
+            - result[].session_duration
+            - result[].auto_redirect_to_identity
+            - result[].allowed_idps
+            - result[].created_at
+            - result[].updated_at
+    cloudflare_list_access_app_policies:
+        spec:
+            - result[].id
+            - result[].name
+            - result[].decision
+            - result[].precedence
+            - result[].include
+            - result[].exclude
+            - result[].require
+            - result[].created_at
+            - result[].updated_at
+    cloudflare_list_access_identity_providers:
+        spec:
+            - result[].id
+            - result[].name
+            - result[].type
+            - result[].config.client_id
+            - result[].scim_config.enabled
+    cloudflare_list_tunnels:
+        spec:
+            - result[].id
+            - result[].name
+            - result[].status
+            - result[].connections[].id
+            - result[].connections[].colo_name
+            - result[].connections[].is_pending_reconnect
+            - result[].created_at
+            - result[].deleted_at
+    cloudflare_list_email_routing_rules:
+        spec:
+            - result[].tag
+            - result[].name
+            - result[].enabled
+            - result[].priority
+            - result[].matchers[].type
+            - result[].matchers[].field
+            - result[].matchers[].value
+            - result[].actions[].type
+            - result[].actions[].value
+    cloudflare_list_email_routing_addresses:
+        spec:
+            - result[].tag
+            - result[].email
+            - result[].verified
+            - result[].created
+            - result[].modified
+    cloudflare_list_logpush_jobs:
+        spec:
+            - result[].id
+            - result[].dataset
+            - result[].enabled
+            - result[].name
+            - result[].destination_conf
+            - result[].logpull_options
+            - result[].last_complete
+            - result[].last_error
+            - result[].error_message
+    cloudflare_list_page_rules:
+        spec:
+            - result[].id
+            - result[].status
+            - result[].priority
+            - result[].targets[].constraint.operator
+            - result[].targets[].constraint.value
+            - result[].actions[].id
+            - result[].actions[].value
+            - result[].created_on
+            - result[].modified_on
+    cloudflare_list_notification_policies:
+        spec:
+            - result[].id
+            - result[].name
+            - result[].description
+            - result[].enabled
+            - result[].alert_type
+            - result[].mechanisms
+            - result[].created
+            - result[].modified
+    cloudflare_list_notification_webhooks:
+        spec:
+            - result[].id
+            - result[].name
+            - result[].url
+            - result[].type
+            - result[].created_at
+            - result[].last_success
+            - result[].last_failure
+    cloudflare_list_api_tokens:
+        spec:
+            - result[].id
+            - result[].name
+            - result[].status
+            - result[].issued_on
+            - result[].modified_on
+            - result[].last_used_on
+            - result[].expires_on
+            - result[].not_before

--- a/integrations/cloudflare/compute_extras.go
+++ b/integrations/cloudflare/compute_extras.go
@@ -1,0 +1,172 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+// --- Workers extras ---
+
+func listWorkerSecrets(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	scriptName := r.Str("script_name")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := c.get(ctx, "/accounts/%s/workers/scripts/%s/secrets", acct, scriptName)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func listWorkerDeployments(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	scriptName := r.Str("script_name")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := c.get(ctx, "/accounts/%s/workers/scripts/%s/deployments", acct, scriptName)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func getWorkerSubdomain(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := c.get(ctx, "/accounts/%s/workers/subdomain", acct)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func listWorkerTails(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	scriptName := r.Str("script_name")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := c.get(ctx, "/accounts/%s/workers/scripts/%s/tails", acct, scriptName)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+// --- Pages: create project / deployment / domains ---
+
+func createPagesProject(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	name := r.Str("name")
+	productionBranch := r.Str("production_branch")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	body := map[string]any{
+		"name":              name,
+		"production_branch": productionBranch,
+	}
+	if buildConfig, _ := mcp.ArgMap(args, "build_config"); buildConfig != nil {
+		body["build_config"] = buildConfig
+	}
+	if source, _ := mcp.ArgMap(args, "source"); source != nil {
+		body["source"] = source
+	}
+	if deploymentConfigs, _ := mcp.ArgMap(args, "deployment_configs"); deploymentConfigs != nil {
+		body["deployment_configs"] = deploymentConfigs
+	}
+	data, err := c.post(ctx, fmt.Sprintf("/accounts/%s/pages/projects", acct), body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func createPagesDeployment(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	projectName := r.Str("project_name")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	branch, _ := mcp.ArgStr(args, "branch")
+	body := map[string]any{}
+	if branch != "" {
+		body["branch"] = branch
+	}
+	data, err := c.post(ctx, fmt.Sprintf("/accounts/%s/pages/projects/%s/deployments", acct, projectName), body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func listPagesDomains(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	projectName := r.Str("project_name")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := c.get(ctx, "/accounts/%s/pages/projects/%s/domains", acct, projectName)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+// --- KV bulk delete ---
+
+func bulkDeleteKVValues(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	namespaceID := r.Str("namespace_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	keys, err := mcp.ArgStrSlice(args, "keys")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	if len(keys) == 0 {
+		return mcp.ErrResult(fmt.Errorf("keys (non-empty array of strings) is required"))
+	}
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	body := map[string]any{"keys": keys}
+	data, err := c.post(ctx, fmt.Sprintf("/accounts/%s/storage/kv/namespaces/%s/bulk/delete", acct, namespaceID), body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}

--- a/integrations/cloudflare/compute_extras.go
+++ b/integrations/cloudflare/compute_extras.go
@@ -163,8 +163,7 @@ func bulkDeleteKVValues(ctx context.Context, c *cloudflare, args map[string]any)
 	if err != nil {
 		return mcp.ErrResult(err)
 	}
-	body := map[string]any{"keys": keys}
-	data, err := c.post(ctx, fmt.Sprintf("/accounts/%s/storage/kv/namespaces/%s/bulk/delete", acct, namespaceID), body)
+	data, err := c.post(ctx, fmt.Sprintf("/accounts/%s/storage/kv/namespaces/%s/bulk/delete", acct, namespaceID), keys)
 	if err != nil {
 		return mcp.ErrResult(err)
 	}

--- a/integrations/cloudflare/email_logpush.go
+++ b/integrations/cloudflare/email_logpush.go
@@ -1,0 +1,124 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+// --- Email Routing ---
+
+func listEmailRoutingRules(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	zoneID := r.Str("zone_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := c.get(ctx, "/zones/%s/email/routing/rules", zoneID)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func listEmailRoutingAddresses(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	verified, _ := mcp.ArgStr(args, "verified")
+	q := queryEncode(map[string]string{
+		"verified": verified,
+		"page":     fmt.Sprintf("%d", mcp.OptInt(args, "page", 1)),
+		"per_page": fmt.Sprintf("%d", mcp.OptInt(args, "per_page", 20)),
+	})
+	data, err := c.get(ctx, "/accounts/%s/email/routing/addresses%s", acct, q)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func getEmailRoutingSettings(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	zoneID := r.Str("zone_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := c.get(ctx, "/zones/%s/email/routing", zoneID)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+// --- Logpush (account-scoped) ---
+
+func listLogpushJobs(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := c.get(ctx, "/accounts/%s/logpush/jobs", acct)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func getLogpushJob(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	jobID := mcp.OptInt(args, "job_id", 0)
+	if jobID == 0 {
+		return mcp.ErrResult(fmt.Errorf("job_id (integer) is required"))
+	}
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := c.get(ctx, "/accounts/%s/logpush/jobs/%d", acct, jobID)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func createLogpushJob(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	dataset := r.Str("dataset")
+	destinationConf := r.Str("destination_conf")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	body := map[string]any{
+		"dataset":          dataset,
+		"destination_conf": destinationConf,
+	}
+	if name, _ := mcp.ArgStr(args, "name"); name != "" {
+		body["name"] = name
+	}
+	if frequency, _ := mcp.ArgStr(args, "frequency"); frequency != "" {
+		body["frequency"] = frequency
+	}
+	if logpullOptions, _ := mcp.ArgStr(args, "logpull_options"); logpullOptions != "" {
+		body["logpull_options"] = logpullOptions
+	}
+	if outputOptions, _ := mcp.ArgMap(args, "output_options"); outputOptions != nil {
+		body["output_options"] = outputOptions
+	}
+	if filter, _ := mcp.ArgStr(args, "filter"); filter != "" {
+		body["filter"] = filter
+	}
+	if enabled, err := mcp.ArgBool(args, "enabled"); err == nil && hasKey(args, "enabled") {
+		body["enabled"] = enabled
+	}
+	data, err := c.post(ctx, fmt.Sprintf("/accounts/%s/logpush/jobs", acct), body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}

--- a/integrations/cloudflare/email_logpush.go
+++ b/integrations/cloudflare/email_logpush.go
@@ -68,9 +68,10 @@ func listLogpushJobs(ctx context.Context, c *cloudflare, args map[string]any) (*
 }
 
 func getLogpushJob(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
-	jobID := mcp.OptInt(args, "job_id", 0)
-	if jobID == 0 {
-		return mcp.ErrResult(fmt.Errorf("job_id (integer) is required"))
+	r := mcp.NewArgs(args)
+	jobID := r.Int("job_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
 	}
 	acct, err := c.acctID(args)
 	if err != nil {

--- a/integrations/cloudflare/expanded_coverage_test.go
+++ b/integrations/cloudflare/expanded_coverage_test.go
@@ -219,6 +219,9 @@ func TestBulkDeleteKVValues(t *testing.T) {
 	c, ts := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "POST", r.Method)
 		assert.Contains(t, r.URL.Path, "/accounts/test-acct/storage/kv/namespaces/ns1/bulk/delete")
+		var body []string
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, []string{"a", "b"}, body)
 		_, _ = w.Write([]byte(`{"success":true,"result":{"successful_key_count":2}}`))
 	}))
 	defer ts.Close()

--- a/integrations/cloudflare/expanded_coverage_test.go
+++ b/integrations/cloudflare/expanded_coverage_test.go
@@ -1,0 +1,425 @@
+package cloudflare
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Workers AI ---
+
+func TestListAIModels_PassesFilters(t *testing.T) {
+	c, ts := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Contains(t, r.URL.Path, "/accounts/test-acct/ai/models/search")
+		q := r.URL.Query()
+		assert.Equal(t, "llama", q.Get("search"))
+		assert.Equal(t, "text-generation", q.Get("task"))
+		_, _ = w.Write([]byte(`{"success":true,"result":[{"id":"m1","name":"@cf/meta/llama-3"}]}`))
+	}))
+	defer ts.Close()
+	result, err := c.Execute(context.Background(), "cloudflare_list_ai_models", map[string]any{
+		"search": "llama", "task": "text-generation",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "llama-3")
+}
+
+func TestRunAIModel_PromptShortcut(t *testing.T) {
+	c, ts := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Contains(t, r.URL.Path, "/accounts/test-acct/ai/run/@cf/meta/llama-3")
+		body := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(body)
+		assert.Contains(t, string(body), `"prompt":"hello"`)
+		_, _ = w.Write([]byte(`{"success":true,"result":{"response":"hi"}}`))
+	}))
+	defer ts.Close()
+	result, err := c.Execute(context.Background(), "cloudflare_run_ai_model", map[string]any{
+		"model_name": "@cf/meta/llama-3", "prompt": "hello",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "response")
+}
+
+func TestRunAIModel_RequiresBody(t *testing.T) {
+	c, ts := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("should not hit API when body and prompt are missing")
+	}))
+	defer ts.Close()
+	result, err := c.Execute(context.Background(), "cloudflare_run_ai_model", map[string]any{
+		"model_name": "@cf/meta/llama-3",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+}
+
+// --- Vectorize ---
+
+func TestListVectorizeIndexes(t *testing.T) {
+	c, ts := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Contains(t, r.URL.Path, "/accounts/test-acct/vectorize/v2/indexes")
+		_, _ = w.Write([]byte(`{"success":true,"result":[{"name":"idx1","config":{"dimensions":768,"metric":"cosine"}}]}`))
+	}))
+	defer ts.Close()
+	result, err := c.Execute(context.Background(), "cloudflare_list_vectorize_indexes", map[string]any{})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "idx1")
+}
+
+func TestQueryVectorizeIndex(t *testing.T) {
+	c, ts := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Contains(t, r.URL.Path, "/accounts/test-acct/vectorize/v2/indexes/idx1/query")
+		_, _ = w.Write([]byte(`{"success":true,"result":{"matches":[{"id":"a","score":0.9}]}}`))
+	}))
+	defer ts.Close()
+	result, err := c.Execute(context.Background(), "cloudflare_query_vectorize_index", map[string]any{
+		"index_name": "idx1",
+		"vector":     []any{0.1, 0.2, 0.3},
+		"topK":       5,
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "matches")
+}
+
+func TestQueryVectorizeIndex_RequiresVector(t *testing.T) {
+	c, ts := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("should not hit API")
+	}))
+	defer ts.Close()
+	result, err := c.Execute(context.Background(), "cloudflare_query_vectorize_index", map[string]any{
+		"index_name": "idx1",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+}
+
+// --- Queues ---
+
+func TestListQueues(t *testing.T) {
+	c, ts := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Contains(t, r.URL.Path, "/accounts/test-acct/queues")
+		_, _ = w.Write([]byte(`{"success":true,"result":[{"queue_id":"q1","queue_name":"main"}]}`))
+	}))
+	defer ts.Close()
+	result, err := c.Execute(context.Background(), "cloudflare_list_queues", map[string]any{})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "main")
+}
+
+func TestSendQueueMessages(t *testing.T) {
+	c, ts := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Contains(t, r.URL.Path, "/accounts/test-acct/queues/q1/messages")
+		_, _ = w.Write([]byte(`{"success":true,"result":{"sent":2}}`))
+	}))
+	defer ts.Close()
+	result, err := c.Execute(context.Background(), "cloudflare_send_queue_messages", map[string]any{
+		"queue_id": "q1",
+		"messages": []any{map[string]any{"body": "hello"}, map[string]any{"body": "world"}},
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+}
+
+// --- Hyperdrive ---
+
+func TestListHyperdriveConfigs(t *testing.T) {
+	c, ts := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Contains(t, r.URL.Path, "/accounts/test-acct/hyperdrive/configs")
+		_, _ = w.Write([]byte(`{"success":true,"result":[{"id":"hd1","name":"pg-main"}]}`))
+	}))
+	defer ts.Close()
+	result, err := c.Execute(context.Background(), "cloudflare_list_hyperdrive_configs", map[string]any{})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "pg-main")
+}
+
+// --- Workers extras ---
+
+func TestListWorkerSecrets(t *testing.T) {
+	c, ts := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Contains(t, r.URL.Path, "/accounts/test-acct/workers/scripts/api/secrets")
+		_, _ = w.Write([]byte(`{"success":true,"result":[{"name":"API_KEY","type":"secret_text"}]}`))
+	}))
+	defer ts.Close()
+	result, err := c.Execute(context.Background(), "cloudflare_list_worker_secrets", map[string]any{
+		"script_name": "api",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "API_KEY")
+}
+
+func TestGetWorkerSubdomain(t *testing.T) {
+	c, ts := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Contains(t, r.URL.Path, "/accounts/test-acct/workers/subdomain")
+		_, _ = w.Write([]byte(`{"success":true,"result":{"name":"acme"}}`))
+	}))
+	defer ts.Close()
+	result, err := c.Execute(context.Background(), "cloudflare_get_worker_subdomain", map[string]any{})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "acme")
+}
+
+// --- Pages extras ---
+
+func TestCreatePagesProject(t *testing.T) {
+	c, ts := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Contains(t, r.URL.Path, "/accounts/test-acct/pages/projects")
+		_, _ = w.Write([]byte(`{"success":true,"result":{"name":"site"}}`))
+	}))
+	defer ts.Close()
+	result, err := c.Execute(context.Background(), "cloudflare_create_pages_project", map[string]any{
+		"name":              "site",
+		"production_branch": "main",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+}
+
+func TestListPagesDomains(t *testing.T) {
+	c, ts := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Contains(t, r.URL.Path, "/accounts/test-acct/pages/projects/site/domains")
+		_, _ = w.Write([]byte(`{"success":true,"result":[{"id":"d1","name":"example.com","status":"active"}]}`))
+	}))
+	defer ts.Close()
+	result, err := c.Execute(context.Background(), "cloudflare_list_pages_domains", map[string]any{
+		"project_name": "site",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "example.com")
+}
+
+// --- KV bulk ---
+
+func TestBulkDeleteKVValues(t *testing.T) {
+	c, ts := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Contains(t, r.URL.Path, "/accounts/test-acct/storage/kv/namespaces/ns1/bulk/delete")
+		_, _ = w.Write([]byte(`{"success":true,"result":{"successful_key_count":2}}`))
+	}))
+	defer ts.Close()
+	result, err := c.Execute(context.Background(), "cloudflare_bulk_delete_kv_values", map[string]any{
+		"namespace_id": "ns1",
+		"keys":         []any{"a", "b"},
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+}
+
+// --- Stream / Images ---
+
+func TestListStreamVideos(t *testing.T) {
+	c, ts := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Contains(t, r.URL.Path, "/accounts/test-acct/stream")
+		_, _ = w.Write([]byte(`{"success":true,"result":[{"uid":"v1","meta":{"name":"intro"}}]}`))
+	}))
+	defer ts.Close()
+	result, err := c.Execute(context.Background(), "cloudflare_list_stream_videos", map[string]any{})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "intro")
+}
+
+func TestDeleteImage(t *testing.T) {
+	c, ts := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method)
+		assert.Contains(t, r.URL.Path, "/accounts/test-acct/images/v1/img1")
+		_, _ = w.Write([]byte(`{"success":true,"result":{}}`))
+	}))
+	defer ts.Close()
+	result, err := c.Execute(context.Background(), "cloudflare_delete_image", map[string]any{
+		"image_id": "img1",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+}
+
+// --- Zero Trust Access ---
+
+func TestListAccessApps(t *testing.T) {
+	c, ts := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Contains(t, r.URL.Path, "/accounts/test-acct/access/apps")
+		_, _ = w.Write([]byte(`{"success":true,"result":[{"id":"a1","name":"internal","domain":"internal.acme.com"}]}`))
+	}))
+	defer ts.Close()
+	result, err := c.Execute(context.Background(), "cloudflare_list_access_apps", map[string]any{})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "internal")
+}
+
+func TestListAccessAppPolicies(t *testing.T) {
+	c, ts := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Contains(t, r.URL.Path, "/accounts/test-acct/access/apps/a1/policies")
+		_, _ = w.Write([]byte(`{"success":true,"result":[{"id":"p1","name":"engineers","decision":"allow"}]}`))
+	}))
+	defer ts.Close()
+	result, err := c.Execute(context.Background(), "cloudflare_list_access_app_policies", map[string]any{
+		"app_id": "a1",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "engineers")
+}
+
+// --- Tunnels ---
+
+func TestListTunnels(t *testing.T) {
+	c, ts := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Contains(t, r.URL.Path, "/accounts/test-acct/cfd_tunnel")
+		_, _ = w.Write([]byte(`{"success":true,"result":[{"id":"t1","name":"home","status":"healthy"}]}`))
+	}))
+	defer ts.Close()
+	result, err := c.Execute(context.Background(), "cloudflare_list_tunnels", map[string]any{})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "home")
+}
+
+// --- Email Routing ---
+
+func TestListEmailRoutingRules(t *testing.T) {
+	c, ts := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Contains(t, r.URL.Path, "/zones/z1/email/routing/rules")
+		_, _ = w.Write([]byte(`{"success":true,"result":[{"tag":"r1","name":"catch-all","enabled":true}]}`))
+	}))
+	defer ts.Close()
+	result, err := c.Execute(context.Background(), "cloudflare_list_email_routing_rules", map[string]any{
+		"zone_id": "z1",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "catch-all")
+}
+
+func TestGetEmailRoutingSettings(t *testing.T) {
+	c, ts := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.True(t, strings.HasSuffix(r.URL.Path, "/zones/z1/email/routing"))
+		_, _ = w.Write([]byte(`{"success":true,"result":{"enabled":true,"name":"acme"}}`))
+	}))
+	defer ts.Close()
+	result, err := c.Execute(context.Background(), "cloudflare_get_email_routing_settings", map[string]any{
+		"zone_id": "z1",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "enabled")
+}
+
+// --- Logpush ---
+
+func TestListLogpushJobs(t *testing.T) {
+	c, ts := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Contains(t, r.URL.Path, "/accounts/test-acct/logpush/jobs")
+		_, _ = w.Write([]byte(`{"success":true,"result":[{"id":1,"dataset":"http_requests","enabled":true}]}`))
+	}))
+	defer ts.Close()
+	result, err := c.Execute(context.Background(), "cloudflare_list_logpush_jobs", map[string]any{})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "http_requests")
+}
+
+func TestGetLogpushJob(t *testing.T) {
+	c, ts := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Contains(t, r.URL.Path, "/accounts/test-acct/logpush/jobs/42")
+		_, _ = w.Write([]byte(`{"success":true,"result":{"id":42,"dataset":"http_requests"}}`))
+	}))
+	defer ts.Close()
+	result, err := c.Execute(context.Background(), "cloudflare_get_logpush_job", map[string]any{
+		"job_id": 42,
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+}
+
+// --- Page Rules ---
+
+func TestListPageRules(t *testing.T) {
+	c, ts := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Contains(t, r.URL.Path, "/zones/z1/pagerules")
+		_, _ = w.Write([]byte(`{"success":true,"result":[{"id":"pr1","status":"active","priority":1}]}`))
+	}))
+	defer ts.Close()
+	result, err := c.Execute(context.Background(), "cloudflare_list_page_rules", map[string]any{
+		"zone_id": "z1",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "pr1")
+}
+
+// --- Notifications ---
+
+func TestListNotificationPolicies(t *testing.T) {
+	c, ts := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Contains(t, r.URL.Path, "/accounts/test-acct/alerting/v3/policies")
+		_, _ = w.Write([]byte(`{"success":true,"result":[{"id":"np1","name":"prod-alerts","enabled":true}]}`))
+	}))
+	defer ts.Close()
+	result, err := c.Execute(context.Background(), "cloudflare_list_notification_policies", map[string]any{})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "prod-alerts")
+}
+
+// --- API Tokens ---
+
+func TestListAPITokens(t *testing.T) {
+	c, ts := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Contains(t, r.URL.Path, "/accounts/test-acct/tokens")
+		_, _ = w.Write([]byte(`{"success":true,"result":[{"id":"tok1","name":"ci","status":"active"}]}`))
+	}))
+	defer ts.Close()
+	result, err := c.Execute(context.Background(), "cloudflare_list_api_tokens", map[string]any{})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "ci")
+}
+
+func TestDeleteAPIToken(t *testing.T) {
+	c, ts := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method)
+		assert.Contains(t, r.URL.Path, "/accounts/test-acct/tokens/tok1")
+		_, _ = w.Write([]byte(`{"success":true,"result":{}}`))
+	}))
+	defer ts.Close()
+	result, err := c.Execute(context.Background(), "cloudflare_delete_api_token", map[string]any{
+		"token_id": "tok1",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+}

--- a/integrations/cloudflare/expanded_coverage_test.go
+++ b/integrations/cloudflare/expanded_coverage_test.go
@@ -2,10 +2,12 @@ package cloudflare
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"strings"
 	"testing"
 
+	mcp "github.com/daltoniam/switchboard"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -400,7 +402,7 @@ func TestListNotificationPolicies(t *testing.T) {
 func TestListAPITokens(t *testing.T) {
 	c, ts := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "GET", r.Method)
-		assert.Contains(t, r.URL.Path, "/accounts/test-acct/tokens")
+		assert.True(t, strings.HasSuffix(r.URL.Path, "/user/tokens"))
 		_, _ = w.Write([]byte(`{"success":true,"result":[{"id":"tok1","name":"ci","status":"active"}]}`))
 	}))
 	defer ts.Close()
@@ -410,10 +412,25 @@ func TestListAPITokens(t *testing.T) {
 	assert.Contains(t, result.Data, "ci")
 }
 
+func TestGetAPIToken(t *testing.T) {
+	c, ts := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.True(t, strings.HasSuffix(r.URL.Path, "/user/tokens/tok1"))
+		_, _ = w.Write([]byte(`{"success":true,"result":{"id":"tok1","name":"ci","status":"active"}}`))
+	}))
+	defer ts.Close()
+	result, err := c.Execute(context.Background(), "cloudflare_get_api_token", map[string]any{
+		"token_id": "tok1",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "ci")
+}
+
 func TestDeleteAPIToken(t *testing.T) {
 	c, ts := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "DELETE", r.Method)
-		assert.Contains(t, r.URL.Path, "/accounts/test-acct/tokens/tok1")
+		assert.True(t, strings.HasSuffix(r.URL.Path, "/user/tokens/tok1"))
 		_, _ = w.Write([]byte(`{"success":true,"result":{}}`))
 	}))
 	defer ts.Close()
@@ -422,4 +439,28 @@ func TestDeleteAPIToken(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.False(t, result.IsError)
+}
+
+func TestListLogpushJobs_DoesNotCompactDestinationCredentials(t *testing.T) {
+	fields, ok := fieldCompactionSpecs["cloudflare_list_logpush_jobs"]
+	require.True(t, ok)
+
+	var payload any
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"result":[{
+			"id":1,
+			"dataset":"http_requests",
+			"enabled":true,
+			"name":"prod",
+			"destination_conf":"s3://bucket/path?access-key-id=AKIAEXAMPLE&secret-access-key=supersecret",
+			"logpull_options":"fields=RayID"
+		}]
+	}`), &payload))
+
+	compacted := mcp.CompactAny(payload, fields)
+	encoded, err := json.Marshal(compacted)
+	require.NoError(t, err)
+	assert.NotContains(t, string(encoded), "destination_conf")
+	assert.NotContains(t, string(encoded), "supersecret")
+	assert.Contains(t, string(encoded), "http_requests")
 }

--- a/integrations/cloudflare/governance.go
+++ b/integrations/cloudflare/governance.go
@@ -1,0 +1,137 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+// --- Page Rules ---
+
+func listPageRules(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	zoneID := r.Str("zone_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	status, _ := mcp.ArgStr(args, "status")
+	order, _ := mcp.ArgStr(args, "order")
+	direction, _ := mcp.ArgStr(args, "direction")
+	q := queryEncode(map[string]string{
+		"status":    status,
+		"order":     order,
+		"direction": direction,
+	})
+	data, err := c.get(ctx, "/zones/%s/pagerules%s", zoneID, q)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func getPageRule(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	zoneID := r.Str("zone_id")
+	pageruleID := r.Str("pagerule_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := c.get(ctx, "/zones/%s/pagerules/%s", zoneID, pageruleID)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func deletePageRule(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	zoneID := r.Str("zone_id")
+	pageruleID := r.Str("pagerule_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := c.del(ctx, "/zones/%s/pagerules/%s", zoneID, pageruleID)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+// --- Notifications (Alerting v3) ---
+
+func listNotificationPolicies(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := c.get(ctx, "/accounts/%s/alerting/v3/policies", acct)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func listNotificationWebhooks(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := c.get(ctx, "/accounts/%s/alerting/v3/destinations/webhooks", acct)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+// --- Account API Tokens ---
+
+func listAPITokens(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	q := queryEncode(map[string]string{
+		"page":     fmt.Sprintf("%d", mcp.OptInt(args, "page", 1)),
+		"per_page": fmt.Sprintf("%d", mcp.OptInt(args, "per_page", 20)),
+	})
+	data, err := c.get(ctx, "/accounts/%s/tokens%s", acct, q)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func getAPIToken(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	tokenID := r.Str("token_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := c.get(ctx, "/accounts/%s/tokens/%s", acct, tokenID)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func deleteAPIToken(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	tokenID := r.Str("token_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := c.del(ctx, "/accounts/%s/tokens/%s", acct, tokenID)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}

--- a/integrations/cloudflare/governance.go
+++ b/integrations/cloudflare/governance.go
@@ -84,18 +84,14 @@ func listNotificationWebhooks(ctx context.Context, c *cloudflare, args map[strin
 	return mcp.RawResult(data)
 }
 
-// --- Account API Tokens ---
+// --- User API Tokens ---
 
 func listAPITokens(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
-	acct, err := c.acctID(args)
-	if err != nil {
-		return mcp.ErrResult(err)
-	}
 	q := queryEncode(map[string]string{
 		"page":     fmt.Sprintf("%d", mcp.OptInt(args, "page", 1)),
 		"per_page": fmt.Sprintf("%d", mcp.OptInt(args, "per_page", 20)),
 	})
-	data, err := c.get(ctx, "/accounts/%s/tokens%s", acct, q)
+	data, err := c.get(ctx, "/user/tokens%s", q)
 	if err != nil {
 		return mcp.ErrResult(err)
 	}
@@ -108,11 +104,7 @@ func getAPIToken(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.
 	if err := r.Err(); err != nil {
 		return mcp.ErrResult(err)
 	}
-	acct, err := c.acctID(args)
-	if err != nil {
-		return mcp.ErrResult(err)
-	}
-	data, err := c.get(ctx, "/accounts/%s/tokens/%s", acct, tokenID)
+	data, err := c.get(ctx, "/user/tokens/%s", tokenID)
 	if err != nil {
 		return mcp.ErrResult(err)
 	}
@@ -125,11 +117,7 @@ func deleteAPIToken(ctx context.Context, c *cloudflare, args map[string]any) (*m
 	if err := r.Err(); err != nil {
 		return mcp.ErrResult(err)
 	}
-	acct, err := c.acctID(args)
-	if err != nil {
-		return mcp.ErrResult(err)
-	}
-	data, err := c.del(ctx, "/accounts/%s/tokens/%s", acct, tokenID)
+	data, err := c.del(ctx, "/user/tokens/%s", tokenID)
 	if err != nil {
 		return mcp.ErrResult(err)
 	}

--- a/integrations/cloudflare/media.go
+++ b/integrations/cloudflare/media.go
@@ -1,0 +1,120 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+// --- Stream videos ---
+
+func listStreamVideos(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	after, _ := mcp.ArgStr(args, "after")
+	before, _ := mcp.ArgStr(args, "before")
+	creator, _ := mcp.ArgStr(args, "creator")
+	status, _ := mcp.ArgStr(args, "status")
+	search, _ := mcp.ArgStr(args, "search")
+	q := queryEncode(map[string]string{
+		"after":   after,
+		"before":  before,
+		"creator": creator,
+		"status":  status,
+		"search":  search,
+	})
+	data, err := c.get(ctx, "/accounts/%s/stream%s", acct, q)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func getStreamVideo(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	identifier := r.Str("identifier")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := c.get(ctx, "/accounts/%s/stream/%s", acct, identifier)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func deleteStreamVideo(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	identifier := r.Str("identifier")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := c.del(ctx, "/accounts/%s/stream/%s", acct, identifier)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+// --- Cloudflare Images v1 ---
+
+func listImages(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	q := queryEncode(map[string]string{
+		"page":     fmt.Sprintf("%d", mcp.OptInt(args, "page", 1)),
+		"per_page": fmt.Sprintf("%d", mcp.OptInt(args, "per_page", 50)),
+	})
+	data, err := c.get(ctx, "/accounts/%s/images/v1%s", acct, q)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func getImage(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	imageID := r.Str("image_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := c.get(ctx, "/accounts/%s/images/v1/%s", acct, imageID)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func deleteImage(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	imageID := r.Str("image_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := c.del(ctx, "/accounts/%s/images/v1/%s", acct, imageID)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}

--- a/integrations/cloudflare/queues_hyperdrive.go
+++ b/integrations/cloudflare/queues_hyperdrive.go
@@ -1,0 +1,179 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+// --- Queues ---
+
+func listQueues(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	q := queryEncode(map[string]string{
+		"page":     fmt.Sprintf("%d", mcp.OptInt(args, "page", 1)),
+		"per_page": fmt.Sprintf("%d", mcp.OptInt(args, "per_page", 20)),
+	})
+	data, err := c.get(ctx, "/accounts/%s/queues%s", acct, q)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func getQueue(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	queueID := r.Str("queue_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := c.get(ctx, "/accounts/%s/queues/%s", acct, queueID)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func createQueue(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	queueName := r.Str("queue_name")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	body := map[string]any{"queue_name": queueName}
+	if settings, _ := mcp.ArgMap(args, "settings"); settings != nil {
+		body["settings"] = settings
+	}
+	data, err := c.post(ctx, fmt.Sprintf("/accounts/%s/queues", acct), body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func deleteQueue(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	queueID := r.Str("queue_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := c.del(ctx, "/accounts/%s/queues/%s", acct, queueID)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func sendQueueMessages(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	queueID := r.Str("queue_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	msgs, ok := args["messages"]
+	if !ok || msgs == nil {
+		return mcp.ErrResult(fmt.Errorf("messages (array of {body: ...} objects) is required"))
+	}
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	body := map[string]any{"messages": msgs}
+	data, err := c.post(ctx, fmt.Sprintf("/accounts/%s/queues/%s/messages", acct, queueID), body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+// --- Hyperdrive ---
+
+func listHyperdriveConfigs(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := c.get(ctx, "/accounts/%s/hyperdrive/configs", acct)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func getHyperdriveConfig(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	hyperdriveID := r.Str("hyperdrive_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := c.get(ctx, "/accounts/%s/hyperdrive/configs/%s", acct, hyperdriveID)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func createHyperdriveConfig(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	name := r.Str("name")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	origin, _ := mcp.ArgMap(args, "origin")
+	if origin == nil {
+		return mcp.ErrResult(fmt.Errorf("origin (connection details map) is required"))
+	}
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	body := map[string]any{"name": name, "origin": origin}
+	if caching, _ := mcp.ArgMap(args, "caching"); caching != nil {
+		body["caching"] = caching
+	}
+	if mtls, _ := mcp.ArgMap(args, "mtls"); mtls != nil {
+		body["mtls"] = mtls
+	}
+	data, err := c.post(ctx, fmt.Sprintf("/accounts/%s/hyperdrive/configs", acct), body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func deleteHyperdriveConfig(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	hyperdriveID := r.Str("hyperdrive_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := c.del(ctx, "/accounts/%s/hyperdrive/configs/%s", acct, hyperdriveID)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}

--- a/integrations/cloudflare/tools.go
+++ b/integrations/cloudflare/tools.go
@@ -450,4 +450,427 @@ var tools = []mcp.ToolDefinition{
 		},
 		Required: []string{"gateway_id", "log_id"},
 	},
+
+	// ── Workers AI ───────────────────────────────────────────────────
+	{
+		Name:        mcp.ToolName("cloudflare_list_ai_models"),
+		Description: "List Workers AI models available to run on Cloudflare's edge. Workers AI hosts open-source LLMs, embeddings, image, and speech models. Start here to discover model ids (e.g. @cf/meta/llama-3.1-8b-instruct) before calling run_ai_model.",
+		Parameters: map[string]string{
+			"account_id": "Account identifier (defaults to configured account_id)",
+			"search":     "Free-text search filter (e.g. llama, embedding)",
+			"task":       "Filter by task type (e.g. Text Generation, Text Embeddings, Speech Recognition)",
+			"source":     "Filter by source (1 for first-party, 2 for Hugging Face)",
+			"page":       "Page number (default 1)",
+			"per_page":   "Results per page (default 20)",
+		},
+	},
+	{
+		Name:        mcp.ToolName("cloudflare_run_ai_model"),
+		Description: "Run inference on a Workers AI model — text generation, embeddings, classification, translation, speech-to-text, image generation. Pass either `prompt` (string) for simple text-in, or `body` (object) for the model's full request schema (messages, input, image, audio, etc.). Use after list_ai_models.",
+		Parameters: map[string]string{
+			"account_id": "Account identifier (defaults to configured account_id)",
+			"model_name": "Full model identifier (e.g. @cf/meta/llama-3.1-8b-instruct)",
+			"prompt":     "Convenience: text prompt (wrapped as {\"prompt\":...}). Ignored if `body` is set.",
+			"body":       "Full inference request body as a JSON object (model-specific schema)",
+		},
+		Required: []string{"model_name"},
+	},
+
+	// ── Vectorize ────────────────────────────────────────────────────
+	{
+		Name:        mcp.ToolName("cloudflare_list_vectorize_indexes"),
+		Description: "List Vectorize v2 indexes. Vectorize is Cloudflare's globally distributed vector database for semantic search, RAG, and embeddings. Start here to discover index names before querying.",
+		Parameters:  map[string]string{"account_id": "Account identifier (defaults to configured account_id)"},
+	},
+	{
+		Name:        mcp.ToolName("cloudflare_get_vectorize_index"),
+		Description: "Get a Vectorize index's configuration: dimensions, distance metric, vector count. Use after list_vectorize_indexes.",
+		Parameters:  map[string]string{"account_id": "Account identifier (defaults to configured account_id)", "index_name": "Vectorize index name"},
+		Required:    []string{"index_name"},
+	},
+	{
+		Name:        mcp.ToolName("cloudflare_create_vectorize_index"),
+		Description: "Create a new Vectorize v2 index for storing embeddings. Pick a metric (cosine, euclidean, dot-product) and dimension count (e.g. 768, 1536) that match your embedding model.",
+		Parameters: map[string]string{
+			"account_id":  "Account identifier (defaults to configured account_id)",
+			"name":        "Index name",
+			"metric":      "Distance metric: cosine, euclidean, or dot-product",
+			"dimensions":  "Vector dimension count (e.g. 768, 1024, 1536)",
+			"description": "Optional human description",
+		},
+		Required: []string{"name", "metric", "dimensions"},
+	},
+	{
+		Name:        mcp.ToolName("cloudflare_delete_vectorize_index"),
+		Description: "Delete a Vectorize index and all its vectors. Irreversible.",
+		Parameters:  map[string]string{"account_id": "Account identifier (defaults to configured account_id)", "index_name": "Vectorize index name"},
+		Required:    []string{"index_name"},
+	},
+	{
+		Name:        mcp.ToolName("cloudflare_query_vectorize_index"),
+		Description: "Query a Vectorize index by vector — returns the topK nearest neighbors. Use for semantic search, RAG retrieval, recommendation lookup.",
+		Parameters: map[string]string{
+			"account_id":     "Account identifier (defaults to configured account_id)",
+			"index_name":     "Vectorize index name",
+			"vector":         "Query vector as JSON array of floats",
+			"topK":           "Number of nearest neighbors to return (default 5)",
+			"returnValues":   "Whether to return the matched vectors (true/false)",
+			"returnMetadata": "Whether to return metadata: 'none', 'indexed', or 'all'",
+			"namespace":      "Optional namespace to scope the query",
+			"filter":         "Optional metadata filter (JSON object)",
+		},
+		Required: []string{"index_name", "vector"},
+	},
+
+	// ── Queues ───────────────────────────────────────────────────────
+	{
+		Name:        mcp.ToolName("cloudflare_list_queues"),
+		Description: "List Cloudflare Queues. Queues are durable message queues for Workers — producer/consumer messaging, batch processing, async work. Start here to discover queue IDs.",
+		Parameters: map[string]string{
+			"account_id": "Account identifier (defaults to configured account_id)",
+			"page":       "Page number (default 1)",
+			"per_page":   "Results per page (default 20)",
+		},
+	},
+	{
+		Name:        mcp.ToolName("cloudflare_get_queue"),
+		Description: "Get a Queue's details: producers, consumers, message counts, settings. Use after list_queues.",
+		Parameters:  map[string]string{"account_id": "Account identifier (defaults to configured account_id)", "queue_id": "Queue identifier"},
+		Required:    []string{"queue_id"},
+	},
+	{
+		Name:        mcp.ToolName("cloudflare_create_queue"),
+		Description: "Create a new Cloudflare Queue.",
+		Parameters: map[string]string{
+			"account_id": "Account identifier (defaults to configured account_id)",
+			"queue_name": "Queue name",
+			"settings":   "Optional settings map (delivery_delay, message_retention_period, etc.)",
+		},
+		Required: []string{"queue_name"},
+	},
+	{
+		Name:        mcp.ToolName("cloudflare_delete_queue"),
+		Description: "Delete a Cloudflare Queue and all pending messages. Irreversible.",
+		Parameters:  map[string]string{"account_id": "Account identifier (defaults to configured account_id)", "queue_id": "Queue identifier"},
+		Required:    []string{"queue_id"},
+	},
+	{
+		Name:        mcp.ToolName("cloudflare_send_queue_messages"),
+		Description: "Publish messages to a Cloudflare Queue. Messages is a JSON array of objects with at least a `body` field.",
+		Parameters: map[string]string{
+			"account_id": "Account identifier (defaults to configured account_id)",
+			"queue_id":   "Queue identifier",
+			"messages":   "JSON array of message objects (each with `body` and optional `content_type`, `delay_seconds`)",
+		},
+		Required: []string{"queue_id", "messages"},
+	},
+
+	// ── Hyperdrive ───────────────────────────────────────────────────
+	{
+		Name:        mcp.ToolName("cloudflare_list_hyperdrive_configs"),
+		Description: "List Hyperdrive configs. Hyperdrive accelerates database connections from Workers by pooling and caching at the edge. Start here to discover config IDs.",
+		Parameters:  map[string]string{"account_id": "Account identifier (defaults to configured account_id)"},
+	},
+	{
+		Name:        mcp.ToolName("cloudflare_get_hyperdrive_config"),
+		Description: "Get a Hyperdrive config's details: origin connection, caching, mTLS. Use after list_hyperdrive_configs.",
+		Parameters:  map[string]string{"account_id": "Account identifier (defaults to configured account_id)", "hyperdrive_id": "Hyperdrive config identifier"},
+		Required:    []string{"hyperdrive_id"},
+	},
+	{
+		Name:        mcp.ToolName("cloudflare_create_hyperdrive_config"),
+		Description: "Create a Hyperdrive config that proxies and caches a database connection (Postgres, MySQL) for Workers.",
+		Parameters: map[string]string{
+			"account_id": "Account identifier (defaults to configured account_id)",
+			"name":       "Config name",
+			"origin":     "Origin connection JSON: {scheme, host, port, database, user, password}",
+			"caching":    "Optional caching JSON: {disabled, max_age, stale_while_revalidate}",
+			"mtls":       "Optional mTLS JSON",
+		},
+		Required: []string{"name", "origin"},
+	},
+	{
+		Name:        mcp.ToolName("cloudflare_delete_hyperdrive_config"),
+		Description: "Delete a Hyperdrive config. Workers using this config will fail until rebound.",
+		Parameters:  map[string]string{"account_id": "Account identifier (defaults to configured account_id)", "hyperdrive_id": "Hyperdrive config identifier"},
+		Required:    []string{"hyperdrive_id"},
+	},
+
+	// ── Workers extras ───────────────────────────────────────────────
+	{
+		Name:        mcp.ToolName("cloudflare_list_worker_secrets"),
+		Description: "List secret names bound to a Worker script. Values are never returned by the API. Use to audit which secrets a Worker has access to.",
+		Parameters:  map[string]string{"account_id": "Account identifier (defaults to configured account_id)", "script_name": "Worker script name"},
+		Required:    []string{"script_name"},
+	},
+	{
+		Name:        mcp.ToolName("cloudflare_list_worker_deployments"),
+		Description: "List recent deployments for a Worker script with versions, authors, timestamps. Use to inspect deploy history or find a version to roll back to.",
+		Parameters:  map[string]string{"account_id": "Account identifier (defaults to configured account_id)", "script_name": "Worker script name"},
+		Required:    []string{"script_name"},
+	},
+	{
+		Name:        mcp.ToolName("cloudflare_get_worker_subdomain"),
+		Description: "Get the workers.dev subdomain enabled for this account (used as the default Worker URL).",
+		Parameters:  map[string]string{"account_id": "Account identifier (defaults to configured account_id)"},
+	},
+	{
+		Name:        mcp.ToolName("cloudflare_list_worker_tails"),
+		Description: "List active Worker tails (live log streams) for a script. Use to find existing tails before opening a new live-log session.",
+		Parameters:  map[string]string{"account_id": "Account identifier (defaults to configured account_id)", "script_name": "Worker script name"},
+		Required:    []string{"script_name"},
+	},
+
+	// ── Pages create/list domains ───────────────────────────────────
+	{
+		Name:        mcp.ToolName("cloudflare_create_pages_project"),
+		Description: "Create a Cloudflare Pages project (static site / Jamstack app).",
+		Parameters: map[string]string{
+			"account_id":         "Account identifier (defaults to configured account_id)",
+			"name":               "Project name",
+			"production_branch":  "Production branch (e.g. main)",
+			"build_config":       "Optional build config JSON: {build_command, destination_dir, root_dir, web_analytics_tag}",
+			"source":             "Optional source JSON: {type, config: {owner, repo_name, production_branch, ...}}",
+			"deployment_configs": "Optional deployment_configs JSON: {production, preview}",
+		},
+		Required: []string{"name", "production_branch"},
+	},
+	{
+		Name:        mcp.ToolName("cloudflare_create_pages_deployment"),
+		Description: "Trigger a new Pages deployment, optionally targeting a specific branch.",
+		Parameters: map[string]string{
+			"account_id":   "Account identifier (defaults to configured account_id)",
+			"project_name": "Pages project name",
+			"branch":       "Optional branch to deploy (defaults to production)",
+		},
+		Required: []string{"project_name"},
+	},
+	{
+		Name:        mcp.ToolName("cloudflare_list_pages_domains"),
+		Description: "List custom domains attached to a Pages project (DNS + cert state).",
+		Parameters:  map[string]string{"account_id": "Account identifier (defaults to configured account_id)", "project_name": "Pages project name"},
+		Required:    []string{"project_name"},
+	},
+
+	// ── KV bulk ──────────────────────────────────────────────────────
+	{
+		Name:        mcp.ToolName("cloudflare_bulk_delete_kv_values"),
+		Description: "Delete multiple keys from a Workers KV namespace in one call (up to 10000 keys).",
+		Parameters: map[string]string{
+			"account_id":   "Account identifier (defaults to configured account_id)",
+			"namespace_id": "KV namespace identifier",
+			"keys":         "JSON array of key names to delete",
+		},
+		Required: []string{"namespace_id", "keys"},
+	},
+
+	// ── Stream ───────────────────────────────────────────────────────
+	{
+		Name:        mcp.ToolName("cloudflare_list_stream_videos"),
+		Description: "List videos hosted on Cloudflare Stream. Start here to discover video IDs for playback URLs, analytics, or deletion.",
+		Parameters: map[string]string{
+			"account_id": "Account identifier (defaults to configured account_id)",
+			"after":      "Show videos uploaded after this ISO 8601 timestamp",
+			"before":     "Show videos uploaded before this ISO 8601 timestamp",
+			"creator":    "Filter by creator id",
+			"status":     "Filter by status (queued, inprogress, ready, error)",
+			"search":     "Free-text search across video names",
+		},
+	},
+	{
+		Name:        mcp.ToolName("cloudflare_get_stream_video"),
+		Description: "Get a Stream video's metadata: playback URLs (HLS/DASH), thumbnail, duration, status. Use after list_stream_videos.",
+		Parameters:  map[string]string{"account_id": "Account identifier (defaults to configured account_id)", "identifier": "Stream video identifier"},
+		Required:    []string{"identifier"},
+	},
+	{
+		Name:        mcp.ToolName("cloudflare_delete_stream_video"),
+		Description: "Delete a Stream video. Irreversible.",
+		Parameters:  map[string]string{"account_id": "Account identifier (defaults to configured account_id)", "identifier": "Stream video identifier"},
+		Required:    []string{"identifier"},
+	},
+
+	// ── Images ───────────────────────────────────────────────────────
+	{
+		Name:        mcp.ToolName("cloudflare_list_images"),
+		Description: "List images hosted on Cloudflare Images. Start here to discover image IDs for delivery URLs or deletion.",
+		Parameters: map[string]string{
+			"account_id": "Account identifier (defaults to configured account_id)",
+			"page":       "Page number (default 1)",
+			"per_page":   "Results per page (default 50)",
+		},
+	},
+	{
+		Name:        mcp.ToolName("cloudflare_get_image"),
+		Description: "Get a Cloudflare Images record: variants, metadata, upload timestamp.",
+		Parameters:  map[string]string{"account_id": "Account identifier (defaults to configured account_id)", "image_id": "Image identifier"},
+		Required:    []string{"image_id"},
+	},
+	{
+		Name:        mcp.ToolName("cloudflare_delete_image"),
+		Description: "Delete an image from Cloudflare Images. Irreversible.",
+		Parameters:  map[string]string{"account_id": "Account identifier (defaults to configured account_id)", "image_id": "Image identifier"},
+		Required:    []string{"image_id"},
+	},
+
+	// ── Zero Trust Access ────────────────────────────────────────────
+	{
+		Name:        mcp.ToolName("cloudflare_list_access_apps"),
+		Description: "List Cloudflare Zero Trust Access applications (apps protected by Cloudflare Access). Start here to discover app IDs before listing policies or auditing access.",
+		Parameters: map[string]string{
+			"account_id": "Account identifier (defaults to configured account_id)",
+			"page":       "Page number (default 1)",
+			"per_page":   "Results per page (default 25)",
+		},
+	},
+	{
+		Name:        mcp.ToolName("cloudflare_list_access_app_policies"),
+		Description: "List Access policies bound to a specific application. Shows who can access the app (groups, emails, IPs, IdPs, mTLS). Use after list_access_apps.",
+		Parameters:  map[string]string{"account_id": "Account identifier (defaults to configured account_id)", "app_id": "Access application identifier"},
+		Required:    []string{"app_id"},
+	},
+	{
+		Name:        mcp.ToolName("cloudflare_list_access_identity_providers"),
+		Description: "List configured Access identity providers (Google, Okta, Azure AD, SAML, OIDC, GitHub, etc.).",
+		Parameters:  map[string]string{"account_id": "Account identifier (defaults to configured account_id)"},
+	},
+
+	// ── Cloudflared Tunnels ─────────────────────────────────────────
+	{
+		Name:        mcp.ToolName("cloudflare_list_tunnels"),
+		Description: "List Cloudflared tunnels for an account. Tunnels expose private origins to Cloudflare without inbound ports. Start here to discover tunnel IDs and health.",
+		Parameters: map[string]string{
+			"account_id":      "Account identifier (defaults to configured account_id)",
+			"name":            "Filter by tunnel name",
+			"status":          "Filter by status: healthy, degraded, down, inactive",
+			"include_deleted": "Include deleted tunnels (true/false)",
+			"page":            "Page number (default 1)",
+			"per_page":        "Results per page (default 20)",
+		},
+	},
+	{
+		Name:        mcp.ToolName("cloudflare_get_tunnel"),
+		Description: "Get a Cloudflared tunnel's details: name, status, connections, created/deleted timestamps. Use after list_tunnels.",
+		Parameters:  map[string]string{"account_id": "Account identifier (defaults to configured account_id)", "tunnel_id": "Tunnel identifier"},
+		Required:    []string{"tunnel_id"},
+	},
+	{
+		Name:        mcp.ToolName("cloudflare_delete_tunnel"),
+		Description: "Delete a Cloudflared tunnel. Origins behind it become unreachable.",
+		Parameters:  map[string]string{"account_id": "Account identifier (defaults to configured account_id)", "tunnel_id": "Tunnel identifier"},
+		Required:    []string{"tunnel_id"},
+	},
+
+	// ── Email Routing ────────────────────────────────────────────────
+	{
+		Name:        mcp.ToolName("cloudflare_list_email_routing_rules"),
+		Description: "List Email Routing rules for a zone (which incoming addresses forward where). Start here for email routing config audits.",
+		Parameters:  map[string]string{"zone_id": "Zone identifier"},
+		Required:    []string{"zone_id"},
+	},
+	{
+		Name:        mcp.ToolName("cloudflare_list_email_routing_addresses"),
+		Description: "List verified destination email addresses for Email Routing (account-scoped).",
+		Parameters: map[string]string{
+			"account_id": "Account identifier (defaults to configured account_id)",
+			"verified":   "Filter by verified status (true/false)",
+			"page":       "Page number (default 1)",
+			"per_page":   "Results per page (default 20)",
+		},
+	},
+	{
+		Name:        mcp.ToolName("cloudflare_get_email_routing_settings"),
+		Description: "Get Email Routing settings for a zone (enabled state, MX/SPF records, skip_wizard).",
+		Parameters:  map[string]string{"zone_id": "Zone identifier"},
+		Required:    []string{"zone_id"},
+	},
+
+	// ── Logpush ──────────────────────────────────────────────────────
+	{
+		Name:        mcp.ToolName("cloudflare_list_logpush_jobs"),
+		Description: "List Logpush jobs for an account (HTTP requests, firewall events, Workers traces, etc. exported to S3/GCS/Azure/Sumo/Datadog/Splunk/New Relic/R2). Start here to inspect log-export pipelines.",
+		Parameters:  map[string]string{"account_id": "Account identifier (defaults to configured account_id)"},
+	},
+	{
+		Name:        mcp.ToolName("cloudflare_get_logpush_job"),
+		Description: "Get a Logpush job's config: dataset, destination, frequency, filters, last error. Use after list_logpush_jobs.",
+		Parameters:  map[string]string{"account_id": "Account identifier (defaults to configured account_id)", "job_id": "Logpush job ID (integer)"},
+		Required:    []string{"job_id"},
+	},
+	{
+		Name:        mcp.ToolName("cloudflare_create_logpush_job"),
+		Description: "Create a Logpush job to export Cloudflare logs to an external sink (S3, GCS, Azure, R2, Splunk, Datadog, New Relic, Sumo Logic, HTTP).",
+		Parameters: map[string]string{
+			"account_id":       "Account identifier (defaults to configured account_id)",
+			"dataset":          "Log dataset (e.g. http_requests, firewall_events, workers_trace_events)",
+			"destination_conf": "Destination connection string (e.g. s3://bucket/path?region=...)",
+			"name":             "Optional job name",
+			"frequency":        "Optional frequency: high or low",
+			"logpull_options":  "Optional logpull options string (fields, timestamps, etc.)",
+			"output_options":   "Optional output options map (field_names, timestamp_format, batch sizing)",
+			"filter":           "Optional log filter expression",
+			"enabled":          "Whether the job is enabled (true/false)",
+		},
+		Required: []string{"dataset", "destination_conf"},
+	},
+
+	// ── Page Rules ───────────────────────────────────────────────────
+	{
+		Name:        mcp.ToolName("cloudflare_list_page_rules"),
+		Description: "List Page Rules for a zone (URL-pattern rules for cache, redirects, headers, security). Start here for legacy page-rule audits before migrating to Rulesets.",
+		Parameters: map[string]string{
+			"zone_id":   "Zone identifier",
+			"status":    "Filter by status (active, disabled)",
+			"order":     "Sort field (priority, status)",
+			"direction": "Sort direction (asc, desc)",
+		},
+		Required: []string{"zone_id"},
+	},
+	{
+		Name:        mcp.ToolName("cloudflare_get_page_rule"),
+		Description: "Get a Page Rule's targets and actions. Use after list_page_rules.",
+		Parameters:  map[string]string{"zone_id": "Zone identifier", "pagerule_id": "Page Rule identifier"},
+		Required:    []string{"zone_id", "pagerule_id"},
+	},
+	{
+		Name:        mcp.ToolName("cloudflare_delete_page_rule"),
+		Description: "Delete a Page Rule.",
+		Parameters:  map[string]string{"zone_id": "Zone identifier", "pagerule_id": "Page Rule identifier"},
+		Required:    []string{"zone_id", "pagerule_id"},
+	},
+
+	// ── Notifications (Alerting v3) ─────────────────────────────────
+	{
+		Name:        mcp.ToolName("cloudflare_list_notification_policies"),
+		Description: "List notification (alerting) policies — what conditions trigger emails, PagerDuty, webhooks for an account.",
+		Parameters:  map[string]string{"account_id": "Account identifier (defaults to configured account_id)"},
+	},
+	{
+		Name:        mcp.ToolName("cloudflare_list_notification_webhooks"),
+		Description: "List configured webhook destinations for Cloudflare notifications.",
+		Parameters:  map[string]string{"account_id": "Account identifier (defaults to configured account_id)"},
+	},
+
+	// ── Account API Tokens ──────────────────────────────────────────
+	{
+		Name:        mcp.ToolName("cloudflare_list_api_tokens"),
+		Description: "List Cloudflare API tokens issued under an account. Start here to audit which tokens exist, their scopes, and their last-used timestamp.",
+		Parameters: map[string]string{
+			"account_id": "Account identifier (defaults to configured account_id)",
+			"page":       "Page number (default 1)",
+			"per_page":   "Results per page (default 20)",
+		},
+	},
+	{
+		Name:        mcp.ToolName("cloudflare_get_api_token"),
+		Description: "Get a Cloudflare API token's policy details: permissions, IP/time restrictions, expiry, last_used_on. Use after list_api_tokens.",
+		Parameters:  map[string]string{"account_id": "Account identifier (defaults to configured account_id)", "token_id": "API token identifier"},
+		Required:    []string{"token_id"},
+	},
+	{
+		Name:        mcp.ToolName("cloudflare_delete_api_token"),
+		Description: "Revoke (delete) a Cloudflare API token. Any client using it will start receiving 401s.",
+		Parameters:  map[string]string{"account_id": "Account identifier (defaults to configured account_id)", "token_id": "API token identifier"},
+		Required:    []string{"token_id"},
+	},
 }

--- a/integrations/cloudflare/tools.go
+++ b/integrations/cloudflare/tools.go
@@ -851,26 +851,25 @@ var tools = []mcp.ToolDefinition{
 		Parameters:  map[string]string{"account_id": "Account identifier (defaults to configured account_id)"},
 	},
 
-	// ── Account API Tokens ──────────────────────────────────────────
+	// ── User API Tokens ─────────────────────────────────────────────
 	{
 		Name:        mcp.ToolName("cloudflare_list_api_tokens"),
-		Description: "List Cloudflare API tokens issued under an account. Start here to audit which tokens exist, their scopes, and their last-used timestamp.",
+		Description: "List Cloudflare API tokens issued under the authenticated user. Start here to audit which tokens exist, their scopes, and their last-used timestamp.",
 		Parameters: map[string]string{
-			"account_id": "Account identifier (defaults to configured account_id)",
-			"page":       "Page number (default 1)",
-			"per_page":   "Results per page (default 20)",
+			"page":     "Page number (default 1)",
+			"per_page": "Results per page (default 20)",
 		},
 	},
 	{
 		Name:        mcp.ToolName("cloudflare_get_api_token"),
 		Description: "Get a Cloudflare API token's policy details: permissions, IP/time restrictions, expiry, last_used_on. Use after list_api_tokens.",
-		Parameters:  map[string]string{"account_id": "Account identifier (defaults to configured account_id)", "token_id": "API token identifier"},
+		Parameters:  map[string]string{"token_id": "API token identifier"},
 		Required:    []string{"token_id"},
 	},
 	{
 		Name:        mcp.ToolName("cloudflare_delete_api_token"),
 		Description: "Revoke (delete) a Cloudflare API token. Any client using it will start receiving 401s.",
-		Parameters:  map[string]string{"account_id": "Account identifier (defaults to configured account_id)", "token_id": "API token identifier"},
+		Parameters:  map[string]string{"token_id": "API token identifier"},
 		Required:    []string{"token_id"},
 	},
 }

--- a/integrations/cloudflare/zero_trust.go
+++ b/integrations/cloudflare/zero_trust.go
@@ -1,0 +1,113 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+// --- Zero Trust Access ---
+
+func listAccessApps(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	q := queryEncode(map[string]string{
+		"page":     fmt.Sprintf("%d", mcp.OptInt(args, "page", 1)),
+		"per_page": fmt.Sprintf("%d", mcp.OptInt(args, "per_page", 25)),
+	})
+	data, err := c.get(ctx, "/accounts/%s/access/apps%s", acct, q)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func listAccessAppPolicies(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	appID := r.Str("app_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := c.get(ctx, "/accounts/%s/access/apps/%s/policies", acct, appID)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func listAccessIdentityProviders(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := c.get(ctx, "/accounts/%s/access/identity_providers", acct)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+// --- Cloudflared (Zero Trust) Tunnels ---
+
+func listTunnels(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	name, _ := mcp.ArgStr(args, "name")
+	status, _ := mcp.ArgStr(args, "status")
+	includeDeleted, _ := mcp.ArgStr(args, "include_deleted")
+	q := queryEncode(map[string]string{
+		"name":            name,
+		"status":          status,
+		"include_deleted": includeDeleted,
+		"page":            fmt.Sprintf("%d", mcp.OptInt(args, "page", 1)),
+		"per_page":        fmt.Sprintf("%d", mcp.OptInt(args, "per_page", 20)),
+	})
+	data, err := c.get(ctx, "/accounts/%s/cfd_tunnel%s", acct, q)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func getTunnel(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	tunnelID := r.Str("tunnel_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := c.get(ctx, "/accounts/%s/cfd_tunnel/%s", acct, tunnelID)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func deleteTunnel(ctx context.Context, c *cloudflare, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	tunnelID := r.Str("tunnel_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	acct, err := c.acctID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := c.del(ctx, "/accounts/%s/cfd_tunnel/%s", acct, tunnelID)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}


### PR DESCRIPTION
## Summary

Stacks on top of #183 (AI Gateway). Adds **50 new tools** across 13 Cloudflare API surfaces so agents can drive the rest of the platform without falling back to raw HTTP.

### New surfaces

| Surface | Tools |
|---|---|
| Workers AI | `list_ai_models`, `run_ai_model` |
| Vectorize v2 | `list/get/create/delete_vectorize_index`, `query_vectorize_index` |
| Queues | `list/get/create/delete_queue`, `send_queue_messages` |
| Hyperdrive | `list/get/create/delete_hyperdrive_config` |
| Workers extras | `list_worker_secrets`, `list_worker_deployments`, `get_worker_subdomain`, `list_worker_tails` |
| Pages extras | `create_pages_project`, `create_pages_deployment`, `list_pages_domains` |
| KV bulk | `bulk_delete_kv_values` |
| Stream | `list/get/delete_stream_video` |
| Images | `list/get/delete_image` |
| Zero Trust Access | `list_access_apps`, `list_access_app_policies`, `list_access_identity_providers` |
| Cloudflare Tunnel | `list/get/delete_tunnel` |
| Email Routing | `list_email_routing_rules`, `list_email_routing_addresses`, `get_email_routing_settings` |
| Logpush | `list/get/create_logpush_job` |
| Page Rules | `list/get/delete_page_rule` |
| Notifications | `list_notification_policies`, `list_notification_webhooks` |
| API Tokens | `list/get/delete_api_token` |

### Conventions followed

- Every list tool ships a `compact.yaml` field whitelist so multi-tool agent loops do not blow the response cap.
- Tool descriptions follow the three-tier discoverability pattern from `add-integration` SKILL.md (entry points say \"Start here\", drill-down tools say \"Use after X\", mutations include workflow hints).
- All handlers use the shared `mcp.NewArgs` / `mcp.ArgStr` / `mcp.OptInt` helpers (no local arg-coercion).
- Endpoint paths verified against Cloudflare API docs + `cf-terraforming` (e.g. `/access/apps` not `/applications`, `/cfd_tunnel` not `/tunnels`).

### Deferred (call out)

**R2 object-level operations** (put/get/delete object, multipart upload) are intentionally not included. They require S3-style SigV4 signing against a different host (`{account_id}.r2.cloudflarestorage.com`) with separate access key credentials. That is a much bigger surface (new credential fields, a SigV4 signer, separate transport) and deserves its own PR.

## Test plan

- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./integrations/cloudflare/...` — 0 issues
- [x] `go test ./...` — all packages pass
- [x] Httptest-backed unit tests for at least one tool from every new surface, plus required-field error paths
- [x] Dispatch + compact-spec parity tests (`TestDispatchMap_*`, `TestFieldCompactionSpecs_*`) still pass


💘 Generated with Crush