### PR TITLE
feat(server): allow appending deployment-specific MCP instructions

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -69,21 +69,36 @@ const (
 
 // Server wraps the MCP SDK server and exposes search/execute tools.
 type Server struct {
-	mcpServer        *mcpsdk.Server
-	services         *mcp.Services
-	scriptEngine     *script.Engine
-	sessionStore     SessionStore
-	retryBackoff     time.Duration
-	breakers         map[string]*breaker
-	breakerThreshold int
-	breakerCooldown  time.Duration
-	searchMu         sync.RWMutex
-	idf              map[string]float64
-	synMap           map[string][]string
-	allTools         []toolWithIntegration // pre-indexed tools with token sets
-	catalogBytes     int64                 // byte size of full tool catalog (for savings accounting)
-	discoverAll      bool
+	mcpServer         *mcpsdk.Server
+	services          *mcp.Services
+	scriptEngine      *script.Engine
+	sessionStore      SessionStore
+	retryBackoff      time.Duration
+	breakers          map[string]*breaker
+	breakerThreshold  int
+	breakerCooldown   time.Duration
+	searchMu          sync.RWMutex
+	idf               map[string]float64
+	synMap            map[string][]string
+	allTools          []toolWithIntegration // pre-indexed tools with token sets
+	catalogBytes      int64                 // byte size of full tool catalog (for savings accounting)
+	discoverAll       bool
+	extraInstructions string // appended to the base MCP instructions
 }
+
+// baseInstructions is the default guidance sent to clients in the MCP
+// initialize response. Deployments can append deployment-specific guidance
+// (e.g. "this org has private tunnels") via WithExtraInstructions.
+const baseInstructions = "Switchboard aggregates tools from multiple integrations " +
+	"behind two meta-tools: search and execute. " +
+	"Always search before calling execute — do not guess tool names. " +
+	"Search uses synonym matching, so short keyword queries work best " +
+	"(e.g., {\"query\": \"get page\"} finds notion_retrieve_page). " +
+	"Use the session tool to set context (e.g., owner/repo) once — " +
+	"subsequent execute calls auto-inject those values as defaults. " +
+	"Use the history tool to review prior calls after context compression. " +
+	"Every execute result is auto-pinned ($1, $2, ...) — use pin to retrieve or " +
+	"pass handles like $1.field in execute arguments to reference previous results."
 
 // Option configures optional Server behavior.
 type Option func(*Server)
@@ -107,31 +122,20 @@ func WithSessionStore(store SessionStore) Option {
 	return func(s *Server) { s.sessionStore = store }
 }
 
+// WithExtraInstructions appends deployment-specific guidance to the base MCP
+// instructions returned in the initialize response. Hosted deployments use
+// this to tell clients about capabilities that only exist for some orgs — for
+// example that an org has private-resource tunnels and how to target them.
+// The text is appended after the base instructions, separated by a space.
+func WithExtraInstructions(text string) Option {
+	return func(s *Server) { s.extraInstructions = strings.TrimSpace(text) }
+}
+
 // New creates a Server that exposes two MCP tools — search and execute —
 // following the Cloudflare "code mode" pattern for progressive discovery
 // and efficient tool execution.
 func New(services *mcp.Services, opts ...Option) *Server {
-	mcpServer := mcpsdk.NewServer(
-		&mcpsdk.Implementation{
-			Name:    "switchboard",
-			Version: version.String(),
-		},
-		&mcpsdk.ServerOptions{
-			Instructions: "Switchboard aggregates tools from multiple integrations " +
-				"behind two meta-tools: search and execute. " +
-				"Always search before calling execute — do not guess tool names. " +
-				"Search uses synonym matching, so short keyword queries work best " +
-				"(e.g., {\"query\": \"get page\"} finds notion_retrieve_page). " +
-				"Use the session tool to set context (e.g., owner/repo) once — " +
-				"subsequent execute calls auto-inject those values as defaults. " +
-				"Use the history tool to review prior calls after context compression. " +
-				"Every execute result is auto-pinned ($1, $2, ...) — use pin to retrieve or " +
-				"pass handles like $1.field in execute arguments to reference previous results.",
-		},
-	)
-
 	s := &Server{
-		mcpServer:        mcpServer,
 		services:         services,
 		sessionStore:     NewMemorySessionStore(DefaultSessionTTL),
 		retryBackoff:     500 * time.Millisecond,
@@ -142,6 +146,19 @@ func New(services *mcp.Services, opts ...Option) *Server {
 	for _, opt := range opts {
 		opt(s)
 	}
+
+	instructions := baseInstructions
+	if s.extraInstructions != "" {
+		instructions += " " + s.extraInstructions
+	}
+	s.mcpServer = mcpsdk.NewServer(
+		&mcpsdk.Implementation{
+			Name:    "switchboard",
+			Version: version.String(),
+		},
+		&mcpsdk.ServerOptions{Instructions: instructions},
+	)
+
 	s.scriptEngine = script.New(&toolExecutor{server: s})
 
 	s.registerTools()

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -3682,3 +3682,47 @@ func mustMarshal(v any) json.RawMessage {
 	}
 	return data
 }
+
+func TestWithExtraInstructions(t *testing.T) {
+	extra := "This org has private-resource tunnels; pass agent_id to target one."
+
+	cases := []struct {
+		name      string
+		opts      []Option
+		wantExtra bool
+	}{
+		{name: "default has no extra", opts: nil, wantExtra: false},
+		{name: "extra appended", opts: []Option{WithExtraInstructions(extra)}, wantExtra: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			services := &mcp.Services{
+				Config:   newMockConfigService(nil),
+				Registry: newMockRegistry(),
+			}
+			s := New(services, tc.opts...)
+
+			clientTransport, serverTransport := mcpsdk.NewInMemoryTransports()
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			ss, err := s.mcpServer.Connect(ctx, serverTransport, nil)
+			require.NoError(t, err)
+			defer ss.Close() //nolint:errcheck
+
+			client := mcpsdk.NewClient(&mcpsdk.Implementation{Name: "test", Version: "1.0"}, nil)
+			cs, err := client.Connect(ctx, clientTransport, nil)
+			require.NoError(t, err)
+			defer cs.Close() //nolint:errcheck
+
+			got := cs.InitializeResult().Instructions
+			assert.Contains(t, got, "search and execute", "base instructions must always be present")
+			if tc.wantExtra {
+				assert.Contains(t, got, extra, "extra instructions should be appended")
+			} else {
+				assert.NotContains(t, got, extra)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why

The MCP `initialize` response tells connecting clients how to use the gateway (search before execute, session context, pinning, etc.). That guidance was fixed, so a deployment had no way to add notes that only apply to some tenants — for example that a particular organization has private-resource tunnels and how to target a specific one.

## What changed

- Add a `WithExtraInstructions(text)` server option that appends deployment-specific guidance to the standard instructions.
- The open-source default is unchanged: with no option set, clients receive exactly the same instructions as before.

## Tests

Added a test that drives the initialize handshake over an in-memory transport and asserts the base instructions are always present and that supplied extra text is appended only when the option is used.

## Context

Enables a hosted deployment to tell assistants, per organization, that private tunnels exist and how to reach them — the client-facing half of making multi-tunnel querying discoverable.

💘 Generated with Crush