### PR TITLE
ci: run Crush reviews with Grok

### DIFF
--- a/.ci/crush/crush.json
+++ b/.ci/crush/crush.json
@@ -37,6 +37,8 @@
           "name": "Grok Build 0.1",
           "context_window": 256000,
           "default_max_tokens": 16384,
+          "cost_per_1m_in": 1.0,
+          "cost_per_1m_out": 2.0,
           "can_reason": true,
           "supports_attachments": true
         }

--- a/.ci/crush/crush.json
+++ b/.ci/crush/crush.json
@@ -1,16 +1,45 @@
 {
   "$schema": "https://charm.land/crush.json",
+  "models": {
+    "large": {
+      "model": "grok-4.3",
+      "provider": "xAI",
+      "max_tokens": 16384
+    },
+    "small": {
+      "model": "grok-3-mini",
+      "provider": "xAI",
+      "max_tokens": 8192
+    }
+  },
   "providers": {
-    "bedrock": {
-      "type": "bedrock",
-      "name": "AWS Bedrock",
-      "extra_params": {
-        "region": "us-east-1"
+    "xAI": {
+      "type": "openai-compat",
+      "base_url": "https://gateway.ai.cloudflare.com/v1/a9d106d880527eaecdaf7835b792849d/curri-gateway/grok",
+      "api_key": "${CF_AIG_TOKEN:?set CF_AIG_TOKEN to your Cloudflare AI Gateway token}",
+      "extra_headers": {
+        "cf-aig-metadata": "{\"developer_id\": \"dalton.cherry\", \"task_type\": \"ci_pr_review\", \"tool\": \"crush\", \"tier\": \"frontier\"}",
+        "cf-aig-collect-log-payload": "false"
       },
       "models": [
         {
-          "id": "anthropic.claude-opus-4-6-v1",
-          "name": "Claude Opus 4.6"
+          "id": "grok-4.3",
+          "name": "Grok 4.3",
+          "cost_per_1m_in": 1.25,
+          "cost_per_1m_out": 2.5,
+          "context_window": 1000000,
+          "default_max_tokens": 16384,
+          "can_reason": true,
+          "supports_attachments": true
+        },
+        {
+          "id": "grok-3-mini",
+          "name": "Grok 3 Mini",
+          "cost_per_1m_in": 0.3,
+          "cost_per_1m_out": 0.5,
+          "context_window": 131000,
+          "default_max_tokens": 8192,
+          "can_reason": true
         }
       ]
     }

--- a/.ci/crush/crush.json
+++ b/.ci/crush/crush.json
@@ -7,18 +7,18 @@
       "max_tokens": 16384
     },
     "small": {
-      "model": "grok-3-mini",
+      "model": "grok-build-0.1",
       "provider": "xAI",
-      "max_tokens": 8192
+      "max_tokens": 16384
     }
   },
   "providers": {
     "xAI": {
       "type": "openai-compat",
-      "base_url": "https://gateway.ai.cloudflare.com/v1/a9d106d880527eaecdaf7835b792849d/curri-gateway/grok",
+      "base_url": "https://gateway.ai.cloudflare.com/v1/${CF_AIG_ACCOUNT_ID:?set CF_AIG_ACCOUNT_ID}/${CF_AIG_GATEWAY_ID:?set CF_AIG_GATEWAY_ID}/grok",
       "api_key": "${CF_AIG_TOKEN:?set CF_AIG_TOKEN to your Cloudflare AI Gateway token}",
       "extra_headers": {
-        "cf-aig-metadata": "{\"developer_id\": \"dalton.cherry\", \"task_type\": \"ci_pr_review\", \"tool\": \"crush\", \"tier\": \"frontier\"}",
+        "cf-aig-metadata": "{\"developer_id\": \"austin.cherry\", \"task_type\": \"ci_pr_review\", \"tool\": \"crush\", \"tier\": \"frontier\"}",
         "cf-aig-collect-log-payload": "false"
       },
       "models": [
@@ -33,13 +33,12 @@
           "supports_attachments": true
         },
         {
-          "id": "grok-3-mini",
-          "name": "Grok 3 Mini",
-          "cost_per_1m_in": 0.3,
-          "cost_per_1m_out": 0.5,
-          "context_window": 131000,
-          "default_max_tokens": 8192,
-          "can_reason": true
+          "id": "grok-build-0.1",
+          "name": "Grok Build 0.1",
+          "context_window": 256000,
+          "default_max_tokens": 16384,
+          "can_reason": true,
+          "supports_attachments": true
         }
       ]
     }

--- a/.github/workflows/crush-pr-review.yml
+++ b/.github/workflows/crush-pr-review.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   crush-review:
     name: Crush PR Review
-    runs-on: [self-hosted, linux, x64, crush-review]
+    runs-on: ubuntu-latest
     # Only run when: CI passed, it was a PR event, and the PR is not from a fork
     if: >
       github.event.workflow_run.conclusion == 'success' &&

--- a/.github/workflows/crush-pr-review.yml
+++ b/.github/workflows/crush-pr-review.yml
@@ -49,6 +49,8 @@ jobs:
       - name: Run Crush PR Review
         env:
           CF_AIG_TOKEN: ${{ secrets.CF_AIG_TOKEN }}
+          CF_AIG_ACCOUNT_ID: ${{ secrets.CF_AIG_ACCOUNT_ID }}
+          CF_AIG_GATEWAY_ID: ${{ secrets.CF_AIG_GATEWAY_ID }}
           GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
           CRUSH_SKILLS_DIR: ${{ github.workspace }}/.claude/skills
           CRUSH_GLOBAL_CONFIG: ${{ github.workspace }}/.ci/crush

--- a/.github/workflows/crush-pr-review.yml
+++ b/.github/workflows/crush-pr-review.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   crush-review:
     name: Crush PR Review
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, crush-review]
     # Only run when: CI passed, it was a PR event, and the PR is not from a fork
     if: >
       github.event.workflow_run.conclusion == 'success' &&
@@ -48,8 +48,7 @@ jobs:
 
       - name: Run Crush PR Review
         env:
-          AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
-          AWS_REGION: us-east-1
+          CF_AIG_TOKEN: ${{ secrets.CF_AIG_TOKEN }}
           GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
           CRUSH_SKILLS_DIR: ${{ github.workspace }}/.claude/skills
           CRUSH_GLOBAL_CONFIG: ${{ github.workspace }}/.ci/crush


### PR DESCRIPTION

## Summary

- Switches the Crush PR review CI config from Bedrock to the Cloudflare AI Gateway-backed xAI/Grok provider.
- Targets a dedicated self-hosted runner label set for PR review jobs and uses the new `CF_AIG_TOKEN` repo secret.

## Test plan

- [x] python3 -m json.tool .ci/crush/crush.json
- [x] go test ./...
- [x] make ci
- [ ] Merge/restart Switchboard with DigitalOcean `user_data` support
- [ ] Provision the `crush-review` self-hosted runner before marking ready

💘 Generated with Crush