### PR TITLE
Fix RWX integration against live API schema

### DIFF
--- a/integrations/rwx/api.go
+++ b/integrations/rwx/api.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"mime/multipart"
 	"net/http"
 	"net/url"
 	"path"
@@ -100,11 +99,24 @@ func rwxAPIError(resp *http.Response) error {
 	return err
 }
 
+type rwxNestedStatus struct {
+	Result        string `json:"result"`
+	Execution     string `json:"execution"`
+	AbortedStatus string `json:"aborted_status"`
+}
+
 type rwxStatusResult struct {
-	RunID                     string `json:"run_id"`
-	RunIDCamel                string `json:"RunID"`
-	TaskID                    string `json:"task_id"`
-	TaskIDCamel               string `json:"TaskID"`
+	RunID       string          `json:"run_id"`
+	RunIDCamel  string          `json:"RunID"`
+	TaskID      string          `json:"task_id"`
+	TaskIDCamel string          `json:"TaskID"`
+	RunStatus   rwxNestedStatus `json:"run_status"`
+	TaskStatus  rwxNestedStatus `json:"task_status"`
+	Polling     struct {
+		Completed bool `json:"completed"`
+	} `json:"polling"`
+	// Legacy flat fields — retained for backward compatibility with any
+	// endpoint or fixture that still returns the un-nested shape.
 	ExecutionStatus           string `json:"execution_status"`
 	ExecutionStatusCamel      string `json:"ExecutionStatus"`
 	ResultStatus              string `json:"result_status"`
@@ -132,6 +144,12 @@ func (s rwxStatusResult) taskID() string {
 }
 
 func (s rwxStatusResult) executionStatus() string {
+	if s.TaskStatus.Execution != "" {
+		return s.TaskStatus.Execution
+	}
+	if s.RunStatus.Execution != "" {
+		return s.RunStatus.Execution
+	}
 	if s.ExecutionStatus != "" {
 		return s.ExecutionStatus
 	}
@@ -139,6 +157,12 @@ func (s rwxStatusResult) executionStatus() string {
 }
 
 func (s rwxStatusResult) resultStatus() string {
+	if s.TaskStatus.Result != "" {
+		return s.TaskStatus.Result
+	}
+	if s.RunStatus.Result != "" {
+		return s.RunStatus.Result
+	}
 	if s.ResultStatus != "" {
 		return s.ResultStatus
 	}
@@ -146,7 +170,17 @@ func (s rwxStatusResult) resultStatus() string {
 }
 
 func (s rwxStatusResult) completed() bool {
-	return s.Completed || s.CompletedCamel || s.executionStatus() == "finished"
+	return s.Polling.Completed || s.Completed || s.CompletedCamel || s.executionStatus() == "finished"
+}
+
+func (s rwxStatusResult) abortedSubStatus() string {
+	if s.TaskStatus.AbortedStatus != "" && s.TaskStatus.AbortedStatus != "not_applicable" {
+		return s.TaskStatus.AbortedStatus
+	}
+	if s.RunStatus.AbortedStatus != "" && s.RunStatus.AbortedStatus != "not_applicable" {
+		return s.RunStatus.AbortedStatus
+	}
+	return s.ExecutionAbortedSubStatus
 }
 
 type rwxLogDownload struct {
@@ -205,26 +239,16 @@ func (r *rwx) downloadArtifact(ctx context.Context, artifact rwxArtifactDownload
 }
 
 func (r *rwx) downloadLogArchive(ctx context.Context, request rwxLogDownload) ([]byte, error) {
-	var body bytes.Buffer
-	writer := multipart.NewWriter(&body)
-	if err := writer.WriteField("token", request.Token); err != nil {
-		return nil, err
-	}
-	if err := writer.WriteField("filename", request.Filename); err != nil {
-		return nil, err
-	}
-	if err := writer.WriteField("contents", request.Contents); err != nil {
-		return nil, err
-	}
-	if err := writer.Close(); err != nil {
-		return nil, err
-	}
+	form := url.Values{}
+	form.Set("token", request.Token)
+	form.Set("filename", request.Filename)
+	form.Set("contents", request.Contents)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, request.URL, &body)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, request.URL, strings.NewReader(form.Encode()))
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/octet-stream")
 
 	resp, err := r.client.Do(req)

--- a/integrations/rwx/api_direct_test.go
+++ b/integrations/rwx/api_direct_test.go
@@ -60,11 +60,11 @@ func TestDownloadLogs_UsesDirectAPIZipDownload(t *testing.T) {
 
 	downloadServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Contains(t, r.Header.Get("Content-Type"), "multipart/form-data")
-		require.NoError(t, r.ParseMultipartForm(1024))
-		assert.Equal(t, "tok", r.FormValue("token"))
-		assert.Equal(t, "logs.zip", r.FormValue("filename"))
-		assert.Equal(t, "contents", r.FormValue("contents"))
+		assert.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
+		require.NoError(t, r.ParseForm())
+		assert.Equal(t, "tok", r.PostFormValue("token"))
+		assert.Equal(t, "logs.zip", r.PostFormValue("filename"))
+		assert.Equal(t, "contents", r.PostFormValue("contents"))
 		_, _ = w.Write(zipData.Bytes())
 	}))
 	defer downloadServer.Close()
@@ -95,12 +95,13 @@ func TestGetArtifacts_UsesDirectAPI(t *testing.T) {
 		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
 		assert.Equal(t, "/mint/api/artifact_downloads", r.URL.Path)
 		assert.Equal(t, "run-123", r.URL.Query().Get("run_id"))
+		assert.Equal(t, "lint", r.URL.Query().Get("task_key"))
 		_, _ = w.Write([]byte(`[{"key":"coverage","filename":"coverage.txt","url":"https://example.test/download","token":"secret-token"}]`))
 	}))
 	defer ts.Close()
 
 	r := &rwx{accessToken: "test-token", org: "my-org", baseURL: ts.URL, client: ts.Client(), logCache: newLogCache()}
