### PR TITLE
ci: keep Crush reviews visible and lightweight

### DIFF
--- a/.agents/skills/pr-comments/SKILL.md
+++ b/.agents/skills/pr-comments/SKILL.md
@@ -16,8 +16,10 @@ Post review findings as inline comments on specific diff lines via the GitHub Pu
 
 **Before doing anything else**, check the pr-review output:
 
-- If the review found **zero Must Fix and zero Should Fix items**, submit an `APPROVE` review with a short body like "Clean PR — builds, tests pass, lint clean. LGTM." and **no inline comments**. Then stop.
-- If only "Consider" items exist and they're truly optional, approve without inline comments.
+- Before submitting any review, fetch PR status checks with `gh pr view <number> --repo <owner>/<repo> --json statusCheckRollup` and include a short status summary in the review body or fallback comment.
+- If the review found **zero Must Fix and zero Should Fix items**, submit an `APPROVE` review with a short body like "Clean PR — CI/status checks are passing and I didn't find any blocking issues. LGTM." and **no inline comments**. Then stop.
+- If GitHub rejects the approval because the token belongs to the PR author, post a regular PR comment with the same short positive summary, include the CI/status check summary, and mention that approval was blocked by GitHub's own-PR restriction. Then stop.
+- If only "Consider" items exist and they're truly optional, approve without inline comments. If approval is blocked by GitHub's own-PR restriction, post a regular PR comment summarizing that the review found no blocking issues and include the CI/status check summary.
 - Only proceed to Step 1 if there are **concrete, actionable findings** worth commenting on.
 
 **Never post test/placeholder comments.** Every comment submitted to the PR must contain real, substantive feedback.

--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -48,46 +48,32 @@ git fetch origin <headRefName> && git checkout <headRefName>
 
 Note the PR size (files changed, additions, deletions) — large PRs deserve extra scrutiny.
 
-### Step 2: Build Verification
+### Step 2: CI Status Verification
 
-The project must compile cleanly:
+CI has already run before this review workflow starts. Do not rerun `go build`, `go mod tidy`, `go test`, `golangci-lint`, or the full CI matrix during automated review.
 
-```bash
-go build -o switchboard ./cmd/server
-```
-
-If the build fails, stop and report it as a **Must Fix** item. No further review is meaningful if the code doesn't compile.
-
-Also check that `go.mod` and `go.sum` are tidy:
-```bash
-go mod tidy
-git diff --exit-code go.mod go.sum
-```
-
-If `go mod tidy` produces changes, flag it.
-
-### Step 3: Test Suite
-
-Run the full test suite with the race detector:
+Use GitHub status and run metadata to verify CI instead:
 
 ```bash
-go test -race ./...
+gh pr view <number> --repo daltoniam/switchboard --json statusCheckRollup
 ```
 
-- If tests fail due to code issues, report each failure as a **Must Fix** item with the test name, file, and error output.
+Report the existing CI result in the review. If CI failed or is missing, report that as a **Must Fix** item. If CI passed, proceed directly to diff review.
+
+### Step 3: Test Coverage Review
+
+Review whether the diff includes appropriate tests for the changed behavior. Do not run the test suite unless needed to validate a specific finding that cannot be assessed from the diff and existing CI status.
+
 - If there are no tests for new functionality, flag it as a **Must Fix** item. Every change must have tests.
 - Check for `testify` assertions — the project uses `github.com/stretchr/testify`.
 - Verify dispatch map parity tests exist for any new/modified adapter.
+- If a targeted command is truly necessary, keep it narrow and set `GOMAXPROCS=1` and `GOFLAGS=-p=1`.
 
-### Step 4: Linting and Static Analysis
+### Step 4: Lint and Static Analysis Status
 
-Run the project's configured linters:
+Do not run `golangci-lint` or broad static analysis during automated review. Use the existing CI result as the lint/static-analysis signal.
 
-```bash
-golangci-lint run
-```
-
-Must return 0 issues. Report linter findings grouped by severity. Don't flag issues that exist in unchanged code unless they're in functions modified by the PR.
+Review changed code manually for correctness, security, performance, and maintainability. Don't flag issues that exist in unchanged code unless they're in functions modified by the PR.
 
 ### Step 5: Code Review — Architecture and Patterns
 

--- a/.ci/crush/crush.json
+++ b/.ci/crush/crush.json
@@ -18,7 +18,7 @@
       "base_url": "https://gateway.ai.cloudflare.com/v1/${CF_AIG_ACCOUNT_ID:?set CF_AIG_ACCOUNT_ID}/${CF_AIG_GATEWAY_ID:?set CF_AIG_GATEWAY_ID}/grok",
       "api_key": "${CF_AIG_TOKEN:?set CF_AIG_TOKEN to your Cloudflare AI Gateway token}",
       "extra_headers": {
-        "cf-aig-metadata": "{\"developer_id\": \"austin.cherry\", \"task_type\": \"ci_pr_review\", \"tool\": \"crush\", \"tier\": \"frontier\"}",
+        "cf-aig-metadata": "{\"developer_id\": \"austin.cherry\", \"tier\": \"frontier\"}",
         "cf-aig-collect-log-payload": "false"
       },
       "models": [

--- a/.github/workflows/crush-pr-review.yml
+++ b/.github/workflows/crush-pr-review.yml
@@ -54,8 +54,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
           CRUSH_SKILLS_DIR: ${{ github.workspace }}/.claude/skills
           CRUSH_GLOBAL_CONFIG: ${{ github.workspace }}/.ci/crush
+          GOMAXPROCS: "1"
+          GOFLAGS: "-p=1"
         run: >
           crush run -c "${{ github.workspace }}"
           "Review PR #${{ steps.pr.outputs.number }} in ${{ github.repository }}.
+          CI has already passed for this PR. Do not rerun build, test, lint, go mod tidy, golangci-lint, or the full CI matrix. Inspect existing CI/status checks and focus on code review of the diff.
           Use the pr-review skill to do a full code review, then use the pr-comments skill to post your findings as inline comments on the PR.
           The repo is already checked out locally. Use gh CLI for all GitHub API interactions."


### PR DESCRIPTION

## Summary

- Use existing CI status during Crush reviews instead of rerunning build/test/lint work.
- Leave a visible fallback comment with CI status when GitHub blocks own-PR approvals.

## Test plan

- `git diff --check`
- `actionlint .github/workflows/crush-pr-review.yml`

💘 Generated with Crush