### PR TITLE
feat(postgres): query databases through a hosted agent tunnel

### DIFF
--- a/integrations/postgres/postgres.go
+++ b/integrations/postgres/postgres.go
@@ -35,9 +35,11 @@ var (
 	_ mcp.ToolMaxBytesIntegration    = (*postgres)(nil)
 )
 
-// pgConn holds a single Postgres connection and its metadata.
+// pgConn holds a single Postgres connection and its metadata. Statement
+// execution goes through runner, which is either a direct *sql.DB (sqlRunner)
+// or a hosted tunnel relay (tunnelRunner) when mode=agent.
 type pgConn struct {
-	db       *sql.DB
+	runner   runner
 	connStr  string
 	readOnly bool
 	alias    string
@@ -73,7 +75,7 @@ func New() mcp.Integration {
 func (p *postgres) Name() string { return "postgres" }
 
 func (p *postgres) PlainTextKeys() []string {
-	return []string{"host", "port", "user", "database", "sslmode", "read_only", "connections"}
+	return []string{"host", "port", "user", "database", "sslmode", "read_only", "connections", "mode", "tunnel_url", "org"}
 }
 
 func (p *postgres) Placeholders() map[string]string {
@@ -83,7 +85,7 @@ func (p *postgres) Placeholders() map[string]string {
 }
 
 func (p *postgres) OptionalKeys() []string {
-	return []string{"connections"}
+	return []string{"connections", "mode", "tunnel_url", "org", "tunnel_auth_token"}
 }
 
 func (p *postgres) Configure(ctx context.Context, creds mcp.Credentials) error {
@@ -135,7 +137,7 @@ func (p *postgres) Configure(ctx context.Context, creds mcp.Credentials) error {
 		c, err := openConn(ctx, pc.alias, pc.creds)
 		if err != nil {
 			for _, prev := range newConns {
-				_ = prev.db.Close()
+				_ = prev.runner.close()
 			}
 			if pc.alias != "default" {
 				return fmt.Errorf("postgres: connection %q: %w", pc.alias, err)
@@ -152,13 +154,17 @@ func (p *postgres) Configure(ctx context.Context, creds mcp.Credentials) error {
 	p.mu.Unlock()
 
 	for _, c := range old {
-		_ = c.db.Close()
+		_ = c.runner.close()
 	}
 
 	return nil
 }
 
 func openConn(ctx context.Context, alias string, creds mcp.Credentials) (*pgConn, error) {
+	if strings.EqualFold(strings.TrimSpace(creds["mode"]), "agent") {
+		return openAgentConn(ctx, alias, creds)
+	}
+
 	readOnly := creds["read_only"] != "false"
 	connStr, host, dbName, err := buildConnStr(creds)
 	if err != nil {
@@ -181,12 +187,36 @@ func openConn(ctx context.Context, alias string, creds mcp.Credentials) (*pgConn
 	}
 
 	return &pgConn{
-		db:       db,
+		runner:   &sqlRunner{db: db},
 		connStr:  connStr,
 		readOnly: readOnly,
 		alias:    alias,
 		host:     host,
 		dbName:   dbName,
+	}, nil
+}
+
+// openAgentConn builds a tunnel-backed connection. The real DSN lives in the
+// customer-side agent; hosted only needs the tunnel endpoint and org ID. Agent
+// mode is always read-only because tunneld enforces it server-side.
+func openAgentConn(ctx context.Context, alias string, creds mcp.Credentials) (*pgConn, error) {
+	r, err := newTunnelRunner(creds["tunnel_url"], creds["org"], creds["tunnel_auth_token"])
+	if err != nil {
+		return nil, err
+	}
+
+	pingCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	if err := r.ping(pingCtx); err != nil {
+		return nil, fmt.Errorf("postgres: failed to reach agent tunnel: %w", err)
+	}
+
+	return &pgConn{
+		runner:   r,
+		readOnly: true,
+		alias:    alias,
+		host:     "agent:" + strings.TrimSpace(creds["org"]),
+		dbName:   creds["database"],
 	}, nil
 }
 
@@ -247,7 +277,7 @@ func (p *postgres) Close() error {
 	defer p.mu.Unlock()
 	var firstErr error
 	for _, c := range p.conns {
-		if err := c.db.Close(); err != nil && firstErr == nil {
+		if err := c.runner.close(); err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}
@@ -265,7 +295,7 @@ func (p *postgres) Healthy(ctx context.Context) bool {
 	if !ok {
 		return false
 	}
-	return c.db.PingContext(ctx) == nil
+	return c.runner.ping(ctx) == nil
 }
 
 func (p *postgres) Tools() []mcp.ToolDefinition {
@@ -321,36 +351,20 @@ func (p *postgres) getConnForArgs(args map[string]any) (*pgConn, error) {
 // --- Query helpers ---
 
 func (p *postgres) query(ctx context.Context, conn *pgConn, q string, args ...any) (json.RawMessage, error) {
-	rows, err := conn.db.QueryContext(ctx, q, args...)
-	if err != nil {
-		return nil, fmt.Errorf("query error: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
-
-	return scanRows(rows)
+	return conn.runner.queryRows(ctx, q, args...)
 }
 
 func (p *postgres) exec(ctx context.Context, conn *pgConn, query string, args ...any) (json.RawMessage, error) {
-	result, err := conn.db.ExecContext(ctx, query, args...)
-	if err != nil {
-		return nil, fmt.Errorf("exec error: %w", err)
-	}
-
-	rowsAffected, _ := result.RowsAffected()
-	data, _ := json.Marshal(map[string]any{
-		"status":        "success",
-		"rows_affected": rowsAffected,
-	})
-	return json.RawMessage(data), nil
+	return conn.runner.exec(ctx, query, args...)
 }
 
 func (p *postgres) queryRow(ctx context.Context, conn *pgConn, query string, args ...any) (json.RawMessage, error) {
-	rows, err := conn.db.QueryContext(ctx, query, args...)
-	if err != nil {
-		return nil, fmt.Errorf("query error: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
+	return conn.runner.queryRow(ctx, query, args...)
+}
 
+// scanFirstRow returns the first row of a result set as a JSON object, or {} if
+// there are no rows. It mirrors the previous direct queryRow behavior.
+func scanFirstRow(rows *sql.Rows) (json.RawMessage, error) {
 	columns, err := rows.Columns()
 	if err != nil {
 		return nil, fmt.Errorf("columns error: %w", err)

--- a/integrations/postgres/postgres_test.go
+++ b/integrations/postgres/postgres_test.go
@@ -145,7 +145,7 @@ func TestTools_NoDuplicateNames(t *testing.T) {
 
 func TestExecute_UnknownTool(t *testing.T) {
 	p := &postgres{
-		conns:        map[string]*pgConn{"default": {db: &sql.DB{}, readOnly: true, alias: "default"}},
+		conns:        map[string]*pgConn{"default": {runner: &sqlRunner{db: &sql.DB{}}, readOnly: true, alias: "default"}},
 		defaultAlias: "default",
 	}
 	result, err := p.Execute(context.Background(), "postgres_nonexistent", nil)
@@ -186,8 +186,8 @@ func TestDispatchMap_NoOrphanHandlers(t *testing.T) {
 func TestGetConnForArgs_Default(t *testing.T) {
 	p := &postgres{
 		conns: map[string]*pgConn{
-			"default": {db: &sql.DB{}, alias: "default"},
-			"prod":    {db: &sql.DB{}, alias: "prod"},
+			"default": {runner: &sqlRunner{db: &sql.DB{}}, alias: "default"},
+			"prod":    {runner: &sqlRunner{db: &sql.DB{}}, alias: "prod"},
 		},
 		defaultAlias: "default",
 	}
@@ -199,8 +199,8 @@ func TestGetConnForArgs_Default(t *testing.T) {
 func TestGetConnForArgs_ExplicitAlias(t *testing.T) {
 	p := &postgres{
 		conns: map[string]*pgConn{
-			"default": {db: &sql.DB{}, alias: "default"},
-			"prod":    {db: &sql.DB{}, alias: "prod"},
+			"default": {runner: &sqlRunner{db: &sql.DB{}}, alias: "default"},
+			"prod":    {runner: &sqlRunner{db: &sql.DB{}}, alias: "prod"},
 		},
 		defaultAlias: "default",
 	}
@@ -212,7 +212,7 @@ func TestGetConnForArgs_ExplicitAlias(t *testing.T) {
 func TestGetConnForArgs_UnknownAlias(t *testing.T) {
 	p := &postgres{
 		conns: map[string]*pgConn{
-			"default": {db: &sql.DB{}, alias: "default"},
+			"default": {runner: &sqlRunner{db: &sql.DB{}}, alias: "default"},
 		},
 		defaultAlias: "default",
 	}
@@ -227,8 +227,8 @@ func TestGetConnForArgs_UnknownAlias(t *testing.T) {
 func TestListDatabases(t *testing.T) {
 	p := &postgres{
 		conns: map[string]*pgConn{
-			"default":   {db: &sql.DB{}, alias: "default", host: "localhost", dbName: "mydb", readOnly: true},
-			"analytics": {db: &sql.DB{}, alias: "analytics", host: "analytics.example.com", dbName: "analytics", readOnly: false},
+			"default":   {runner: &sqlRunner{db: &sql.DB{}}, alias: "default", host: "localhost", dbName: "mydb", readOnly: true},
+			"analytics": {runner: &sqlRunner{db: &sql.DB{}}, alias: "analytics", host: "analytics.example.com", dbName: "analytics", readOnly: false},
 		},
 		defaultAlias: "default",
 	}
@@ -304,7 +304,7 @@ func TestSanitizeIdentifier(t *testing.T) {
 func newTestPostgres() *postgres {
 	return &postgres{
 		conns: map[string]*pgConn{
-			"default": {db: &sql.DB{}, readOnly: true, alias: "default"},
+			"default": {runner: &sqlRunner{db: &sql.DB{}}, readOnly: true, alias: "default"},
 		},
 		defaultAlias: "default",
 	}
@@ -313,7 +313,7 @@ func newTestPostgres() *postgres {
 func newTestPostgresWritable() *postgres {
 	return &postgres{
 		conns: map[string]*pgConn{
-			"default": {db: &sql.DB{}, readOnly: false, alias: "default"},
+			"default": {runner: &sqlRunner{db: &sql.DB{}}, readOnly: false, alias: "default"},
 		},
 		defaultAlias: "default",
 	}

--- a/integrations/postgres/queries.go
+++ b/integrations/postgres/queries.go
@@ -44,19 +44,7 @@ func queryTool(ctx context.Context, p *postgres, args map[string]any) (*mcp.Tool
 
 	wrapped := fmt.Sprintf("SELECT * FROM (%s) AS _q LIMIT %d", strings.TrimRight(strings.TrimSpace(sqlStr), ";"), limit) // #nosec G201 -- intentional: this tool executes user-provided SQL in a read-only transaction
 
-	tx, err := conn.db.BeginTx(ctx, &readOnlyTx)
-	if err != nil {
-		return mcp.ErrResult(fmt.Errorf("begin transaction: %w", err))
-	}
-	defer func() { _ = tx.Rollback() }()
-
-	rows, err := tx.QueryContext(ctx, wrapped)
-	if err != nil {
-		return mcp.ErrResult(fmt.Errorf("query error: %w", err))
-	}
-	defer func() { _ = rows.Close() }()
-
-	data, err := scanRows(rows)
+	data, err := conn.runner.queryReadOnly(ctx, wrapped)
 	if err != nil {
 		return mcp.ErrResult(err)
 	}
@@ -127,19 +115,7 @@ func explainTool(ctx context.Context, p *postgres, args map[string]any) (*mcp.To
 		explain = fmt.Sprintf("EXPLAIN (FORMAT %s) %s", format, sqlStr)
 	}
 
-	tx, err := conn.db.BeginTx(ctx, &readOnlyTx)
-	if err != nil {
-		return mcp.ErrResult(fmt.Errorf("begin transaction: %w", err))
-	}
-	defer func() { _ = tx.Rollback() }()
-
-	rows, err := tx.QueryContext(ctx, explain)
-	if err != nil {
-		return mcp.ErrResult(fmt.Errorf("explain error: %w", err))
-	}
-	defer func() { _ = rows.Close() }()
-
-	data, err := scanRows(rows)
+	data, err := conn.runner.queryReadOnly(ctx, explain)
 	if err != nil {
 		return mcp.ErrResult(err)
 	}
@@ -209,19 +185,7 @@ func selectTool(ctx context.Context, p *postgres, args map[string]any) (*mcp.Too
 		q += fmt.Sprintf(" OFFSET %d", offset)
 	}
 
-	tx, err := conn.db.BeginTx(ctx, &readOnlyTx)
-	if err != nil {
-		return mcp.ErrResult(fmt.Errorf("begin transaction: %w", err))
-	}
-	defer func() { _ = tx.Rollback() }()
-
-	rows, err := tx.QueryContext(ctx, q)
-	if err != nil {
-		return mcp.ErrResult(fmt.Errorf("query error: %w", err))
-	}
-	defer func() { _ = rows.Close() }()
-
-	data, err := scanRows(rows)
+	data, err := conn.runner.queryReadOnly(ctx, q)
 	if err != nil {
 		return mcp.ErrResult(err)
 	}

--- a/integrations/postgres/runner.go
+++ b/integrations/postgres/runner.go
@@ -1,0 +1,276 @@
+package postgres
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// runner abstracts how the adapter talks to a database. The direct
+// implementation (sqlRunner) opens a *sql.DB and runs statements locally.
+// The agent implementation (tunnelRunner) forwards read-only queries to a
+// hosted tunneld over HTTP, which relays them to a customer-side agent that
+// holds the real DSN. Both return the same JSON shapes the tools already
+// expect, so every tool works identically regardless of mode.
+type runner interface {
+	// queryRows runs a read query and returns a JSON array of row objects,
+	// matching scanRows output.
+	queryRows(ctx context.Context, query string, args ...any) (json.RawMessage, error)
+	// queryReadOnly runs a query inside a read-only transaction. Direct mode
+	// wraps it in BEGIN ... READ ONLY; agent mode relies on tunneld enforcing
+	// read-only server-side.
+	queryReadOnly(ctx context.Context, query string, args ...any) (json.RawMessage, error)
+	// queryRow runs a query and returns the first row as a JSON object (or {}).
+	queryRow(ctx context.Context, query string, args ...any) (json.RawMessage, error)
+	// exec runs a write statement. Agent mode is read-only and returns an error.
+	exec(ctx context.Context, query string, args ...any) (json.RawMessage, error)
+	// ping checks connectivity.
+	ping(ctx context.Context) error
+	// close releases resources.
+	close() error
+}
+
+// --- direct (*sql.DB) runner ---
+
+type sqlRunner struct {
+	db *sql.DB
+}
+
+func (r *sqlRunner) queryRows(ctx context.Context, query string, args ...any) (json.RawMessage, error) {
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query error: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	return scanRows(rows)
+}
+
+func (r *sqlRunner) queryReadOnly(ctx context.Context, query string, args ...any) (json.RawMessage, error) {
+	tx, err := r.db.BeginTx(ctx, &readOnlyTx)
+	if err != nil {
+		return nil, fmt.Errorf("begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	rows, err := tx.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query error: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	return scanRows(rows)
+}
+
+func (r *sqlRunner) queryRow(ctx context.Context, query string, args ...any) (json.RawMessage, error) {
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query error: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	return scanFirstRow(rows)
+}
+
+func (r *sqlRunner) exec(ctx context.Context, query string, args ...any) (json.RawMessage, error) {
+	result, err := r.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("exec error: %w", err)
+	}
+	rowsAffected, _ := result.RowsAffected()
+	data, _ := json.Marshal(map[string]any{
+		"status":        "success",
+		"rows_affected": rowsAffected,
+	})
+	return json.RawMessage(data), nil
+}
+
+func (r *sqlRunner) ping(ctx context.Context) error { return r.db.PingContext(ctx) }
+func (r *sqlRunner) close() error                   { return r.db.Close() }
+
+// --- agent (tunneld HTTP) runner ---
+
+const (
+	tunnelDefaultMaxRows   = 1000
+	tunnelDefaultTimeoutMs = 30000
+)
+
+// tunnelRunner forwards queries to a hosted tunneld /internal/query endpoint.
+// tunneld relays to the org's agent, which executes against the real database
+// in read-only mode. Writes are not possible over this path.
+type tunnelRunner struct {
+	client    *http.Client
+	endpoint  string // fully-qualified tunneld /internal/query URL
+	orgID     string
+	authToken string
+	maxRows   int
+	timeoutMs int
+}
+
+func newTunnelRunner(tunnelURL, orgID, authToken string) (*tunnelRunner, error) {
+	tunnelURL = strings.TrimSpace(tunnelURL)
+	if tunnelURL == "" {
+		return nil, fmt.Errorf("postgres: tunnel_url is required for mode=agent")
+	}
+	if strings.TrimSpace(orgID) == "" {
+		return nil, fmt.Errorf("postgres: org is required for mode=agent")
+	}
+	endpoint := strings.TrimRight(tunnelURL, "/")
+	if !strings.HasSuffix(endpoint, "/internal/query") {
+		endpoint += "/internal/query"
+	}
+	return &tunnelRunner{
+		client:    &http.Client{Timeout: 45 * time.Second},
+		endpoint:  endpoint,
+		orgID:     strings.TrimSpace(orgID),
+		authToken: strings.TrimSpace(authToken),
+		maxRows:   tunnelDefaultMaxRows,
+		timeoutMs: tunnelDefaultTimeoutMs,
+	}, nil
+}
+
+// tunnelQueryRequest mirrors the JSON the tunneld /internal/query endpoint
+// accepts. read_only is always enforced server-side, so it is not sent.
+type tunnelQueryRequest struct {
+	OrgID     string `json:"org_id"`
+	SQL       string `json:"sql"`
+	Args      []any  `json:"args,omitempty"`
+	MaxRows   int    `json:"max_rows,omitempty"`
+	TimeoutMs int    `json:"timeout_ms,omitempty"`
+}
+
+// tunnelQueryResponse mirrors tunnel.QueryResult plus the error envelope the
+// endpoint returns on failure.
+type tunnelQueryResponse struct {
+	Columns   []string `json:"columns"`
+	Rows      [][]any  `json:"rows"`
+	Truncated bool     `json:"truncated"`
+	Error     string   `json:"error"`
+}
+
+func (r *tunnelRunner) do(ctx context.Context, query string, args []any) (*tunnelQueryResponse, error) {
+	reqBody, err := json.Marshal(tunnelQueryRequest{
+		OrgID:     r.orgID,
+		SQL:       query,
+		Args:      args,
+		MaxRows:   r.maxRows,
+		TimeoutMs: r.timeoutMs,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, r.endpoint, bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if r.authToken != "" {
+		req.Header.Set("Authorization", "Bearer "+r.authToken)
+	}
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("tunnel request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 32<<20))
+	if err != nil {
+		return nil, fmt.Errorf("read tunnel response: %w", err)
+	}
+
+	var out tunnelQueryResponse
+	if len(body) > 0 {
+		if err := json.Unmarshal(body, &out); err != nil {
+			return nil, fmt.Errorf("decode tunnel response (status %d): %w", resp.StatusCode, err)
+		}
+	}
+	if resp.StatusCode != http.StatusOK {
+		if out.Error != "" {
+			return nil, fmt.Errorf("tunnel query failed: %s", out.Error)
+		}
+		return nil, fmt.Errorf("tunnel query failed: status %d", resp.StatusCode)
+	}
+	if out.Error != "" {
+		return nil, fmt.Errorf("tunnel query failed: %s", out.Error)
+	}
+	return &out, nil
+}
+
+// rowObjects converts the column/row-array tunnel response into the JSON array
+// of row objects that scanRows produces, so tool output is identical to direct
+// mode.
+func (resp *tunnelQueryResponse) rowObjects() (json.RawMessage, error) {
+	results := make([]map[string]any, 0, len(resp.Rows))
+	for _, row := range resp.Rows {
+		obj := make(map[string]any, len(resp.Columns))
+		for i, col := range resp.Columns {
+			if i < len(row) {
+				obj[col] = normalizeTunnelValue(row[i])
+			} else {
+				obj[col] = nil
+			}
+		}
+		results = append(results, obj)
+	}
+	data, err := json.Marshal(results)
+	if err != nil {
+		return nil, fmt.Errorf("marshal error: %w", err)
+	}
+	return json.RawMessage(data), nil
+}
+
+// normalizeTunnelValue mirrors scanRows' []byte -> string handling. JSON
+// decoding already yields strings/float64/bool/nil, but base64-encoded byte
+// payloads can arrive as strings; we leave them as-is to match the direct path.
+func normalizeTunnelValue(v any) any { return v }
+
+func (r *tunnelRunner) queryRows(ctx context.Context, query string, args ...any) (json.RawMessage, error) {
+	resp, err := r.do(ctx, query, args)
+	if err != nil {
+		return nil, err
+	}
+	return resp.rowObjects()
+}
+
+func (r *tunnelRunner) queryReadOnly(ctx context.Context, query string, args ...any) (json.RawMessage, error) {
+	// tunneld enforces read-only server-side, so no transaction wrapping needed.
+	return r.queryRows(ctx, query, args...)
+}
+
+func (r *tunnelRunner) queryRow(ctx context.Context, query string, args ...any) (json.RawMessage, error) {
+	resp, err := r.do(ctx, query, args)
+	if err != nil {
+		return nil, err
+	}
+	if len(resp.Rows) == 0 {
+		return json.RawMessage(`{}`), nil
+	}
+	obj := make(map[string]any, len(resp.Columns))
+	for i, col := range resp.Columns {
+		if i < len(resp.Rows[0]) {
+			obj[col] = normalizeTunnelValue(resp.Rows[0][i])
+		} else {
+			obj[col] = nil
+		}
+	}
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return nil, fmt.Errorf("marshal error: %w", err)
+	}
+	return json.RawMessage(data), nil
+}
+
+func (r *tunnelRunner) exec(_ context.Context, _ string, _ ...any) (json.RawMessage, error) {
+	return nil, fmt.Errorf("postgres: write statements are not supported over the agent tunnel (read-only)")
+}
+
+func (r *tunnelRunner) ping(ctx context.Context) error {
+	_, err := r.do(ctx, "SELECT 1", nil)
+	return err
+}
+
+func (r *tunnelRunner) close() error { return nil }

--- a/integrations/postgres/runner_test.go
+++ b/integrations/postgres/runner_test.go
@@ -1,0 +1,185 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeTunneld returns an httptest server mimicking tunneld's /internal/query
+// endpoint. The handler is supplied by each test.
+func fakeTunneld(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/internal/query", handler)
+	return httptest.NewServer(mux)
+}
+
+func TestNewTunnelRunner_Validation(t *testing.T) {
+	_, err := newTunnelRunner("", "org-1", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tunnel_url is required")
+
+	_, err = newTunnelRunner("http://x", "", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "org is required")
+}
+
+func TestNewTunnelRunner_EndpointSuffix(t *testing.T) {
+	r, err := newTunnelRunner("http://tunneld.svc:8092", "org-1", "tok")
+	require.NoError(t, err)
+	assert.Equal(t, "http://tunneld.svc:8092/internal/query", r.endpoint)
+
+	r, err = newTunnelRunner("http://tunneld.svc:8092/internal/query/", "org-1", "tok")
+	require.NoError(t, err)
+	assert.Equal(t, "http://tunneld.svc:8092/internal/query", r.endpoint)
+}
+
+func TestTunnelRunner_QueryRows_Transform(t *testing.T) {
+	srv := fakeTunneld(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "Bearer secret", r.Header.Get("Authorization"))
+		var req tunnelQueryRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		assert.Equal(t, "org-1", req.OrgID)
+		assert.Equal(t, "SELECT id, name FROM users", req.SQL)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(tunnelQueryResponse{
+			Columns:   []string{"id", "name"},
+			Rows:      [][]any{{float64(1), "alice"}, {float64(2), "bob"}},
+			Truncated: false,
+		})
+	})
+	defer srv.Close()
+
+	r, err := newTunnelRunner(srv.URL, "org-1", "secret")
+	require.NoError(t, err)
+
+	data, err := r.queryRows(context.Background(), "SELECT id, name FROM users")
+	require.NoError(t, err)
+
+	var got []map[string]any
+	require.NoError(t, json.Unmarshal(data, &got))
+	require.Len(t, got, 2)
+	assert.Equal(t, "alice", got[0]["name"])
+	assert.Equal(t, float64(1), got[0]["id"])
+	assert.Equal(t, "bob", got[1]["name"])
+}
+
+func TestTunnelRunner_QueryRows_Empty(t *testing.T) {
+	srv := fakeTunneld(t, func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(tunnelQueryResponse{Columns: []string{"id"}, Rows: nil})
+	})
+	defer srv.Close()
+
+	r, err := newTunnelRunner(srv.URL, "org-1", "")
+	require.NoError(t, err)
+
+	data, err := r.queryRows(context.Background(), "SELECT id FROM users WHERE false")
+	require.NoError(t, err)
+	assert.JSONEq(t, `[]`, string(data))
+}
+
+func TestTunnelRunner_QueryRow(t *testing.T) {
+	srv := fakeTunneld(t, func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(tunnelQueryResponse{
+			Columns: []string{"count"},
+			Rows:    [][]any{{float64(42)}},
+		})
+	})
+	defer srv.Close()
+
+	r, err := newTunnelRunner(srv.URL, "org-1", "")
+	require.NoError(t, err)
+
+	data, err := r.queryRow(context.Background(), "SELECT count(*) FROM users")
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"count":42}`, string(data))
+}
+
+func TestTunnelRunner_QueryRow_Empty(t *testing.T) {
+	srv := fakeTunneld(t, func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(tunnelQueryResponse{Columns: []string{"x"}, Rows: nil})
+	})
+	defer srv.Close()
+
+	r, err := newTunnelRunner(srv.URL, "org-1", "")
+	require.NoError(t, err)
+
+	data, err := r.queryRow(context.Background(), "SELECT x FROM t WHERE false")
+	require.NoError(t, err)
+	assert.JSONEq(t, `{}`, string(data))
+}
+
+func TestTunnelRunner_ServerError(t *testing.T) {
+	srv := fakeTunneld(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(tunnelQueryResponse{Error: "relation \"nope\" does not exist"})
+	})
+	defer srv.Close()
+
+	r, err := newTunnelRunner(srv.URL, "org-1", "")
+	require.NoError(t, err)
+
+	_, err = r.queryRows(context.Background(), "SELECT * FROM nope")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not exist")
+}
+
+func TestTunnelRunner_Exec_ReadOnly(t *testing.T) {
+	r, err := newTunnelRunner("http://x", "org-1", "")
+	require.NoError(t, err)
+	_, err = r.exec(context.Background(), "DELETE FROM users")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read-only")
+}
+
+func TestTunnelRunner_Ping(t *testing.T) {
+	var gotSQL string
+	srv := fakeTunneld(t, func(w http.ResponseWriter, r *http.Request) {
+		var req tunnelQueryRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		gotSQL = req.SQL
+		_ = json.NewEncoder(w).Encode(tunnelQueryResponse{Columns: []string{"?column?"}, Rows: [][]any{{float64(1)}}})
+	})
+	defer srv.Close()
+
+	r, err := newTunnelRunner(srv.URL, "org-1", "")
+	require.NoError(t, err)
+	require.NoError(t, r.ping(context.Background()))
+	assert.Equal(t, "SELECT 1", gotSQL)
+}
+
+func TestConfigure_AgentMode(t *testing.T) {
+	srv := fakeTunneld(t, func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(tunnelQueryResponse{Columns: []string{"?column?"}, Rows: [][]any{{float64(1)}}})
+	})
+	defer srv.Close()
+
+	p := &postgres{conns: make(map[string]*pgConn)}
+	err := p.Configure(context.Background(), mcp.Credentials{
+		"mode":       "agent",
+		"tunnel_url": srv.URL,
+		"org":        "9a7331b4-73b5-457b-affd-4592962ab6f2",
+	})
+	require.NoError(t, err)
+
+	conn, ok := p.conns["default"]
+	require.True(t, ok)
+	assert.True(t, conn.readOnly)
+	assert.Equal(t, "agent:9a7331b4-73b5-457b-affd-4592962ab6f2", conn.host)
+	assert.True(t, p.Healthy(context.Background()))
+}
+
+func TestConfigure_AgentMode_MissingTunnelURL(t *testing.T) {
+	p := &postgres{conns: make(map[string]*pgConn)}
+	err := p.Configure(context.Background(), mcp.Credentials{"mode": "agent", "org": "org-1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tunnel_url is required")
+}


### PR DESCRIPTION
## Summary
- Adds an **agent connection mode** to the Postgres integration so it can run read-only queries against a customer's database without ever holding the database credentials. The real DSN stays on the customer-side agent; queries are forwarded to a hosted relay that proxies to that agent and returns rows.
- All existing Postgres tools (`query`, `select`, `explain`, `list_tables`, etc.) work identically in agent mode. Direct connections are unchanged. Writes are rejected over the tunnel because the relay enforces read-only access.

## How it works
A new `runner` interface abstracts statement execution. `sqlRunner` is the existing direct `*sql.DB` path (byte-identical behavior, including read-only transaction wrapping). `tunnelRunner` speaks plain HTTP/JSON to the hosted relay's query endpoint and converts its column/row-array response into the same row-object JSON the tools already emit, so output is identical regardless of mode.

Agent mode is selected with credentials `mode=agent`, `tunnel_url`, `org`, and optional `tunnel_auth_token` — no DSN.

## Tests
- `runner_test.go`: tunnel request/response transform, empty results, single-row, server-error propagation, read-only write rejection, ping, endpoint normalization, and agent-mode `Configure`/`Healthy` against an httptest relay.