### PR TITLE
feat(digitalocean): support droplet user data

### DIFF
--- a/integrations/digitalocean/digitalocean_test.go
+++ b/integrations/digitalocean/digitalocean_test.go
@@ -2,8 +2,10 @@ package digitalocean
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/digitalocean/godo"
@@ -112,6 +114,36 @@ func TestErrResult(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, result.IsError)
 	assert.Equal(t, "test error", result.Data)
+}
+
+func TestCreateDroplet_UserData(t *testing.T) {
+	var captured map[string]any
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Contains(t, r.URL.Path, "/droplets")
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&captured))
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"droplet":{"id":123,"name":"runner"}}`)
+	}))
+	defer ts.Close()
+
+	d := &integration{}
+	require.NoError(t, d.Configure(context.Background(), mcp.Credentials{
+		"api_token": "dop_v1_test123",
+		"base_url":  ts.URL,
+	}))
+
+	result, err := createDroplet(context.Background(), d, map[string]any{
+		"name":      "runner",
+		"region":    "sfo3",
+		"size":      "s-2vcpu-4gb",
+		"image":     "ubuntu-24-04-x64",
+		"user_data": "#cloud-config\npackage_update: true\n",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.False(t, result.IsError, "unexpected error: %s", result.Data)
+	assert.Equal(t, "#cloud-config\npackage_update: true\n", captured["user_data"])
 }
 
 func TestWrapRetryable_RateLimited(t *testing.T) {

--- a/integrations/digitalocean/droplets.go
+++ b/integrations/digitalocean/droplets.go
@@ -74,6 +74,11 @@ func createDroplet(ctx context.Context, d *integration, args map[string]any) (*m
 		req.VPCUUID = vpcUUID
 	}
 
+	userData, _ := mcp.ArgStr(args, "user_data")
+	if userData != "" {
+		req.UserData = userData
+	}
+
 	droplet, _, err := d.client.Droplets.Create(ctx, req)
 	if err != nil {
 		return errResult(err)

--- a/integrations/digitalocean/tools.go
+++ b/integrations/digitalocean/tools.go
@@ -20,8 +20,8 @@ var tools = []mcp.ToolDefinition{
 		Required:   []string{"droplet_id"},
 	},
 	{
-		Name: mcp.ToolName("digitalocean_create_droplet"), Description: "Create a new droplet",
-		Parameters: map[string]string{"name": "Droplet name", "region": "Region slug (e.g. nyc3)", "size": "Size slug (e.g. s-1vcpu-1gb)", "image": "Image slug or ID (e.g. ubuntu-24-04-x64)", "ssh_keys": "Comma-separated SSH key IDs or fingerprints", "tags": "Comma-separated tags", "vpc_uuid": "VPC UUID"},
+		Name: mcp.ToolName("digitalocean_create_droplet"), Description: "Create a new droplet. Use user_data for cloud-init bootstrapping scripts when the droplet must self-configure on first boot.",
+		Parameters: map[string]string{"name": "Droplet name", "region": "Region slug (e.g. nyc3)", "size": "Size slug (e.g. s-1vcpu-1gb)", "image": "Image slug or ID (e.g. ubuntu-24-04-x64)", "ssh_keys": "Comma-separated SSH key IDs or fingerprints", "tags": "Comma-separated tags", "vpc_uuid": "VPC UUID", "user_data": "Cloud-init user data script for first boot configuration"},
 		Required:   []string{"name", "region", "size", "image"},
 	},
 	{


### PR DESCRIPTION

## Summary

- Adds optional `user_data` support to DigitalOcean droplet creation so Switchboard can pass cloud-init bootstrap scripts.
- Documents the new parameter in the droplet creation tool metadata and covers the request payload with a regression test.

## Test plan

- [x] go test ./integrations/digitalocean
- [x] go test ./...
- [x] make ci

💘 Generated with Crush