### PR TITLE
Support multiple Kubernetes clusters

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -114,6 +114,7 @@ var envMapping = map[string]map[string]string{
 		"insecure_skip_tls_verify": "KUBERNETES_INSECURE_SKIP_TLS_VERIFY",
 		"in_cluster":               "KUBERNETES_IN_CLUSTER",
 		"clusters":                 "KUBERNETES_CLUSTERS",
+		"allow_mutations":          "KUBERNETES_ALLOW_MUTATIONS",
 	},
 	"vercel": {
 		"api_token": "VERCEL_API_TOKEN",
@@ -352,7 +353,7 @@ func defaultConfig() *mcp.Config {
 			},
 			"kubernetes": {
 				Enabled:     false,
-				Credentials: mcp.Credentials{"kubeconfig": "", "kubeconfig_path": "", "context": "", "namespace": "", "api_server": "", "token": "", "ca_cert": "", "insecure_skip_tls_verify": "", "in_cluster": "", "clusters": ""},
+				Credentials: mcp.Credentials{"kubeconfig": "", "kubeconfig_path": "", "context": "", "namespace": "", "api_server": "", "token": "", "ca_cert": "", "insecure_skip_tls_verify": "", "in_cluster": "", "clusters": "", "allow_mutations": ""},
 			},
 			"vercel": {
 				Enabled:     false,

--- a/config/config.go
+++ b/config/config.go
@@ -113,6 +113,7 @@ var envMapping = map[string]map[string]string{
 		"ca_cert":                  "KUBERNETES_CA_CERT",
 		"insecure_skip_tls_verify": "KUBERNETES_INSECURE_SKIP_TLS_VERIFY",
 		"in_cluster":               "KUBERNETES_IN_CLUSTER",
+		"clusters":                 "KUBERNETES_CLUSTERS",
 	},
 	"vercel": {
 		"api_token": "VERCEL_API_TOKEN",
@@ -351,7 +352,7 @@ func defaultConfig() *mcp.Config {
 			},
 			"kubernetes": {
 				Enabled:     false,
-				Credentials: mcp.Credentials{"kubeconfig": "", "kubeconfig_path": "", "context": "", "namespace": "", "api_server": "", "token": "", "ca_cert": "", "insecure_skip_tls_verify": "", "in_cluster": ""},
+				Credentials: mcp.Credentials{"kubeconfig": "", "kubeconfig_path": "", "context": "", "namespace": "", "api_server": "", "token": "", "ca_cert": "", "insecure_skip_tls_verify": "", "in_cluster": "", "clusters": ""},
 			},
 			"vercel": {
 				Enabled:     false,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -279,7 +279,7 @@ func TestDefaultConfig(t *testing.T) {
 		"cloudflare":    {"api_token", "account_id"},
 		"digitalocean":  {"api_token"},
 		"fly":           {"api_token", "base_url"},
-		"kubernetes":    {"kubeconfig", "kubeconfig_path", "context", "namespace", "api_server", "token", "ca_cert", "insecure_skip_tls_verify", "in_cluster", "clusters"},
+		"kubernetes":    {"kubeconfig", "kubeconfig_path", "context", "namespace", "api_server", "token", "ca_cert", "insecure_skip_tls_verify", "in_cluster", "clusters", "allow_mutations"},
 		"vercel":        {"api_token", "team_id", "team_slug", "base_url"},
 		"web":           {},
 		"signoz":        {"api_key", "base_url", "skip_verify"},
@@ -526,6 +526,7 @@ func TestEnvMapping_ReturnsMapping(t *testing.T) {
 	assert.Equal(t, "KUBERNETES_INSECURE_SKIP_TLS_VERIFY", m["kubernetes"]["insecure_skip_tls_verify"])
 	assert.Equal(t, "KUBERNETES_IN_CLUSTER", m["kubernetes"]["in_cluster"])
 	assert.Equal(t, "KUBERNETES_CLUSTERS", m["kubernetes"]["clusters"])
+	assert.Equal(t, "KUBERNETES_ALLOW_MUTATIONS", m["kubernetes"]["allow_mutations"])
 	assert.Equal(t, "VERCEL_API_TOKEN", m["vercel"]["api_token"])
 	assert.Equal(t, "VERCEL_TEAM_ID", m["vercel"]["team_id"])
 	assert.Equal(t, "VERCEL_TEAM_SLUG", m["vercel"]["team_slug"])

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -279,7 +279,7 @@ func TestDefaultConfig(t *testing.T) {
 		"cloudflare":    {"api_token", "account_id"},
 		"digitalocean":  {"api_token"},
 		"fly":           {"api_token", "base_url"},
-		"kubernetes":    {"kubeconfig", "kubeconfig_path", "context", "namespace", "api_server", "token", "ca_cert", "insecure_skip_tls_verify", "in_cluster"},
+		"kubernetes":    {"kubeconfig", "kubeconfig_path", "context", "namespace", "api_server", "token", "ca_cert", "insecure_skip_tls_verify", "in_cluster", "clusters"},
 		"vercel":        {"api_token", "team_id", "team_slug", "base_url"},
 		"web":           {},
 		"signoz":        {"api_key", "base_url", "skip_verify"},
@@ -525,6 +525,7 @@ func TestEnvMapping_ReturnsMapping(t *testing.T) {
 	assert.Equal(t, "KUBERNETES_CA_CERT", m["kubernetes"]["ca_cert"])
 	assert.Equal(t, "KUBERNETES_INSECURE_SKIP_TLS_VERIFY", m["kubernetes"]["insecure_skip_tls_verify"])
 	assert.Equal(t, "KUBERNETES_IN_CLUSTER", m["kubernetes"]["in_cluster"])
+	assert.Equal(t, "KUBERNETES_CLUSTERS", m["kubernetes"]["clusters"])
 	assert.Equal(t, "VERCEL_API_TOKEN", m["vercel"]["api_token"])
 	assert.Equal(t, "VERCEL_TEAM_ID", m["vercel"]["team_id"])
 	assert.Equal(t, "VERCEL_TEAM_SLUG", m["vercel"]["team_slug"])

--- a/integrations/kubernetes/compact.yaml
+++ b/integrations/kubernetes/compact.yaml
@@ -36,3 +36,13 @@ tools:
   kubernetes_list_nodes:
     spec: [name, ready, roles, kubelet_version, os_image, container_runtime, capacity, allocatable, taints, labels, creation_timestamp]
     max_bytes: 30000
+  kubernetes_scale_deployment:
+    spec: [action, resource, namespace, name, replicas, deployment]
+  kubernetes_restart_deployment:
+    spec: [action, resource, namespace, name, restarted_at, deployment]
+  kubernetes_cordon_node:
+    spec: [action, resource, name, node]
+  kubernetes_uncordon_node:
+    spec: [action, resource, name, node]
+  kubernetes_delete_pod:
+    spec: [action, resource, namespace, name]

--- a/integrations/kubernetes/compact.yaml
+++ b/integrations/kubernetes/compact.yaml
@@ -3,6 +3,8 @@ version: 1
 tools:
   kubernetes_list_contexts:
     spec: [name, current, cluster, auth_info, namespace]
+  kubernetes_list_clusters:
+    spec: [name, context, current, cluster, auth_info, namespace, source]
   kubernetes_list_namespaces:
     spec: [name, status, labels, creation_timestamp]
   kubernetes_list_pods:

--- a/integrations/kubernetes/handlers.go
+++ b/integrations/kubernetes/handlers.go
@@ -292,6 +292,113 @@ func listNodes(ctx context.Context, k *kubernetes, args map[string]any) (*mcp.To
 	return mcp.JSONResult(out)
 }
 
+func scaleDeployment(ctx context.Context, k *kubernetes, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	name := r.Str("deployment")
+	replicasValue := r.Int("replicas")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if _, ok := args["replicas"]; !ok {
+		return mcp.ErrResult(fmt.Errorf("kubernetes: replicas is required"))
+	}
+	if replicasValue < 0 {
+		return mcp.ErrResult(fmt.Errorf("kubernetes: replicas must be >= 0"))
+	}
+	replicas := int32(replicasValue)
+	ns, err := namespaceFromArgs(k, args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	deployment, err := k.client.AppsV1().Deployments(ns).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return mcp.ErrResult(fmt.Errorf("kubernetes: scale deployment: %w", err))
+	}
+	deployment.Spec.Replicas = &replicas
+	updated, err := k.client.AppsV1().Deployments(ns).Update(ctx, deployment, metav1.UpdateOptions{})
+	if err != nil {
+		return mcp.ErrResult(fmt.Errorf("kubernetes: scale deployment: %w", err))
+	}
+	return mcp.JSONResult(mutationSummary{Action: "scaled", Resource: "deployment", Namespace: ns, Name: name, Replicas: replicas, Deployment: summarizeDeployment(*updated)})
+}
+
+func restartDeployment(ctx context.Context, k *kubernetes, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	name := r.Str("deployment")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	ns, err := namespaceFromArgs(k, args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	deployment, err := k.client.AppsV1().Deployments(ns).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return mcp.ErrResult(fmt.Errorf("kubernetes: restart deployment: %w", err))
+	}
+	if deployment.Spec.Template.Annotations == nil {
+		deployment.Spec.Template.Annotations = map[string]string{}
+	}
+	restartedAt := time.Now().UTC().Format(time.RFC3339)
+	deployment.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"] = restartedAt
+	updated, err := k.client.AppsV1().Deployments(ns).Update(ctx, deployment, metav1.UpdateOptions{})
+	if err != nil {
+		return mcp.ErrResult(fmt.Errorf("kubernetes: restart deployment: %w", err))
+	}
+	return mcp.JSONResult(mutationSummary{Action: "restarted", Resource: "deployment", Namespace: ns, Name: name, RestartedAt: restartedAt, Deployment: summarizeDeployment(*updated)})
+}
+
+func cordonNode(ctx context.Context, k *kubernetes, args map[string]any) (*mcp.ToolResult, error) {
+	return setNodeSchedulable(ctx, k, args, true, "cordoned")
+}
+
+func uncordonNode(ctx context.Context, k *kubernetes, args map[string]any) (*mcp.ToolResult, error) {
+	return setNodeSchedulable(ctx, k, args, false, "uncordoned")
+}
+
+func setNodeSchedulable(ctx context.Context, k *kubernetes, args map[string]any, unschedulable bool, action string) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	name := r.Str("node")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	node, err := k.client.CoreV1().Nodes().Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return mcp.ErrResult(fmt.Errorf("kubernetes: %s node: %w", action, err))
+	}
+	node.Spec.Unschedulable = unschedulable
+	updated, err := k.client.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{})
+	if err != nil {
+		return mcp.ErrResult(fmt.Errorf("kubernetes: %s node: %w", action, err))
+	}
+	return mcp.JSONResult(mutationSummary{Action: action, Resource: "node", Name: name, Node: summarizeNode(*updated)})
+}
+
+func deletePod(ctx context.Context, k *kubernetes, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	podName := r.Str("pod")
+	gracePeriod := r.Int("grace_period_seconds")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	ns, err := namespaceFromArgs(k, args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	opts := metav1.DeleteOptions{}
+	if _, ok := args["grace_period_seconds"]; ok {
+		if gracePeriod < 0 {
+			return mcp.ErrResult(fmt.Errorf("kubernetes: grace_period_seconds must be >= 0"))
+		}
+		v := int64(gracePeriod)
+		opts.GracePeriodSeconds = &v
+	}
+	if err := k.client.CoreV1().Pods(ns).Delete(ctx, podName, opts); err != nil {
+		return mcp.ErrResult(fmt.Errorf("kubernetes: delete pod: %w", err))
+	}
+	return mcp.JSONResult(mutationSummary{Action: "deleted", Resource: "pod", Namespace: ns, Name: podName})
+}
+
 func listOpts(limit int64, labelSelector, fieldSelector string) metav1.ListOptions {
 	return metav1.ListOptions{Limit: limit, LabelSelector: labelSelector, FieldSelector: fieldSelector}
 }
@@ -666,6 +773,17 @@ type rolloutSummary struct {
 	Deployment deploymentSummary `json:"deployment"`
 	Status     string            `json:"status"`
 	Message    string            `json:"message"`
+}
+
+type mutationSummary struct {
+	Action      string            `json:"action"`
+	Resource    string            `json:"resource"`
+	Namespace   string            `json:"namespace,omitempty"`
+	Name        string            `json:"name"`
+	Replicas    int32             `json:"replicas,omitempty"`
+	RestartedAt string            `json:"restarted_at,omitempty"`
+	Deployment  deploymentSummary `json:"deployment,omitempty"`
+	Node        nodeSummary       `json:"node,omitempty"`
 }
 
 type serviceSummary struct {

--- a/integrations/kubernetes/handlers.go
+++ b/integrations/kubernetes/handlers.go
@@ -30,10 +30,32 @@ func listContexts(_ context.Context, k *kubernetes, _ map[string]any) (*mcp.Tool
 	for name, ctx := range cfg.Contexts {
 		out = append(out, contextSummary{
 			Name:      name,
-			Current:   name == cfg.CurrentContext,
+			Current:   name == k.context,
 			Cluster:   ctx.Cluster,
 			AuthInfo:  ctx.AuthInfo,
-			Namespace: ctx.Namespace,
+			Namespace: namespaceForContext(ctx, ""),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Current != out[j].Current {
+			return out[i].Current
+		}
+		return out[i].Name < out[j].Name
+	})
+	return mcp.JSONResult(out)
+}
+
+func listClusters(_ context.Context, k *kubernetes, _ map[string]any) (*mcp.ToolResult, error) {
+	out := make([]clusterSummary, 0, len(k.clients))
+	for name, client := range k.clients {
+		out = append(out, clusterSummary{
+			Name:      name,
+			Context:   client.context,
+			Current:   client.context == k.context,
+			Cluster:   client.cluster,
+			AuthInfo:  client.authInfo,
+			Namespace: client.namespace,
+			Source:    client.source,
 		})
 	}
 	sort.Slice(out, func(i, j int) bool {
@@ -544,6 +566,16 @@ type contextSummary struct {
 	Cluster   string `json:"cluster"`
 	AuthInfo  string `json:"auth_info"`
 	Namespace string `json:"namespace,omitempty"`
+}
+
+type clusterSummary struct {
+	Name      string `json:"name"`
+	Context   string `json:"context"`
+	Current   bool   `json:"current"`
+	Cluster   string `json:"cluster,omitempty"`
+	AuthInfo  string `json:"auth_info,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+	Source    string `json:"source,omitempty"`
 }
 
 type namespaceSummary struct {

--- a/integrations/kubernetes/kubernetes.go
+++ b/integrations/kubernetes/kubernetes.go
@@ -45,6 +45,7 @@ type kubernetes struct {
 	context         string
 	kubeconfigBytes []byte
 	clients         map[string]*clusterClient
+	allowMutations  bool
 }
 
 type clusterClient struct {
@@ -78,7 +79,7 @@ func New() mcp.Integration {
 func (k *kubernetes) Name() string { return "kubernetes" }
 
 func (k *kubernetes) PlainTextKeys() []string {
-	return []string{"kubeconfig", "kubeconfig_path", "context", "namespace", "api_server", "ca_cert", "insecure_skip_tls_verify", "in_cluster"}
+	return []string{"kubeconfig", "kubeconfig_path", "context", "namespace", "api_server", "ca_cert", "insecure_skip_tls_verify", "in_cluster", "allow_mutations"}
 }
 
 func (k *kubernetes) Placeholders() map[string]string {
@@ -90,7 +91,7 @@ func (k *kubernetes) Placeholders() map[string]string {
 }
 
 func (k *kubernetes) OptionalKeys() []string {
-	return []string{"kubeconfig", "kubeconfig_path", "context", "namespace", "api_server", "token", "ca_cert", "insecure_skip_tls_verify", "in_cluster", "clusters"}
+	return []string{"kubeconfig", "kubeconfig_path", "context", "namespace", "api_server", "token", "ca_cert", "insecure_skip_tls_verify", "in_cluster", "clusters", "allow_mutations"}
 }
 
 func (k *kubernetes) HasCredentials(creds mcp.Credentials) bool {
@@ -111,6 +112,7 @@ func (k *kubernetes) Configure(_ context.Context, creds mcp.Credentials) error {
 	k.context = selected.context
 	k.kubeconfigBytes = selected.kubeconfigBytes
 	k.clients = clients
+	k.allowMutations = creds["allow_mutations"] == "true"
 	return nil
 }
 
@@ -444,6 +446,9 @@ func (k *kubernetes) Execute(ctx context.Context, toolName mcp.ToolName, args ma
 	if k.client == nil {
 		return mcp.ErrResult(mcp.ErrNotConfigured)
 	}
+	if isMutationTool(toolName) && !k.allowMutations {
+		return mcp.ErrResult(fmt.Errorf("kubernetes: mutation tool %s requires allow_mutations=true", toolName))
+	}
 	selected, err := k.withSelectedContext(args)
 	if err != nil {
 		return mcp.ErrResult(err)
@@ -475,6 +480,19 @@ func (k *kubernetes) withSelectedContext(args map[string]any) (*kubernetes, erro
 	return &clone, nil
 }
 
+func isMutationTool(toolName mcp.ToolName) bool {
+	switch toolName {
+	case mcp.ToolName("kubernetes_scale_deployment"),
+		mcp.ToolName("kubernetes_restart_deployment"),
+		mcp.ToolName("kubernetes_cordon_node"),
+		mcp.ToolName("kubernetes_uncordon_node"),
+		mcp.ToolName("kubernetes_delete_pod"):
+		return true
+	default:
+		return false
+	}
+}
+
 func (k *kubernetes) CompactSpec(toolName mcp.ToolName) ([]mcp.CompactField, bool) {
 	fields, ok := fieldCompactionSpecs[toolName]
 	return fields, ok
@@ -488,19 +506,24 @@ func (k *kubernetes) MaxBytes(toolName mcp.ToolName) (int, bool) {
 type handlerFunc func(ctx context.Context, k *kubernetes, args map[string]any) (*mcp.ToolResult, error)
 
 var dispatch = map[mcp.ToolName]handlerFunc{
-	mcp.ToolName("kubernetes_list_contexts"):    listContexts,
-	mcp.ToolName("kubernetes_list_clusters"):    listClusters,
-	mcp.ToolName("kubernetes_list_namespaces"):  listNamespaces,
-	mcp.ToolName("kubernetes_list_pods"):        listPods,
-	mcp.ToolName("kubernetes_get_pod"):          getPod,
-	mcp.ToolName("kubernetes_read_pod_logs"):    readPodLogs,
-	mcp.ToolName("kubernetes_list_events"):      listEvents,
-	mcp.ToolName("kubernetes_list_deployments"): listDeployments,
-	mcp.ToolName("kubernetes_get_deployment"):   getDeployment,
-	mcp.ToolName("kubernetes_rollout_status"):   rolloutStatus,
-	mcp.ToolName("kubernetes_list_services"):    listServices,
-	mcp.ToolName("kubernetes_list_ingresses"):   listIngresses,
-	mcp.ToolName("kubernetes_list_nodes"):       listNodes,
+	mcp.ToolName("kubernetes_list_contexts"):      listContexts,
+	mcp.ToolName("kubernetes_list_clusters"):      listClusters,
+	mcp.ToolName("kubernetes_list_namespaces"):    listNamespaces,
+	mcp.ToolName("kubernetes_list_pods"):          listPods,
+	mcp.ToolName("kubernetes_get_pod"):            getPod,
+	mcp.ToolName("kubernetes_read_pod_logs"):      readPodLogs,
+	mcp.ToolName("kubernetes_list_events"):        listEvents,
+	mcp.ToolName("kubernetes_list_deployments"):   listDeployments,
+	mcp.ToolName("kubernetes_get_deployment"):     getDeployment,
+	mcp.ToolName("kubernetes_rollout_status"):     rolloutStatus,
+	mcp.ToolName("kubernetes_list_services"):      listServices,
+	mcp.ToolName("kubernetes_list_ingresses"):     listIngresses,
+	mcp.ToolName("kubernetes_list_nodes"):         listNodes,
+	mcp.ToolName("kubernetes_scale_deployment"):   scaleDeployment,
+	mcp.ToolName("kubernetes_restart_deployment"): restartDeployment,
+	mcp.ToolName("kubernetes_cordon_node"):        cordonNode,
+	mcp.ToolName("kubernetes_uncordon_node"):      uncordonNode,
+	mcp.ToolName("kubernetes_delete_pod"):         deletePod,
 }
 
 func namespaceFromArgs(k *kubernetes, args map[string]any) (string, error) {

--- a/integrations/kubernetes/kubernetes.go
+++ b/integrations/kubernetes/kubernetes.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	_ "embed"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -15,6 +17,7 @@ import (
 	k8sclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/util/homedir"
 )
 
@@ -41,6 +44,31 @@ type kubernetes struct {
 	namespace       string
 	context         string
 	kubeconfigBytes []byte
+	clients         map[string]*clusterClient
+}
+
+type clusterClient struct {
+	client          k8sclient.Interface
+	context         string
+	cluster         string
+	authInfo        string
+	namespace       string
+	current         bool
+	source          string
+	kubeconfigBytes []byte
+}
+
+type configuredCluster struct {
+	Name                  string `json:"name"`
+	Context               string `json:"context"`
+	Namespace             string `json:"namespace"`
+	Kubeconfig            string `json:"kubeconfig"`
+	KubeconfigPath        string `json:"kubeconfig_path"`
+	APIServer             string `json:"api_server"`
+	Token                 string `json:"token"`
+	CACert                string `json:"ca_cert"`
+	InsecureSkipTLSVerify string `json:"insecure_skip_tls_verify"`
+	InCluster             string `json:"in_cluster"`
 }
 
 func New() mcp.Integration {
@@ -56,12 +84,13 @@ func (k *kubernetes) PlainTextKeys() []string {
 func (k *kubernetes) Placeholders() map[string]string {
 	return map[string]string{
 		"kubeconfig_path": "~/.kube/config",
+		"context":         "current kubeconfig context",
 		"namespace":       "default",
 	}
 }
 
 func (k *kubernetes) OptionalKeys() []string {
-	return []string{"kubeconfig", "kubeconfig_path", "context", "namespace", "api_server", "token", "ca_cert", "insecure_skip_tls_verify", "in_cluster"}
+	return []string{"kubeconfig", "kubeconfig_path", "context", "namespace", "api_server", "token", "ca_cert", "insecure_skip_tls_verify", "in_cluster", "clusters"}
 }
 
 func (k *kubernetes) HasCredentials(creds mcp.Credentials) bool {
@@ -69,18 +98,19 @@ func (k *kubernetes) HasCredentials(creds mcp.Credentials) bool {
 }
 
 func (k *kubernetes) Configure(_ context.Context, creds mcp.Credentials) error {
-	cfg, data, err := restConfig(creds)
+	clients, defaultName, err := clusterClients(creds)
 	if err != nil {
 		return err
 	}
-	client, err := k8sclient.NewForConfig(cfg)
-	if err != nil {
-		return fmt.Errorf("kubernetes: create client: %w", err)
+	selected, ok := clients[defaultName]
+	if !ok {
+		return fmt.Errorf("kubernetes: configured context %q was not found", defaultName)
 	}
-	k.client = client
-	k.namespace = defaultNamespace(creds)
-	k.context = creds["context"]
-	k.kubeconfigBytes = data
+	k.client = selected.client
+	k.namespace = selected.namespace
+	k.context = selected.context
+	k.kubeconfigBytes = selected.kubeconfigBytes
+	k.clients = clients
 	return nil
 }
 
@@ -98,7 +128,10 @@ func (k *kubernetes) contextConfig() ([]byte, error) {
 
 func restConfig(creds mcp.Credentials) (*rest.Config, []byte, error) {
 	if !explicitCredentials(creds) {
-		return nil, nil, fmt.Errorf("kubernetes: explicit kubeconfig, kubeconfig_path, in_cluster=true, or api_server+token is required")
+		return nil, nil, fmt.Errorf("kubernetes: explicit kubeconfig, kubeconfig_path, clusters, in_cluster=true, or api_server+token is required")
+	}
+	if creds["clusters"] != "" {
+		return nil, nil, fmt.Errorf("kubernetes: clusters must be configured through clusterClients")
 	}
 	if creds["in_cluster"] == "true" {
 		cfg, err := rest.InClusterConfig()
@@ -114,11 +147,145 @@ func restConfig(creds mcp.Credentials) (*rest.Config, []byte, error) {
 	if creds["kubeconfig"] != "" || creds["kubeconfig_path"] != "" {
 		return kubeconfigConfig(creds)
 	}
-	return nil, nil, fmt.Errorf("kubernetes: kubeconfig, kubeconfig_path, in_cluster=true, or api_server+token is required")
+	return nil, nil, fmt.Errorf("kubernetes: kubeconfig, kubeconfig_path, clusters, in_cluster=true, or api_server+token is required")
 }
 
 func explicitCredentials(creds mcp.Credentials) bool {
-	return creds["kubeconfig"] != "" || creds["kubeconfig_path"] != "" || creds["in_cluster"] == "true" || creds["api_server"] != "" || creds["token"] != ""
+	return creds["kubeconfig"] != "" || creds["kubeconfig_path"] != "" || creds["clusters"] != "" || creds["in_cluster"] == "true" || creds["api_server"] != "" || creds["token"] != ""
+}
+
+func clusterClients(creds mcp.Credentials) (map[string]*clusterClient, string, error) {
+	if raw := creds["clusters"]; raw != "" {
+		return clusterClientsFromJSON(creds, raw)
+	}
+	cfg, data, err := restConfig(creds)
+	if err != nil {
+		return nil, "", err
+	}
+	client, err := k8sclient.NewForConfig(cfg)
+	if err != nil {
+		return nil, "", fmt.Errorf("kubernetes: create client: %w", err)
+	}
+	if len(data) > 0 {
+		apiCfg, err := clientcmd.Load(data)
+		if err != nil {
+			return nil, "", fmt.Errorf("kubernetes: load kubeconfig contexts: %w", err)
+		}
+		return clusterClientsFromKubeconfig(creds, apiCfg, data, client)
+	}
+	name := singleClusterName(creds)
+	clients := map[string]*clusterClient{
+		name: {
+			client:    client,
+			context:   name,
+			cluster:   creds["api_server"],
+			namespace: defaultNamespace(creds),
+			current:   true,
+			source:    singleClusterSource(creds),
+		},
+	}
+	return clients, name, nil
+}
+
+func clusterClientsFromJSON(base mcp.Credentials, raw string) (map[string]*clusterClient, string, error) {
+	var configured []configuredCluster
+	if err := json.Unmarshal([]byte(raw), &configured); err != nil {
+		return nil, "", fmt.Errorf("kubernetes: parse clusters: %w", err)
+	}
+	if len(configured) == 0 {
+		return nil, "", fmt.Errorf("kubernetes: clusters must include at least one cluster")
+	}
+	clients := make(map[string]*clusterClient, len(configured))
+	defaultName := base["context"]
+	for i, item := range configured {
+		creds := mcp.Credentials{
+			"kubeconfig":               item.Kubeconfig,
+			"kubeconfig_path":          item.KubeconfigPath,
+			"context":                  item.Context,
+			"namespace":                item.Namespace,
+			"api_server":               item.APIServer,
+			"token":                    item.Token,
+			"ca_cert":                  item.CACert,
+			"insecure_skip_tls_verify": item.InsecureSkipTLSVerify,
+			"in_cluster":               item.InCluster,
+		}
+		if creds["namespace"] == "" {
+			creds["namespace"] = base["namespace"]
+		}
+		cfg, data, err := restConfig(creds)
+		if err != nil {
+			return nil, "", fmt.Errorf("kubernetes: configure cluster %d: %w", i+1, err)
+		}
+		client, err := k8sclient.NewForConfig(cfg)
+		if err != nil {
+			return nil, "", fmt.Errorf("kubernetes: create client for cluster %d: %w", i+1, err)
+		}
+		name := item.Name
+		if name == "" {
+			name = item.Context
+		}
+		if name == "" {
+			name = item.APIServer
+		}
+		if name == "" {
+			name = fmt.Sprintf("cluster-%d", i+1)
+		}
+		clients[name] = &clusterClient{client: client, context: name, cluster: item.APIServer, namespace: defaultNamespace(creds), current: name == defaultName, source: singleClusterSource(creds), kubeconfigBytes: data}
+		if defaultName == "" && i == 0 {
+			defaultName = name
+			clients[name].current = true
+		}
+	}
+	return clients, defaultName, nil
+}
+
+func clusterClientsFromKubeconfig(creds mcp.Credentials, apiCfg *clientcmdapi.Config, data []byte, selected k8sclient.Interface) (map[string]*clusterClient, string, error) {
+	defaultName := creds["context"]
+	if defaultName == "" {
+		defaultName = apiCfg.CurrentContext
+	}
+	if defaultName == "" && len(apiCfg.Contexts) == 1 {
+		for name := range apiCfg.Contexts {
+			defaultName = name
+		}
+	}
+	if defaultName == "" {
+		return nil, "", fmt.Errorf("kubernetes: kubeconfig has no current context; set context explicitly")
+	}
+	clients := make(map[string]*clusterClient, len(apiCfg.Contexts))
+	names := make([]string, 0, len(apiCfg.Contexts))
+	for name := range apiCfg.Contexts {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		ctx := apiCfg.Contexts[name]
+		client := selected
+		if name != defaultName {
+			cfg, err := restConfigFromKubeconfig(apiCfg, name, creds["namespace"])
+			if err != nil {
+				continue
+			}
+			created, err := k8sclient.NewForConfig(cfg)
+			if err != nil {
+				continue
+			}
+			client = created
+		}
+		clients[name] = &clusterClient{client: client, context: name, cluster: ctx.Cluster, authInfo: ctx.AuthInfo, namespace: namespaceForContext(ctx, creds["namespace"]), current: name == defaultName, source: "kubeconfig", kubeconfigBytes: data}
+	}
+	if _, ok := clients[defaultName]; !ok {
+		return nil, "", fmt.Errorf("kubernetes: kubeconfig context %q was not found", defaultName)
+	}
+	return clients, defaultName, nil
+}
+
+func restConfigFromKubeconfig(apiCfg *clientcmdapi.Config, contextName string, namespace string) (*rest.Config, error) {
+	overrides := &clientcmd.ConfigOverrides{}
+	if namespace != "" {
+		overrides.Context.Namespace = namespace
+	}
+	return clientcmd.NewNonInteractiveClientConfig(*apiCfg, contextName, overrides, nil).ClientConfig()
 }
 
 func serviceAccountConfig(creds mcp.Credentials) (*rest.Config, error) {
@@ -145,33 +312,46 @@ func serviceAccountConfig(creds mcp.Credentials) (*rest.Config, error) {
 }
 
 func kubeconfigConfig(creds mcp.Credentials) (*rest.Config, []byte, error) {
-	rules := clientcmd.NewDefaultClientConfigLoadingRules()
-	var data []byte
+	cfg, data, err := loadKubeconfig(creds)
+	if err != nil {
+		return nil, nil, err
+	}
+	contextName := creds["context"]
+	if contextName == "" {
+		contextName = cfg.CurrentContext
+	}
+	restCfg, err := restConfigFromKubeconfig(cfg, contextName, creds["namespace"])
+	if err != nil {
+		return nil, nil, fmt.Errorf("kubernetes: load kubeconfig: %w", err)
+	}
+	return restCfg, data, nil
+}
+
+func loadKubeconfig(creds mcp.Credentials) (*clientcmdapi.Config, []byte, error) {
 	if raw := creds["kubeconfig"]; raw != "" {
-		data = []byte(raw)
-		cfg, err := clientcmd.RESTConfigFromKubeConfig(data)
+		data := []byte(raw)
+		cfg, err := clientcmd.Load(data)
 		if err != nil {
 			return nil, nil, fmt.Errorf("kubernetes: load kubeconfig: %w", err)
 		}
 		return cfg, data, nil
 	}
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
 	if path := creds["kubeconfig_path"]; path != "" {
-		rules.ExplicitPath = expandHome(path)
+		expanded := expandHome(path)
+		if strings.ContainsRune(expanded, os.PathListSeparator) {
+			rules.Precedence = strings.Split(expanded, string(os.PathListSeparator))
+		} else {
+			rules.ExplicitPath = expanded
+		}
 	}
-	overrides := &clientcmd.ConfigOverrides{CurrentContext: creds["context"]}
-	if ns := creds["namespace"]; ns != "" {
-		overrides.Context.Namespace = ns
-	}
-	cfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, overrides).ClientConfig()
+	cfg, err := rules.Load()
 	if err != nil {
 		return nil, nil, fmt.Errorf("kubernetes: load kubeconfig: %w", err)
 	}
-	path := rules.ExplicitPath
-	if path == "" {
-		path = rules.GetDefaultFilename()
-	}
-	if path != "" {
-		data, _ = os.ReadFile(path)
+	data, err := clientcmd.Write(*cfg)
+	if err != nil {
+		return nil, nil, fmt.Errorf("kubernetes: serialize kubeconfig: %w", err)
 	}
 	return cfg, data, nil
 }
@@ -181,6 +361,42 @@ func defaultNamespace(creds mcp.Credentials) string {
 		return ns
 	}
 	return "default"
+}
+
+func namespaceForContext(ctx *clientcmdapi.Context, override string) string {
+	if override != "" {
+		return override
+	}
+	if ctx != nil && ctx.Namespace != "" {
+		return ctx.Namespace
+	}
+	return "default"
+}
+
+func singleClusterName(creds mcp.Credentials) string {
+	if name := creds["context"]; name != "" {
+		return name
+	}
+	if creds["in_cluster"] == "true" {
+		return "in-cluster"
+	}
+	if apiServer := creds["api_server"]; apiServer != "" {
+		return apiServer
+	}
+	return "default"
+}
+
+func singleClusterSource(creds mcp.Credentials) string {
+	switch {
+	case creds["in_cluster"] == "true":
+		return "in_cluster"
+	case creds["api_server"] != "" || creds["token"] != "":
+		return "api_server"
+	case creds["kubeconfig"] != "" || creds["kubeconfig_path"] != "":
+		return "kubeconfig"
+	default:
+		return "unknown"
+	}
 }
 
 func expandHome(path string) string {
@@ -228,7 +444,35 @@ func (k *kubernetes) Execute(ctx context.Context, toolName mcp.ToolName, args ma
 	if k.client == nil {
 		return mcp.ErrResult(mcp.ErrNotConfigured)
 	}
-	return fn(ctx, k, args)
+	selected, err := k.withSelectedContext(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return fn(ctx, selected, args)
+}
+
+func (k *kubernetes) withSelectedContext(args map[string]any) (*kubernetes, error) {
+	if len(k.clients) == 0 {
+		return k, nil
+	}
+	r := mcp.NewArgs(args)
+	contextName := r.Str("context")
+	if err := r.Err(); err != nil {
+		return nil, err
+	}
+	if contextName == "" || contextName == k.context {
+		return k, nil
+	}
+	selected, ok := k.clients[contextName]
+	if !ok {
+		return nil, fmt.Errorf("kubernetes: unknown context %q", contextName)
+	}
+	clone := *k
+	clone.client = selected.client
+	clone.namespace = selected.namespace
+	clone.context = selected.context
+	clone.kubeconfigBytes = selected.kubeconfigBytes
+	return &clone, nil
 }
 
 func (k *kubernetes) CompactSpec(toolName mcp.ToolName) ([]mcp.CompactField, bool) {
@@ -245,6 +489,7 @@ type handlerFunc func(ctx context.Context, k *kubernetes, args map[string]any) (
 
 var dispatch = map[mcp.ToolName]handlerFunc{
 	mcp.ToolName("kubernetes_list_contexts"):    listContexts,
+	mcp.ToolName("kubernetes_list_clusters"):    listClusters,
 	mcp.ToolName("kubernetes_list_namespaces"):  listNamespaces,
 	mcp.ToolName("kubernetes_list_pods"):        listPods,
 	mcp.ToolName("kubernetes_get_pod"):          getPod,

--- a/integrations/kubernetes/kubernetes_test.go
+++ b/integrations/kubernetes/kubernetes_test.go
@@ -53,6 +53,15 @@ func TestConfigure_InlineKubeconfig(t *testing.T) {
 	assert.Equal(t, "apps", k.namespace)
 }
 
+func TestKubeconfigConfig_HonorsRequestedContext(t *testing.T) {
+	cfg, _, err := kubeconfigConfig(mcp.Credentials{
+		"kubeconfig": testMultiKubeconfig(t),
+		"context":    "west",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "https://west.example.test", cfg.Host)
+}
+
 func TestConfigure_ServiceAccountToken(t *testing.T) {
 	i := New()
 	err := i.Configure(context.Background(), mcp.Credentials{
@@ -68,7 +77,7 @@ func TestConfigure_ServiceAccountToken(t *testing.T) {
 func TestTools(t *testing.T) {
 	i := New()
 	tls := i.Tools()
-	assert.Len(t, tls, 12)
+	assert.Len(t, tls, 13)
 	for _, tool := range tls {
 		assert.NotEmpty(t, tool.Name)
 		assert.NotEmpty(t, tool.Description)
@@ -174,6 +183,43 @@ func TestListContexts(t *testing.T) {
 	assert.True(t, contexts[0].Current)
 }
 
+func TestExecute_ContextSelectsCluster(t *testing.T) {
+	k := &kubernetes{
+		client: fake.NewSimpleClientset(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "east-pod", Namespace: "apps"}}),
+		clients: map[string]*clusterClient{
+			"east": {client: fake.NewSimpleClientset(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "east-pod", Namespace: "apps"}}), namespace: "apps"},
+			"west": {client: fake.NewSimpleClientset(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "west-pod", Namespace: "apps"}}), namespace: "apps"},
+		},
+		namespace: "apps",
+		context:   "east",
+	}
+
+	result, err := k.Execute(context.Background(), "kubernetes_list_pods", map[string]any{"context": "west"})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	var pods []podSummary
+	require.NoError(t, json.Unmarshal([]byte(result.Data), &pods))
+	require.Len(t, pods, 1)
+	assert.Equal(t, "west-pod", pods[0].Name)
+}
+
+func TestListClusters(t *testing.T) {
+	i := New()
+	err := i.Configure(context.Background(), mcp.Credentials{"kubeconfig": testMultiKubeconfig(t)})
+	require.NoError(t, err)
+	result, err := i.Execute(context.Background(), "kubernetes_list_clusters", nil)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	var clusters []clusterSummary
+	require.NoError(t, json.Unmarshal([]byte(result.Data), &clusters))
+	require.Len(t, clusters, 2)
+	assert.Equal(t, "east", clusters[0].Context)
+	assert.True(t, clusters[0].Current)
+	assert.Equal(t, "west", clusters[1].Context)
+}
+
 func TestFieldCompactionSpecs_NoOrphanSpecs(t *testing.T) {
 	for name := range fieldCompactionSpecs {
 		_, ok := dispatch[name]
@@ -194,6 +240,28 @@ func testKubeconfig(t *testing.T) string {
 			"test": {Cluster: "test", AuthInfo: "test", Namespace: "default"},
 		},
 		CurrentContext: "test",
+	}
+	data, err := clientcmd.Write(cfg)
+	require.NoError(t, err)
+	return string(data)
+}
+
+func testMultiKubeconfig(t *testing.T) string {
+	t.Helper()
+	cfg := api.Config{
+		Clusters: map[string]*api.Cluster{
+			"east": {Server: "https://east.example.test", InsecureSkipTLSVerify: true},
+			"west": {Server: "https://west.example.test", InsecureSkipTLSVerify: true},
+		},
+		AuthInfos: map[string]*api.AuthInfo{
+			"east": {Token: "east-token"},
+			"west": {Token: "west-token"},
+		},
+		Contexts: map[string]*api.Context{
+			"east": {Cluster: "east", AuthInfo: "east", Namespace: "apps"},
+			"west": {Cluster: "west", AuthInfo: "west", Namespace: "apps"},
+		},
+		CurrentContext: "east",
 	}
 	data, err := clientcmd.Write(cfg)
 	require.NoError(t, err)

--- a/integrations/kubernetes/kubernetes_test.go
+++ b/integrations/kubernetes/kubernetes_test.go
@@ -8,6 +8,7 @@ import (
 	mcp "github.com/daltoniam/switchboard"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -74,10 +75,22 @@ func TestConfigure_ServiceAccountToken(t *testing.T) {
 	assert.Equal(t, "default", k.namespace)
 }
 
+func TestConfigure_AllowMutations(t *testing.T) {
+	i := New()
+	err := i.Configure(context.Background(), mcp.Credentials{
+		"api_server":      "https://kubernetes.example.test",
+		"token":           "token",
+		"allow_mutations": "true",
+	})
+	require.NoError(t, err)
+	k := i.(*kubernetes)
+	assert.True(t, k.allowMutations)
+}
+
 func TestTools(t *testing.T) {
 	i := New()
 	tls := i.Tools()
-	assert.Len(t, tls, 13)
+	assert.Len(t, tls, 18)
 	for _, tool := range tls {
 		assert.NotEmpty(t, tool.Name)
 		assert.NotEmpty(t, tool.Description)
@@ -218,6 +231,71 @@ func TestListClusters(t *testing.T) {
 	assert.Equal(t, "east", clusters[0].Context)
 	assert.True(t, clusters[0].Current)
 	assert.Equal(t, "west", clusters[1].Context)
+}
+
+func TestMutationToolsRequireAllowMutations(t *testing.T) {
+	k := &kubernetes{client: fake.NewSimpleClientset(), namespace: "default"}
+	result, err := k.Execute(context.Background(), "kubernetes_scale_deployment", map[string]any{"deployment": "api", "replicas": 2})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	assert.Contains(t, result.Data, "allow_mutations=true")
+}
+
+func TestScaleDeployment(t *testing.T) {
+	replicas := int32(1)
+	client := fake.NewSimpleClientset(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "apps"},
+		Spec:       appsv1.DeploymentSpec{Replicas: &replicas},
+	})
+	k := &kubernetes{client: client, namespace: "apps", allowMutations: true}
+
+	result, err := k.Execute(context.Background(), "kubernetes_scale_deployment", map[string]any{"deployment": "api", "replicas": 3})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	updated, err := client.AppsV1().Deployments("apps").Get(context.Background(), "api", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, updated.Spec.Replicas)
+	assert.Equal(t, int32(3), *updated.Spec.Replicas)
+	assert.Contains(t, result.Data, "scaled")
+}
+
+func TestRestartDeploymentRollout(t *testing.T) {
+	client := fake.NewSimpleClientset(&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "apps"}})
+	k := &kubernetes{client: client, namespace: "apps", allowMutations: true}
+
+	result, err := k.Execute(context.Background(), "kubernetes_restart_deployment", map[string]any{"deployment": "api"})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	updated, err := client.AppsV1().Deployments("apps").Get(context.Background(), "api", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.NotEmpty(t, updated.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"])
+}
+
+func TestCordonNode(t *testing.T) {
+	client := fake.NewSimpleClientset(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}})
+	k := &kubernetes{client: client, allowMutations: true}
+
+	result, err := k.Execute(context.Background(), "kubernetes_cordon_node", map[string]any{"node": "node-1"})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	updated, err := client.CoreV1().Nodes().Get(context.Background(), "node-1", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.True(t, updated.Spec.Unschedulable)
+}
+
+func TestDeletePod(t *testing.T) {
+	client := fake.NewSimpleClientset(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "apps"}})
+	k := &kubernetes{client: client, namespace: "apps", allowMutations: true}
+
+	result, err := k.Execute(context.Background(), "kubernetes_delete_pod", map[string]any{"pod": "api", "grace_period_seconds": 0})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	_, err = client.CoreV1().Pods("apps").Get(context.Background(), "api", metav1.GetOptions{})
+	require.Error(t, err)
 }
 
 func TestFieldCompactionSpecs_NoOrphanSpecs(t *testing.T) {

--- a/integrations/kubernetes/tools.go
+++ b/integrations/kubernetes/tools.go
@@ -132,4 +132,54 @@ var tools = []mcp.ToolDefinition{
 			"limit":          "Maximum number of nodes to return (default: 100, max: 500).",
 		},
 	},
+	{
+		Name:        mcp.ToolName("kubernetes_scale_deployment"),
+		Description: "Scale a Kubernetes deployment to an explicit replica count. Mutation tool: requires allow_mutations=true and RBAC update permission on deployments/scale.",
+		Parameters: map[string]string{
+			"context":    contextParamDesc,
+			"namespace":  namespaceParamDesc,
+			"deployment": "Deployment name.",
+			"replicas":   "Desired replica count.",
+		},
+		Required: []string{"deployment", "replicas"},
+	},
+	{
+		Name:        mcp.ToolName("kubernetes_restart_deployment"),
+		Description: "Restart a Kubernetes deployment rollout by updating its pod template restart annotation. Mutation tool: requires allow_mutations=true and RBAC patch/update permission on deployments.",
+		Parameters: map[string]string{
+			"context":    contextParamDesc,
+			"namespace":  namespaceParamDesc,
+			"deployment": "Deployment name.",
+		},
+		Required: []string{"deployment"},
+	},
+	{
+		Name:        mcp.ToolName("kubernetes_cordon_node"),
+		Description: "Cordon a Kubernetes node so new pods are not scheduled onto it. Mutation tool: requires allow_mutations=true and RBAC patch/update permission on nodes.",
+		Parameters: map[string]string{
+			"context": contextParamDesc,
+			"node":    "Node name.",
+		},
+		Required: []string{"node"},
+	},
+	{
+		Name:        mcp.ToolName("kubernetes_uncordon_node"),
+		Description: "Uncordon a Kubernetes node so new pods can be scheduled onto it again. Mutation tool: requires allow_mutations=true and RBAC patch/update permission on nodes.",
+		Parameters: map[string]string{
+			"context": contextParamDesc,
+			"node":    "Node name.",
+		},
+		Required: []string{"node"},
+	},
+	{
+		Name:        mcp.ToolName("kubernetes_delete_pod"),
+		Description: "Delete a Kubernetes pod to let its controller recreate it. Mutation tool: requires allow_mutations=true and RBAC delete permission on pods. Prefer this for stuck or crash-looping controller-owned pods, not standalone pods.",
+		Parameters: map[string]string{
+			"context":              contextParamDesc,
+			"namespace":            namespaceParamDesc,
+			"pod":                  "Pod name.",
+			"grace_period_seconds": "Optional graceful termination period in seconds.",
+		},
+		Required: []string{"pod"},
+	},
 }

--- a/integrations/kubernetes/tools.go
+++ b/integrations/kubernetes/tools.go
@@ -3,6 +3,7 @@ package kubernetes
 import mcp "github.com/daltoniam/switchboard"
 
 const namespaceParamDesc = "Namespace (omit to use configured namespace; use all_namespaces=true for all namespaces where supported)."
+const contextParamDesc = "Kubernetes context or configured cluster name. Omit to use the configured default context."
 
 var tools = []mcp.ToolDefinition{
 	{
@@ -11,14 +12,22 @@ var tools = []mcp.ToolDefinition{
 		Parameters:  map[string]string{},
 	},
 	{
+		Name:        mcp.ToolName("kubernetes_list_clusters"),
+		Description: "List configured Kubernetes clusters and contexts available to this integration. Start here when choosing which cluster to inspect.",
+		Parameters:  map[string]string{},
+	},
+	{
 		Name:        mcp.ToolName("kubernetes_list_namespaces"),
 		Description: "List Kubernetes namespaces in the cluster. Start here for Kubernetes cluster discovery and finding available environments.",
-		Parameters:  map[string]string{},
+		Parameters: map[string]string{
+			"context": contextParamDesc,
+		},
 	},
 	{
 		Name:        mcp.ToolName("kubernetes_list_pods"),
 		Description: "List Kubernetes pods with phase, node, labels, restarts, and readiness. Start here for workload health, container debugging, and finding failing pods.",
 		Parameters: map[string]string{
+			"context":        contextParamDesc,
 			"namespace":      namespaceParamDesc,
 			"all_namespaces": "Set true to list pods across all namespaces.",
 			"label_selector": "Kubernetes label selector, for example app=api,tier=backend.",
@@ -30,6 +39,7 @@ var tools = []mcp.ToolDefinition{
 		Name:        mcp.ToolName("kubernetes_get_pod"),
 		Description: "Get details for a specific Kubernetes pod, including containers, conditions, owner references, and recent status. Use after list_pods.",
 		Parameters: map[string]string{
+			"context":   contextParamDesc,
 			"namespace": namespaceParamDesc,
 			"pod":       "Pod name.",
 		},
@@ -39,6 +49,7 @@ var tools = []mcp.ToolDefinition{
 		Name:        mcp.ToolName("kubernetes_read_pod_logs"),
 		Description: "Read logs from a Kubernetes pod container. Use after list_pods or get_pod for debugging crashes, errors, and workload failures.",
 		Parameters: map[string]string{
+			"context":    contextParamDesc,
 			"namespace":  namespaceParamDesc,
 			"pod":        "Pod name.",
 			"container":  "Container name (optional for single-container pods).",
@@ -52,6 +63,7 @@ var tools = []mcp.ToolDefinition{
 		Name:        mcp.ToolName("kubernetes_list_events"),
 		Description: "List Kubernetes events sorted by time. Use for debugging scheduling, image pulls, probes, restarts, and rollout failures.",
 		Parameters: map[string]string{
+			"context":        contextParamDesc,
 			"namespace":      namespaceParamDesc,
 			"all_namespaces": "Set true to list events across all namespaces.",
 			"field_selector": "Kubernetes field selector, for example involvedObject.name=api.",
@@ -62,6 +74,7 @@ var tools = []mcp.ToolDefinition{
 		Name:        mcp.ToolName("kubernetes_list_deployments"),
 		Description: "List Kubernetes deployments with replicas, availability, labels, and images. Use for workload discovery and rollout health checks.",
 		Parameters: map[string]string{
+			"context":        contextParamDesc,
 			"namespace":      namespaceParamDesc,
 			"all_namespaces": "Set true to list deployments across all namespaces.",
 			"label_selector": "Kubernetes label selector.",
@@ -72,6 +85,7 @@ var tools = []mcp.ToolDefinition{
 		Name:        mcp.ToolName("kubernetes_get_deployment"),
 		Description: "Get details for a specific Kubernetes deployment, including rollout conditions, replica counts, strategy, selectors, and images. Use after list_deployments.",
 		Parameters: map[string]string{
+			"context":    contextParamDesc,
 			"namespace":  namespaceParamDesc,
 			"deployment": "Deployment name.",
 		},
@@ -81,6 +95,7 @@ var tools = []mcp.ToolDefinition{
 		Name:        mcp.ToolName("kubernetes_rollout_status"),
 		Description: "Check Kubernetes deployment rollout status and explain whether a rollout is complete, progressing, or stuck. Use after list_deployments or get_deployment.",
 		Parameters: map[string]string{
+			"context":    contextParamDesc,
 			"namespace":  namespaceParamDesc,
 			"deployment": "Deployment name.",
 		},
@@ -90,6 +105,7 @@ var tools = []mcp.ToolDefinition{
 		Name:        mcp.ToolName("kubernetes_list_services"),
 		Description: "List Kubernetes services with type, cluster IPs, external IPs, ports, and selectors. Use for service discovery and network debugging.",
 		Parameters: map[string]string{
+			"context":        contextParamDesc,
 			"namespace":      namespaceParamDesc,
 			"all_namespaces": "Set true to list services across all namespaces.",
 			"label_selector": "Kubernetes label selector.",
@@ -100,6 +116,7 @@ var tools = []mcp.ToolDefinition{
 		Name:        mcp.ToolName("kubernetes_list_ingresses"),
 		Description: "List Kubernetes ingresses with hosts, paths, classes, TLS, and load balancer addresses. Use for HTTP routing and exposure debugging.",
 		Parameters: map[string]string{
+			"context":        contextParamDesc,
 			"namespace":      namespaceParamDesc,
 			"all_namespaces": "Set true to list ingresses across all namespaces.",
 			"label_selector": "Kubernetes label selector.",
@@ -110,6 +127,7 @@ var tools = []mcp.ToolDefinition{
 		Name:        mcp.ToolName("kubernetes_list_nodes"),
 		Description: "List Kubernetes cluster nodes with readiness, versions, roles, taints, capacity, and allocatable resources. Use for cluster capacity and node health debugging.",
 		Parameters: map[string]string{
+			"context":        contextParamDesc,
 			"label_selector": "Kubernetes label selector.",
 			"limit":          "Maximum number of nodes to return (default: 100, max: 500).",
 		},


### PR DESCRIPTION
- Lets the Kubernetes integration discover multiple configured clusters and switch between them per request, so users can inspect more than one cluster without restarting or changing global credentials.
- Adds a read-only cluster discovery tool plus config/env support for explicit multi-cluster definitions.

Validation:
- go test ./...
- make ci
- local MCP smoke test against two EKS contexts

💘 Generated with Crush