### PR TITLE
Add bounded per-request timeouts for WASM HTTP calls

### DIFF
--- a/wasm/host.go
+++ b/wasm/host.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/tetratelabs/wazero/api"
@@ -43,13 +44,23 @@ const h2cHeaderKey = "X-H2C"
 // string in the body field. Required for binary payloads (protobuf, images, etc.).
 const rawBodyHeaderKey = "X-Raw-Body"
 
+// hostTimeoutHeaderKey lets trusted WASM plugins extend one outbound request
+// beyond the default timeout without slowing every integration. The header is
+// consumed by the host and never forwarded upstream.
+const hostTimeoutHeaderKey = "X-Host-Timeout-Seconds"
+
+const (
+	defaultHostHTTPTimeout = 60 * time.Second
+	maxHostHTTPTimeout     = 300 * time.Second
+)
+
 var (
-	hostHTTPClient = &http.Client{Timeout: 60 * time.Second}
+	hostHTTPClient = &http.Client{Timeout: defaultHostHTTPTimeout}
 
 	// h2cClient uses an http2.Transport configured for cleartext (no TLS)
 	// connections. Plugins opt in by setting the X-H2C header.
 	h2cClient = &http.Client{
-		Timeout: 60 * time.Second,
+		Timeout: defaultHostHTTPTimeout,
 		Transport: &http2.Transport{
 			AllowHTTP: true,
 			DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
@@ -112,8 +123,9 @@ func doHostHTTP(ctx context.Context, req *httpRequest) (*httpResponse, error) {
 	// Check for control headers before copying to the outgoing request.
 	useH2C := req.Headers[h2cHeaderKey] != ""
 	rawBody := req.Headers[rawBodyHeaderKey] != ""
+	timeout := hostHTTPTimeout(req.Headers[hostTimeoutHeaderKey])
 	for k, v := range req.Headers {
-		if k == h2cHeaderKey || k == rawBodyHeaderKey {
+		if k == h2cHeaderKey || k == rawBodyHeaderKey || k == hostTimeoutHeaderKey {
 			continue
 		}
 		httpReq.Header.Set(k, v)
@@ -123,8 +135,10 @@ func doHostHTTP(ctx context.Context, req *httpRequest) (*httpResponse, error) {
 	if useH2C {
 		client = h2cClient
 	}
+	clientCopy := *client
+	clientCopy.Timeout = timeout
 
-	resp, err := client.Do(httpReq)
+	resp, err := clientCopy.Do(httpReq)
 	if err != nil {
 		return nil, err
 	}
@@ -150,6 +164,18 @@ func doHostHTTP(ctx context.Context, req *httpRequest) (*httpResponse, error) {
 		result.Body = string(body)
 	}
 	return result, nil
+}
+
+func hostHTTPTimeout(raw string) time.Duration {
+	seconds, err := strconv.Atoi(raw)
+	if err != nil || seconds <= 0 {
+		return defaultHostHTTPTimeout
+	}
+	timeout := time.Duration(seconds) * time.Second
+	if timeout > maxHostHTTPTimeout {
+		return maxHostHTTPTimeout
+	}
+	return timeout
 }
 
 func writeErrorResponse(ctx context.Context, mod api.Module, msg string) uint64 {

--- a/wasm/host_test.go
+++ b/wasm/host_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"testing"
+	"time"
 
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
@@ -72,6 +73,72 @@ func TestDoHostHTTP_H2C_HeaderNotForwarded(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("doHostHTTP: %v", err)
+	}
+}
+
+func TestDoHostHTTP_PerRequestTimeout(t *testing.T) {
+	base := newH2CServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(1500 * time.Millisecond)
+		_, _ = w.Write([]byte("ok"))
+	}))
+
+	_, err := doHostHTTP(context.Background(), &httpRequest{
+		Method:  "GET",
+		URL:     base + "/slow",
+		Headers: map[string]string{hostTimeoutHeaderKey: "1"},
+	})
+	if err == nil {
+		t.Fatal("expected one-second timeout")
+	}
+
+	resp, err := doHostHTTP(context.Background(), &httpRequest{
+		Method:  "GET",
+		URL:     base + "/slow",
+		Headers: map[string]string{hostTimeoutHeaderKey: "2"},
+	})
+	if err != nil {
+		t.Fatalf("two-second override should succeed: %v", err)
+	}
+	if resp.Body != "ok" {
+		t.Errorf("body = %q, want ok", resp.Body)
+	}
+}
+
+func TestDoHostHTTP_TimeoutHeaderNotForwarded(t *testing.T) {
+	base := newH2CServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if v := r.Header.Get(hostTimeoutHeaderKey); v != "" {
+			t.Errorf("timeout control header leaked upstream: %q", v)
+		}
+		_, _ = w.Write([]byte("ok"))
+	}))
+
+	_, err := doHostHTTP(context.Background(), &httpRequest{
+		Method:  "GET",
+		URL:     base + "/test",
+		Headers: map[string]string{hostTimeoutHeaderKey: "300"},
+	})
+	if err != nil {
+		t.Fatalf("doHostHTTP: %v", err)
+	}
+}
+
+func TestHostHTTPTimeoutClamps(t *testing.T) {
+	cases := []struct {
+		value string
+		want  time.Duration
+	}{
+		{"", 60 * time.Second},
+		{"invalid", 60 * time.Second},
+		{"0", 60 * time.Second},
+		{"120", 120 * time.Second},
+		{"999", 300 * time.Second},
+	}
+	for _, tc := range cases {
+		t.Run(tc.value, func(t *testing.T) {
+			if got := hostHTTPTimeout(tc.value); got != tc.want {
+				t.Errorf("hostHTTPTimeout(%q) = %s, want %s", tc.value, got, tc.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- WASM integrations currently share a hard 60-second HTTP client timeout, which forces long-running tools to poll even when their upstream API supports a longer blocking request.
- Add an opt-in `X-Host-Timeout-Seconds` control header. It applies only to that host request, defaults to 60 seconds when absent/invalid, and is capped at 300 seconds.
- Consume the control header in the host so it is never leaked to upstream services; both HTTP/1.1 and h2c transports retain their existing defaults.

## Why

Overmind's child-agent cohort endpoint can wait for specialists server-side, but must currently return after 55 seconds to stay below this 60-second host limit. A bounded per-request override lets that one tool wait nearly five minutes without making every GitHub, Slack, or other integration call slower to fail.

## Test plan

- [x] Override times out a deliberately slow request at one second
- [x] The same request succeeds with a two-second override
- [x] Control header is not forwarded upstream
- [x] Invalid/zero values retain the 60-second default
- [x] Values above 300 seconds are clamped
- [x] `make ci`