### PR TITLE
Fix invalid JSON in Crush review config

### DIFF
--- a/.ci/crush/crush.json
+++ b/.ci/crush/crush.json
@@ -18,7 +18,7 @@
       "base_url": "https://gateway.ai.cloudflare.com/v1/${CF_AIG_ACCOUNT_ID:?set CF_AIG_ACCOUNT_ID}/${CF_AIG_GATEWAY_ID:?set CF_AIG_GATEWAY_ID}/grok",
       "api_key": "${CF_AIG_TOKEN:?set CF_AIG_TOKEN to your Cloudflare AI Gateway token}",
       "extra_headers": {
-        "cf-aig-metadata": "{"developer_id": "austin.cherry", "tier": "frontier"}",
+        "cf-aig-metadata": "{\"developer_id\": \"austin.cherry\", \"tier\": \"frontier\"}",
         "cf-aig-collect-log-payload": "false"
       },
       "models": [


### PR DESCRIPTION
## Summary
- Restores escaped quotes in `.ci/crush/crush.json` `cf-aig-metadata`
- Keeps Grok 4.5 as the Crush PR review large model

## Why
#209 switched the review model to Grok 4.5 but dropped backslash escapes in the metadata JSON string, making `crush.json` invalid. That would break Crush PR reviews once they load the config.

## Test plan
- [x] `python3 -m json.tool .ci/crush/crush.json` succeeds
- [ ] Merge, then re-trigger Crush reviews on open integration PRs