-	result, err := getArtifacts(context.Background(), r, map[string]any{"run_id": "run-123"})
+	result, err := getArtifacts(context.Background(), r, map[string]any{"run_id": "run-123", "task_key": "lint"})
 	require.NoError(t, err)
 	assert.False(t, result.IsError)
 
@@ -111,4 +112,12 @@ func TestGetArtifacts_UsesDirectAPI(t *testing.T) {
 	artifact := parsed["artifacts"].([]any)[0].(map[string]any)
 	assert.Equal(t, "coverage", artifact["key"])
 	assert.Nil(t, artifact["token"])
+}
+
+func TestGetArtifacts_RunIDWithoutTaskRejected(t *testing.T) {
+	r := &rwx{accessToken: "test-token", org: "my-org", baseURL: "https://cloud.rwx.com", logCache: newLogCache()}
+	result, err := getArtifacts(context.Background(), r, map[string]any{"run_id": "run-123"})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "task-scoped")
 }

--- a/integrations/rwx/extras.go
+++ b/integrations/rwx/extras.go
@@ -27,6 +27,9 @@ func getArtifacts(ctx context.Context, r *rwx, args map[string]any) (*mcp.ToolRe
 	if id == "" && taskID == "" {
 		return mcp.ErrResult(fmt.Errorf("either run_id or task_id is required"))
 	}
+	if taskID == "" && taskKey == "" {
+		return mcp.ErrResult(fmt.Errorf("artifacts are task-scoped: pass task_id, or run_id together with task_key (get failed task keys from rwx_get_run_results)"))
+	}
 	runURL := fmt.Sprintf("%s/mint/%s/runs/%s", r.baseURL, r.org, id)
 
 	query := url.Values{}

--- a/integrations/rwx/runs.go
+++ b/integrations/rwx/runs.go
@@ -398,7 +398,7 @@ func getRunResults(ctx context.Context, r *rwx, args map[string]any) (*mcp.ToolR
 	}
 	runURL := fmt.Sprintf("%s/mint/%s/runs/%s", r.baseURL, r.org, id)
 	status := normalizeStatus(statusResult.resultStatus())
-	if !statusResult.completed() && status == "unknown" {
+	if !statusResult.completed() && (status == "unknown" || status == "no_result") {
 		status = "running"
 	}
 
@@ -431,8 +431,8 @@ func getRunResults(ctx context.Context, r *rwx, args map[string]any) (*mcp.ToolR
 	if statusResult.executionStatus() != "" {
 		resp["execution_status"] = statusResult.executionStatus()
 	}
-	if statusResult.ExecutionAbortedSubStatus != "" {
-		resp["execution_aborted_sub_status"] = statusResult.ExecutionAbortedSubStatus
+	if statusResult.abortedSubStatus() != "" {
+		resp["execution_aborted_sub_status"] = statusResult.abortedSubStatus()
 	}
 
 	runDetail, detailErr := fetchRunDetail(ctx, r, id)
@@ -497,15 +497,15 @@ func parseResultsPrompt(prompt string) (tasks []failedTask, failedTests []string
 	for _, line := range lines {
 		trimmed := strings.TrimSpace(line)
 
-		if strings.HasPrefix(trimmed, "# Failed tests:") {
+		if strings.HasPrefix(trimmed, "# Failed test") {
 			section = "tests"
 			continue
 		}
-		if strings.HasPrefix(trimmed, "# Failed tasks:") {
+		if strings.HasPrefix(trimmed, "# Failed task") {
 			section = "tasks"
 			continue
 		}
-		if strings.HasPrefix(trimmed, "# Other problems:") {
+		if strings.HasPrefix(trimmed, "# Other problem") {
 			section = "problems"
 			continue
 		}

--- a/integrations/rwx/rwx_test.go
+++ b/integrations/rwx/rwx_test.go
@@ -387,6 +387,26 @@ For more documentation on the RWX CLI, see ` + "`rwx --help`" + `
 	assert.Empty(t, problems)
 }
 
+func TestParseResultsPrompt_SingularHeaders(t *testing.T) {
+	// Real RWX prompt for a single-task failure uses singular headers
+	// ("# Failed task:") and "for this task" phrasing.
+	prompt := `# Failed task:
+
+You can pull the logs for this task using ` + "`rwx logs <task-id>`" + `
+
+- database (task-id: 33912f93fb072b62652054fb663c85e9)
+
+For more documentation on the RWX CLI, see ` + "`rwx --help`" + `
+`
+	tasks, tests, problems := parseResultsPrompt(prompt)
+
+	require.Len(t, tasks, 1)
+	assert.Equal(t, "database", tasks[0].Key)
+	assert.Equal(t, "33912f93fb072b62652054fb663c85e9", tasks[0].TaskID)
+	assert.Empty(t, tests)
+	assert.Empty(t, problems)
+}
+
 func TestParseResultsPrompt_OtherProblems(t *testing.T) {
 	prompt := `# Other problems:
 
@@ -769,7 +789,13 @@ func TestGetTaskLogs_RunIDAndTaskKey(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, zw.Close())
 
-	downloadServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	downloadServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		assert.Equal(t, http.MethodPost, req.Method)
+		assert.Equal(t, "application/x-www-form-urlencoded", req.Header.Get("Content-Type"))
+		require.NoError(t, req.ParseForm())
+		assert.Equal(t, "tok", req.PostFormValue("token"))
+		assert.Equal(t, "logs.zip", req.PostFormValue("filename"))
+		assert.Equal(t, "contents", req.PostFormValue("contents"))
 		_, _ = w.Write(zipData.Bytes())
 	}))
 	defer downloadServer.Close()
@@ -815,7 +841,7 @@ func TestGetRunResults_BranchLookup(t *testing.T) {
 		switch r.URL.Path {
 		case "/mint/api/results/latest":
 			assert.Equal(t, "main", r.URL.Query().Get("branch_name"))
-			_, _ = w.Write([]byte(`{"run_id":"run-abc","result_status":"succeeded","execution_status":"finished"}`))
+			_, _ = w.Write([]byte(`{"run_id":"run-abc","run_status":{"result":"succeeded","execution":"finished"},"polling":{"completed":true}}`))
 		case "/mint/api/results/prompt":
 			_, _ = w.Write([]byte(``))
 		case "/mint/api/runs/run-abc":
@@ -839,6 +865,92 @@ func TestGetRunResults_BranchLookup(t *testing.T) {
 	assert.Equal(t, "run-abc", parsed["run_id"])
 	assert.Equal(t, "success", parsed["status"])
 	assert.Equal(t, "main", parsed["branch"])
+}
+
+func TestGetRunResults_NestedStatusFailed(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/mint/api/results/status":
+			assert.Equal(t, "run-xyz", r.URL.Query().Get("id"))
+			_, _ = w.Write([]byte(`{"run_status":{"result":"failed","execution":"finished"},"run_id":"run-xyz","polling":{"completed":true}}`))
+		case "/mint/api/results/prompt":
+			_, _ = w.Write([]byte(``))
+		case "/mint/api/runs/run-xyz":
+			_, _ = w.Write([]byte(`{"id":"run-xyz","completed_runtime_seconds":512,"title":"CI","branch":"main","commit_sha":"abc","definition_path":".rwx/ci.yml"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	r := &rwx{accessToken: "test-token", org: "org", baseURL: ts.URL, client: ts.Client(), logCache: newLogCache()}
+
+	result, err := getRunResults(context.Background(), r, map[string]any{"run_id": "run-xyz"})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.Data), &parsed))
+	assert.Equal(t, "failure", parsed["status"])
+	assert.Equal(t, true, parsed["completed"])
+}
+
+func TestGetRunResults_NestedTaskStatus(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/mint/api/results/status":
+			assert.Equal(t, "run-xyz", r.URL.Query().Get("run_id"))
+			assert.Equal(t, "database", r.URL.Query().Get("task_key"))
+			_, _ = w.Write([]byte(`{"run_status":{"result":"failed","execution":"finished"},"task_status":{"result":"failed","execution":"finished"},"run_id":"run-xyz","task_id":"task-123","polling":{"completed":true}}`))
+		case "/mint/api/results/prompt":
+			_, _ = w.Write([]byte(``))
+		case "/mint/api/runs/run-xyz":
+			_, _ = w.Write([]byte(`{"id":"run-xyz","title":"CI"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	r := &rwx{accessToken: "test-token", org: "org", baseURL: ts.URL, client: ts.Client(), logCache: newLogCache()}
+
+	result, err := getRunResults(context.Background(), r, map[string]any{"run_id": "run-xyz", "task_key": "database"})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.Data), &parsed))
+	assert.Equal(t, "failure", parsed["status"])
+	assert.Equal(t, true, parsed["completed"])
+	assert.Equal(t, "task-123", parsed["task_id"])
+	assert.Equal(t, "database", parsed["task_key"])
+}
+
+func TestGetRunResults_NestedStatusRunning(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/mint/api/results/status":
+			_, _ = w.Write([]byte(`{"run_status":{"result":"no_result"},"run_id":"run-run","polling":{"completed":false}}`))
+		case "/mint/api/results/prompt":
+			_, _ = w.Write([]byte(``))
+		case "/mint/api/runs/run-run":
+			_, _ = w.Write([]byte(`{"id":"run-run","title":"CI"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	r := &rwx{accessToken: "test-token", org: "org", baseURL: ts.URL, client: ts.Client(), logCache: newLogCache()}
+
+	result, err := getRunResults(context.Background(), r, map[string]any{"run_id": "run-run"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.Data), &parsed))
+	assert.Equal(t, "running", parsed["status"])
+	assert.Equal(t, false, parsed["completed"])
 }
 
 // --- Vault handler tests ---

--- a/integrations/rwx/tools.go
+++ b/integrations/rwx/tools.go
@@ -108,13 +108,13 @@ var tools = []mcp.ToolDefinition{
 	// ── Artifacts ───────────────────────────────────────────────────
 	{
 		Name:        mcp.ToolName("rwx_get_artifacts"),
-		Description: "List or download artifacts for a run directly from the RWX API. Listed results omit download tokens; download=true fetches artifact content.",
+		Description: "List or download CI/CD artifacts directly from the RWX API. Artifacts are task-scoped: pass task_id, or run_id together with task_key (get failed task keys from rwx_get_run_results). Listed results omit download tokens; download=true fetches artifact content.",
 		Parameters: map[string]string{
-			"run_id":       "RWX run ID or full URL to get artifacts for",
+			"run_id":       "RWX run ID or full URL (must be combined with task_key)",
 			"download":     "Download artifacts (true/false, default: false — just list)",
 			"artifact_key": "Specific artifact key to download (optional, downloads all if not specified)",
-			"task_id":      "RWX task ID or task URL to list/download artifacts for a specific task (optional)",
-			"task_key":     "Task key to list/download artifacts for a task within run_id (optional)",
+			"task_id":      "RWX task ID or task URL to list/download artifacts for a specific task",
+			"task_key":     "Task key to list/download artifacts for a task within run_id (e.g. from rwx_get_run_results failed_tasks)",
 		},
 	},
 


### PR DESCRIPTION
## Summary

The RWX read-path tools were validated only against fixtures that used a flat status schema the real API never returns — so every tool failed in production despite green tests. Discovered while running a full monitor/troubleshoot pass against a real failed run.

- **`rwx_get_run_results`**: parse nested `run_status`/`task_status`/`polling` instead of flat `result_status`/`completed`. Failed runs were misreported as `running` and never flagged as errors.
- **`parseResultsPrompt`**: match singular `# Failed task:` headers so `failed_tasks` (and their task-ids) surface for single-failure runs — previously agents got no task-id to pull logs.
- **`downloadLogArchive`**: POST `application/x-www-form-urlencoded` (the archive endpoint rejects multipart), fixing all log tools (`get`/`grep`/`tail`/`head`) which were 500ing.
- **`rwx_get_artifacts`**: artifacts are task-scoped; require `task_id` or `run_id`+`task_key` and clarify the description (run_id-only returned a confusing "Task not found").

## Test plan

- [x] `make ci` (build, vet, race tests, lint, security) passes
- [x] Tests updated to use the real nested schema and assert the urlencoded log-download request
- [x] Validated live end-to-end through the local switchboard MCP: recent runs → run results (`failure`/`completed`, populated `failed_tasks`) → task logs pinpointing the root cause

💘 Generated with Crush