### PR TITLE
Decouple app sessions from MCP transport session ids

### DIFF
--- a/docs/stateful-features.md
+++ b/docs/stateful-features.md
@@ -81,9 +81,12 @@ if sess := s.sessionFromCtx(ctx); sess != nil {
 ```
 
 #### Transport Binding
-- **HTTP**: Enable stateful mode on `StreamableHTTPHandler` (remove `Stateless: true`). Use `Mcp-Session-Id` header from go-sdk. Map SDK session ID → our `Session`.
-- **Stdio**: Single implicit session (keyed by a constant ID like `"stdio"`). Created on first request, lives for process lifetime.
-- **ProjectRouter**: Session context merges *after* project defaults, so project defaults take precedence over session context but explicit args override both.
+App sessions are **independent of the MCP transport session**. go-sdk 1.7+ Stateless mode no longer honors `Mcp-Session-Id`, so Switchboard keys pin/context/history itself:
+
+- **HTTP**: Keep `Stateless: true` (required for multi-replica). Clients send `X-Switchboard-Session-Id` (UUID per conversation). Fallback order: app header → `Mcp-Session-Id` (legacy) → `"default"`.
+- **Stdio**: Single implicit session (keyed by `"default"` / process lifetime). Optional: set id via context for tests.
+- **Multi-replica (hosted)**: plug a shared `SessionStore` (Redis) via `WithSessionStore`; OSS local binary keeps in-memory.
+- **ProjectRouter**: same app-session resolution; session context merges *after* project defaults.
 
 #### Implementation Steps
 1. [ ] Create `server/session.go` — `Session`, `SessionStore` with TTL-based expiry (background goroutine or lazy eviction)

--- a/server/project_server.go
+++ b/server/project_server.go
@@ -67,7 +67,7 @@ func (pr *ProjectRouter) Handler() http.Handler {
 			return
 		}
 
-		handler := mcpsdk.NewStreamableHTTPHandler(
+		handler := AppSessionMiddleware(mcpsdk.NewStreamableHTTPHandler(
 			func(_ *http.Request) *mcpsdk.Server {
 				return srv.mcpSrv
 			},
@@ -75,7 +75,7 @@ func (pr *ProjectRouter) Handler() http.Handler {
 				Stateless: true,
 				Logger:    slog.Default(),
 			},
-		)
+		))
 		handler.ServeHTTP(w, r)
 	})
 }

--- a/server/server.go
+++ b/server/server.go
@@ -783,10 +783,7 @@ func (s *Server) handleExecute(ctx context.Context, req *mcpsdk.CallToolRequest)
 		args.Arguments = map[string]any{}
 	}
 
-	sess := sessionFromCtx(ctx)
-	if sess == nil {
-		sess = s.sessionStore.GetOrCreate(sessionIDFromReq(req.Session))
-	}
+	sess := s.sessionFor(ctx, req)
 	resolveRefs(sess, args.Arguments)
 	args.Arguments = sess.MergeDefaults(args.Arguments)
 
@@ -1537,23 +1534,29 @@ func (te *toolExecutor) ExecuteRendered(ctx context.Context, toolName mcp.ToolNa
 }
 
 // Handler returns an http.Handler that serves MCP over streamable HTTP transport.
+// App session ids (pin/context/history) are resolved via X-Switchboard-Session-Id
+// when present; see AppSessionMiddleware and resolveAppSessionID.
 func (s *Server) Handler() http.Handler {
-	return mcpsdk.NewStreamableHTTPHandler(
+	return AppSessionMiddleware(mcpsdk.NewStreamableHTTPHandler(
 		func(r *http.Request) *mcpsdk.Server {
 			return s.mcpServer
 		},
 		&mcpsdk.StreamableHTTPOptions{
 			Logger: slog.Default(),
 		},
-	)
+	))
 }
 
 // StatelessHandler returns an http.Handler that serves MCP over streamable HTTP
-// transport in stateless mode. Every request is handled independently with no
-// session state retained across calls, which makes it safe to deploy behind a
-// load balancer with multiple replicas (no session affinity required).
+// transport in stateless mode. Transport-level session state is not retained
+// across calls, so it is safe behind a load balancer without session affinity.
+//
+// Switchboard app sessions (pin/context/history) are still keyed by
+// X-Switchboard-Session-Id (or legacy Mcp-Session-Id). Pair with a shared
+// SessionStore in multi-replica deployments; the default in-memory store is
+// process-local.
 func (s *Server) StatelessHandler() http.Handler {
-	return mcpsdk.NewStreamableHTTPHandler(
+	return AppSessionMiddleware(mcpsdk.NewStreamableHTTPHandler(
 		func(r *http.Request) *mcpsdk.Server {
 			return s.mcpServer
 		},
@@ -1561,7 +1564,7 @@ func (s *Server) StatelessHandler() http.Handler {
 			Stateless: true,
 			Logger:    slog.Default(),
 		},
-	)
+	))
 }
 
 // RunStdio starts the MCP server over stdio transport.

--- a/server/session_codec.go
+++ b/server/session_codec.go
@@ -1,8 +1,11 @@
 package server
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -21,32 +24,49 @@ type sessionSnapshot struct {
 }
 
 // EncodeSession serializes a Session (including pins) to JSON for durable stores.
+// Field snapshots are copied under the session lock so marshal does not block
+// concurrent PinResult/SetContext on large pin payloads.
 func EncodeSession(s *Session) ([]byte, error) {
 	if s == nil {
 		return nil, fmt.Errorf("encode session: nil")
 	}
 	s.mu.RLock()
-	defer s.mu.RUnlock()
-
 	snap := sessionSnapshot{
-		ID:          s.ID,
-		Context:     s.Context,
-		CreatedAt:   s.CreatedAt,
-		LastUsed:    s.LastUsed,
-		Breadcrumbs: s.Breadcrumbs,
-		NextSeq:     s.nextSeq,
-		NextHandle:  s.nextHandle,
-		PinnedSize:  s.pinnedSize,
+		ID:         s.ID,
+		CreatedAt:  s.CreatedAt,
+		LastUsed:   s.LastUsed,
+		NextSeq:    s.nextSeq,
+		NextHandle: s.nextHandle,
+		PinnedSize: s.pinnedSize,
+	}
+	if len(s.Context) > 0 {
+		snap.Context = make(map[string]any, len(s.Context))
+		for k, v := range s.Context {
+			snap.Context[k] = v
+		}
+	} else {
+		snap.Context = map[string]any{}
+	}
+	if len(s.Breadcrumbs) > 0 {
+		snap.Breadcrumbs = make([]Breadcrumb, len(s.Breadcrumbs))
+		copy(snap.Breadcrumbs, s.Breadcrumbs)
 	}
 	if len(s.pinned) > 0 {
 		snap.Pinned = make(map[string]*PinnedResult, len(s.pinned))
 		for k, v := range s.pinned {
-			snap.Pinned[k] = v
+			if v == nil {
+				continue
+			}
+			// Deep-copy pin payload so marshal is independent of the live map.
+			cp := *v
+			if len(v.Data) > 0 {
+				cp.Data = bytes.Clone(v.Data)
+			}
+			snap.Pinned[k] = &cp
 		}
 	}
-	if snap.Context == nil {
-		snap.Context = map[string]any{}
-	}
+	s.mu.RUnlock()
+
 	return json.Marshal(snap)
 }
 
@@ -89,6 +109,16 @@ func DecodeSession(id string, data []byte) (*Session, error) {
 		for _, pr := range s.pinned {
 			if pr != nil {
 				s.pinnedSize += pr.SizeBytes
+			}
+		}
+	}
+	// Recover nextHandle so the next PinResult does not reuse $N.
+	if s.nextHandle == 0 && len(s.pinned) > 0 {
+		for h := range s.pinned {
+			if strings.HasPrefix(h, "$") {
+				if n, err := strconv.Atoi(h[1:]); err == nil && n > s.nextHandle {
+					s.nextHandle = n
+				}
 			}
 		}
 	}

--- a/server/session_codec.go
+++ b/server/session_codec.go
@@ -1,0 +1,102 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// sessionSnapshot is the durable wire form of a Session, including pins.
+// Used by external SessionStore backends (Redis, etc.) and by tests.
+type sessionSnapshot struct {
+	ID          string                   `json:"id"`
+	Context     map[string]any           `json:"context"`
+	CreatedAt   time.Time                `json:"created_at"`
+	LastUsed    time.Time                `json:"last_used"`
+	Breadcrumbs []Breadcrumb             `json:"breadcrumbs,omitempty"`
+	NextSeq     int                      `json:"next_seq"`
+	Pinned      map[string]*PinnedResult `json:"pinned,omitempty"`
+	NextHandle  int                      `json:"next_handle"`
+	PinnedSize  int                      `json:"pinned_size"`
+}
+
+// EncodeSession serializes a Session (including pins) to JSON for durable stores.
+func EncodeSession(s *Session) ([]byte, error) {
+	if s == nil {
+		return nil, fmt.Errorf("encode session: nil")
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	snap := sessionSnapshot{
+		ID:          s.ID,
+		Context:     s.Context,
+		CreatedAt:   s.CreatedAt,
+		LastUsed:    s.LastUsed,
+		Breadcrumbs: s.Breadcrumbs,
+		NextSeq:     s.nextSeq,
+		NextHandle:  s.nextHandle,
+		PinnedSize:  s.pinnedSize,
+	}
+	if len(s.pinned) > 0 {
+		snap.Pinned = make(map[string]*PinnedResult, len(s.pinned))
+		for k, v := range s.pinned {
+			snap.Pinned[k] = v
+		}
+	}
+	if snap.Context == nil {
+		snap.Context = map[string]any{}
+	}
+	return json.Marshal(snap)
+}
+
+// DecodeSession rebuilds a Session from EncodeSession JSON.
+// id is the store key; if the payload carries a different ID it is ignored
+// in favor of the store key so key renames stay consistent.
+func DecodeSession(id string, data []byte) (*Session, error) {
+	if len(data) == 0 {
+		return nil, fmt.Errorf("decode session: empty payload")
+	}
+	var snap sessionSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return nil, fmt.Errorf("decode session: %w", err)
+	}
+	if id == "" {
+		id = snap.ID
+	}
+	if id == "" {
+		return nil, fmt.Errorf("decode session: missing id")
+	}
+	s := &Session{
+		ID:          id,
+		Context:     snap.Context,
+		CreatedAt:   snap.CreatedAt,
+		LastUsed:    snap.LastUsed,
+		Breadcrumbs: snap.Breadcrumbs,
+		nextSeq:     snap.NextSeq,
+		pinned:      snap.Pinned,
+		nextHandle:  snap.NextHandle,
+		pinnedSize:  snap.PinnedSize,
+	}
+	if s.Context == nil {
+		s.Context = make(map[string]any)
+	}
+	if s.pinned == nil {
+		s.pinned = make(map[string]*PinnedResult)
+	}
+	// Recompute pinned size if the snapshot omitted it or drifted.
+	if s.pinnedSize == 0 && len(s.pinned) > 0 {
+		for _, pr := range s.pinned {
+			if pr != nil {
+				s.pinnedSize += pr.SizeBytes
+			}
+		}
+	}
+	if s.CreatedAt.IsZero() {
+		s.CreatedAt = time.Now()
+	}
+	if s.LastUsed.IsZero() {
+		s.LastUsed = s.CreatedAt
+	}
+	return s, nil
+}

--- a/server/session_codec_test.go
+++ b/server/session_codec_test.go
@@ -64,3 +64,23 @@ func TestDecodeSession_PreservesTimestamps(t *testing.T) {
 	assert.True(t, got.CreatedAt.Equal(created))
 	assert.True(t, got.LastUsed.Equal(created.Add(time.Hour)))
 }
+
+func TestDecodeSession_RecoversNextHandle(t *testing.T) {
+	// Snapshot with pins but next_handle omitted (0).
+	raw := []byte(`{
+		"id":"h",
+		"context":{},
+		"created_at":"2026-01-01T00:00:00Z",
+		"last_used":"2026-01-01T00:00:00Z",
+		"pinned":{"$3":{"handle":"$3","tool":"t","data":{"x":1},"pinned_at":"2026-01-01T00:00:00Z","size_bytes":7}},
+		"next_handle":0,
+		"pinned_size":0
+	}`)
+	got, err := DecodeSession("h", raw)
+	require.NoError(t, err)
+	assert.Equal(t, 3, got.nextHandle)
+	handle := got.PinResult("t2", `{"y":2}`)
+	assert.Equal(t, "$4", handle)
+	_, ok := got.GetPinned("$3")
+	assert.True(t, ok)
+}

--- a/server/session_codec_test.go
+++ b/server/session_codec_test.go
@@ -1,0 +1,66 @@
+package server
+
+import (
+	"testing"
+	"time"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodeDecodeSession_RoundTrip(t *testing.T) {
+	s := newSession("roundtrip")
+	s.SetContext(map[string]any{"owner": "daltoniam", "repo": "switchboard"})
+	s.AddBreadcrumb("github_list_issues", map[string]any{"state": "open"}, `[{"n":1}]`, false)
+	handle := s.PinResult("github_list_issues", `{"items":[1,2,3]}`)
+	assert.Equal(t, "$1", handle)
+
+	raw, err := EncodeSession(s)
+	require.NoError(t, err)
+
+	got, err := DecodeSession("roundtrip", raw)
+	require.NoError(t, err)
+	assert.Equal(t, "roundtrip", got.ID)
+	assert.Equal(t, "daltoniam", got.GetContext()["owner"])
+	assert.Equal(t, 1, got.TotalBreadcrumbs())
+	assert.Equal(t, 1, got.PinnedCount())
+
+	pr, ok := got.GetPinned("$1")
+	require.True(t, ok)
+	assert.Equal(t, mcp.ToolName("github_list_issues"), pr.Tool)
+	assert.JSONEq(t, `{"items":[1,2,3]}`, string(pr.Data))
+
+	// Store key wins over payload id.
+	renamed, err := DecodeSession("other-id", raw)
+	require.NoError(t, err)
+	assert.Equal(t, "other-id", renamed.ID)
+}
+
+func TestEncodeSession_Nil(t *testing.T) {
+	_, err := EncodeSession(nil)
+	require.Error(t, err)
+}
+
+func TestDecodeSession_Empty(t *testing.T) {
+	_, err := DecodeSession("x", nil)
+	require.Error(t, err)
+	_, err = DecodeSession("x", []byte{})
+	require.Error(t, err)
+}
+
+func TestDecodeSession_PreservesTimestamps(t *testing.T) {
+	created := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	s := &Session{
+		ID:        "ts",
+		Context:   map[string]any{},
+		CreatedAt: created,
+		LastUsed:  created.Add(time.Hour),
+	}
+	raw, err := EncodeSession(s)
+	require.NoError(t, err)
+	got, err := DecodeSession("ts", raw)
+	require.NoError(t, err)
+	assert.True(t, got.CreatedAt.Equal(created))
+	assert.True(t, got.LastUsed.Equal(created.Add(time.Hour)))
+}

--- a/server/session_context.go
+++ b/server/session_context.go
@@ -107,12 +107,6 @@ func sessionIDFromMCPSession(ss *mcpsdk.ServerSession) string {
 	return defaultSessionID
 }
 
-// sessionIDFromReq is retained for call sites and tests that only have a
-// ServerSession. Prefer resolveAppSessionID when a CallToolRequest is available.
-func sessionIDFromReq(ss *mcpsdk.ServerSession) string {
-	return sessionIDFromMCPSession(ss)
-}
-
 // sessionFor returns the Session bound to this tool call, creating it if needed.
 func (s *Server) sessionFor(ctx context.Context, req *mcpsdk.CallToolRequest) *Session {
 	if sess := sessionFromCtx(ctx); sess != nil {

--- a/server/session_context.go
+++ b/server/session_context.go
@@ -2,11 +2,29 @@ package server
 
 import (
 	"context"
+	"net/http"
+	"strings"
 
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+// AppSessionIDHeader is the HTTP header clients should send to identify a
+// Switchboard app session (pin / context / history). It is independent of the
+// MCP transport session (Mcp-Session-Id), which go-sdk 1.7+ Stateless mode
+// no longer honors.
+//
+// Clients that manage conversation state (e.g. Crush) should mint a UUID per
+// conversation and send it on every MCP request. Legacy clients that still
+// receive Mcp-Session-Id continue to work via the fallback below.
+const AppSessionIDHeader = "X-Switchboard-Session-Id"
+
+// mcpSessionIDHeader is the transport-level session header from the MCP
+// streamable HTTP transport. Kept as a named constant so resolution stays in
+// one place when go-sdk renames or deprecates it.
+const mcpSessionIDHeader = "Mcp-Session-Id"
+
 type sessionContextKey struct{}
+type appSessionIDKey struct{}
 
 func withSession(ctx context.Context, s *Session) context.Context {
 	return context.WithValue(ctx, sessionContextKey{}, s)
@@ -17,9 +35,69 @@ func sessionFromCtx(ctx context.Context) *Session {
 	return s
 }
 
+// WithAppSessionID stores an app session id on the context. Used by
+// AppSessionMiddleware and by tests that bypass HTTP.
+func WithAppSessionID(ctx context.Context, id string) context.Context {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, appSessionIDKey{}, id)
+}
+
+// AppSessionIDFromCtx returns the app session id previously stored with
+// WithAppSessionID, or "" if none is set.
+func AppSessionIDFromCtx(ctx context.Context) string {
+	id, _ := ctx.Value(appSessionIDKey{}).(string)
+	return id
+}
+
 const defaultSessionID = "default"
 
-func sessionIDFromReq(ss *mcpsdk.ServerSession) string {
+// AppSessionMiddleware copies X-Switchboard-Session-Id from the HTTP request
+// onto the request context so tool handlers can resolve app sessions even
+// when the MCP transport session id is empty (go-sdk Stateless mode).
+//
+// Wrap StatelessHandler / Handler with this when serving over HTTP. The
+// go-sdk streamable transport propagates req.Context() into tool handlers.
+func AppSessionMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if id := strings.TrimSpace(r.Header.Get(AppSessionIDHeader)); id != "" {
+			r = r.WithContext(WithAppSessionID(r.Context(), id))
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// resolveAppSessionID picks the app session key for a tool call.
+//
+// Priority:
+//  1. Context value set by AppSessionMiddleware / WithAppSessionID
+//  2. X-Switchboard-Session-Id on the HTTP request (via req.Extra.Header)
+//  3. Mcp-Session-Id header (legacy clients / go-sdk ≤1.6 Stateless)
+//  4. MCP ServerSession.ID() (stateful transport)
+//  5. "default" (single-shot scripts; shared across callers — not for multi-agent)
+func resolveAppSessionID(ctx context.Context, req *mcpsdk.CallToolRequest) string {
+	if id := AppSessionIDFromCtx(ctx); id != "" {
+		return id
+	}
+	if req != nil && req.Extra != nil && req.Extra.Header != nil {
+		if id := strings.TrimSpace(req.Extra.Header.Get(AppSessionIDHeader)); id != "" {
+			return id
+		}
+		if id := strings.TrimSpace(req.Extra.Header.Get(mcpSessionIDHeader)); id != "" {
+			return id
+		}
+	}
+	if req != nil {
+		return sessionIDFromMCPSession(req.Session)
+	}
+	return defaultSessionID
+}
+
+// sessionIDFromMCPSession reads the transport session id. Empty when the
+// server is in Stateless mode on go-sdk 1.7+.
+func sessionIDFromMCPSession(ss *mcpsdk.ServerSession) string {
 	if ss == nil {
 		return defaultSessionID
 	}
@@ -27,4 +105,18 @@ func sessionIDFromReq(ss *mcpsdk.ServerSession) string {
 		return id
 	}
 	return defaultSessionID
+}
+
+// sessionIDFromReq is retained for call sites and tests that only have a
+// ServerSession. Prefer resolveAppSessionID when a CallToolRequest is available.
+func sessionIDFromReq(ss *mcpsdk.ServerSession) string {
+	return sessionIDFromMCPSession(ss)
+}
+
+// sessionFor returns the Session bound to this tool call, creating it if needed.
+func (s *Server) sessionFor(ctx context.Context, req *mcpsdk.CallToolRequest) *Session {
+	if sess := sessionFromCtx(ctx); sess != nil {
+		return sess
+	}
+	return s.sessionStore.GetOrCreate(resolveAppSessionID(ctx, req))
 }

--- a/server/session_context.go
+++ b/server/session_context.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"strings"
+	"unicode"
 
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -23,6 +24,10 @@ const AppSessionIDHeader = "X-Switchboard-Session-Id"
 // one place when go-sdk renames or deprecates it.
 const mcpSessionIDHeader = "Mcp-Session-Id"
 
+// maxAppSessionIDLen caps client-minted session keys so a chatty client cannot
+// grow the SessionStore with unbounded unique ids.
+const maxAppSessionIDLen = 128
+
 type sessionContextKey struct{}
 type appSessionIDKey struct{}
 
@@ -36,9 +41,9 @@ func sessionFromCtx(ctx context.Context) *Session {
 }
 
 // WithAppSessionID stores an app session id on the context. Used by
-// AppSessionMiddleware and by tests that bypass HTTP.
+// AppSessionMiddleware and by tests that bypass HTTP. Invalid ids are ignored.
 func WithAppSessionID(ctx context.Context, id string) context.Context {
-	id = strings.TrimSpace(id)
+	id = normalizeAppSessionID(id)
 	if id == "" {
 		return ctx
 	}
@@ -54,6 +59,27 @@ func AppSessionIDFromCtx(ctx context.Context) string {
 
 const defaultSessionID = "default"
 
+// normalizeAppSessionID trims and validates a client-supplied session id.
+// Empty or invalid values return "" so callers fall through to the next source.
+// Allow-list: ASCII letters, digits, and - _ . : (UUID-safe plus common tokens).
+func normalizeAppSessionID(id string) string {
+	id = strings.TrimSpace(id)
+	if id == "" || len(id) > maxAppSessionIDLen {
+		return ""
+	}
+	for _, r := range id {
+		if r > unicode.MaxASCII {
+			return ""
+		}
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') ||
+			(r >= '0' && r <= '9') || r == '-' || r == '_' || r == '.' || r == ':' {
+			continue
+		}
+		return ""
+	}
+	return id
+}
+
 // AppSessionMiddleware copies X-Switchboard-Session-Id from the HTTP request
 // onto the request context so tool handlers can resolve app sessions even
 // when the MCP transport session id is empty (go-sdk Stateless mode).
@@ -62,7 +88,7 @@ const defaultSessionID = "default"
 // go-sdk streamable transport propagates req.Context() into tool handlers.
 func AppSessionMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if id := strings.TrimSpace(r.Header.Get(AppSessionIDHeader)); id != "" {
+		if id := normalizeAppSessionID(r.Header.Get(AppSessionIDHeader)); id != "" {
 			r = r.WithContext(WithAppSessionID(r.Context(), id))
 		}
 		next.ServeHTTP(w, r)
@@ -76,16 +102,19 @@ func AppSessionMiddleware(next http.Handler) http.Handler {
 //  2. X-Switchboard-Session-Id on the HTTP request (via req.Extra.Header)
 //  3. Mcp-Session-Id header (legacy clients / go-sdk ≤1.6 Stateless)
 //  4. MCP ServerSession.ID() (stateful transport)
-//  5. "default" (single-shot scripts; shared across callers — not for multi-agent)
+//  5. "default" (single-shot scripts / stdio — shared; multi-tenant HTTP
+//     deployments must namespace further, e.g. org+user prefix in the store)
+//
+// All client-supplied values are validated via normalizeAppSessionID.
 func resolveAppSessionID(ctx context.Context, req *mcpsdk.CallToolRequest) string {
 	if id := AppSessionIDFromCtx(ctx); id != "" {
 		return id
 	}
 	if req != nil && req.Extra != nil && req.Extra.Header != nil {
-		if id := strings.TrimSpace(req.Extra.Header.Get(AppSessionIDHeader)); id != "" {
+		if id := normalizeAppSessionID(req.Extra.Header.Get(AppSessionIDHeader)); id != "" {
 			return id
 		}
-		if id := strings.TrimSpace(req.Extra.Header.Get(mcpSessionIDHeader)); id != "" {
+		if id := normalizeAppSessionID(req.Extra.Header.Get(mcpSessionIDHeader)); id != "" {
 			return id
 		}
 	}
@@ -96,12 +125,13 @@ func resolveAppSessionID(ctx context.Context, req *mcpsdk.CallToolRequest) strin
 }
 
 // sessionIDFromMCPSession reads the transport session id. Empty when the
-// server is in Stateless mode on go-sdk 1.7+.
+// server is in Stateless mode on go-sdk 1.7+. Transport ids are also
+// normalized; invalid values fall back to "default".
 func sessionIDFromMCPSession(ss *mcpsdk.ServerSession) string {
 	if ss == nil {
 		return defaultSessionID
 	}
-	if id := ss.ID(); id != "" {
+	if id := normalizeAppSessionID(ss.ID()); id != "" {
 		return id
 	}
 	return defaultSessionID

--- a/server/session_context_test.go
+++ b/server/session_context_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	mcp "github.com/daltoniam/switchboard"
@@ -260,4 +261,34 @@ func TestHandleExecute_AppHeaderPinsAcrossCalls(t *testing.T) {
 
 func TestAppSessionIDHeaderConstant(t *testing.T) {
 	assert.Equal(t, "X-Switchboard-Session-Id", AppSessionIDHeader)
+}
+
+func TestNormalizeAppSessionID(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"  ", ""},
+		{"abc-123", "abc-123"},
+		{"uuid-like_ok.here:1", "uuid-like_ok.here:1"},
+		{"has space", ""},
+		{"bad!", ""},
+		{strings.Repeat("a", maxAppSessionIDLen), strings.Repeat("a", maxAppSessionIDLen)},
+		{strings.Repeat("a", maxAppSessionIDLen+1), ""},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, normalizeAppSessionID(tt.in), "in=%q", tt.in)
+	}
+}
+
+func TestResolveAppSessionID_RejectsInvalidHeader(t *testing.T) {
+	req := &mcpsdk.CallToolRequest{
+		Extra: &mcpsdk.RequestExtra{
+			Header: http.Header{
+				AppSessionIDHeader: []string{"not valid!!"},
+				mcpSessionIDHeader: []string{"good-fallback"},
+			},
+		},
+	}
+	assert.Equal(t, "good-fallback", resolveAppSessionID(context.Background(), req))
 }

--- a/server/session_context_test.go
+++ b/server/session_context_test.go
@@ -1,0 +1,263 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	mcp "github.com/daltoniam/switchboard"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveAppSessionID_Priority(t *testing.T) {
+	tests := []struct {
+		name string
+		ctx  context.Context
+		req  *mcpsdk.CallToolRequest
+		want string
+	}{
+		{
+			name: "context wins over headers",
+			ctx:  WithAppSessionID(context.Background(), "from-ctx"),
+			req: &mcpsdk.CallToolRequest{
+				Extra: &mcpsdk.RequestExtra{
+					Header: http.Header{
+						AppSessionIDHeader: []string{"from-app-header"},
+						mcpSessionIDHeader: []string{"from-mcp-header"},
+					},
+				},
+			},
+			want: "from-ctx",
+		},
+		{
+			name: "app header wins over mcp header",
+			ctx:  context.Background(),
+			req: &mcpsdk.CallToolRequest{
+				Extra: &mcpsdk.RequestExtra{
+					Header: http.Header{
+						AppSessionIDHeader: []string{"app-sess"},
+						mcpSessionIDHeader: []string{"mcp-sess"},
+					},
+				},
+			},
+			want: "app-sess",
+		},
+		{
+			name: "mcp header used when app header absent",
+			ctx:  context.Background(),
+			req: &mcpsdk.CallToolRequest{
+				Extra: &mcpsdk.RequestExtra{
+					Header: http.Header{
+						mcpSessionIDHeader: []string{"mcp-only"},
+					},
+				},
+			},
+			want: "mcp-only",
+		},
+		{
+			name: "trims whitespace on app header",
+			ctx:  context.Background(),
+			req: &mcpsdk.CallToolRequest{
+				Extra: &mcpsdk.RequestExtra{
+					Header: http.Header{
+						AppSessionIDHeader: []string{"  spaced-id  "},
+					},
+				},
+			},
+			want: "spaced-id",
+		},
+		{
+			name: "empty request falls back to default",
+			ctx:  context.Background(),
+			req:  nil,
+			want: defaultSessionID,
+		},
+		{
+			name: "nil session falls back to default",
+			ctx:  context.Background(),
+			req:  &mcpsdk.CallToolRequest{},
+			want: defaultSessionID,
+		},
+		{
+			name: "empty app header ignored",
+			ctx:  context.Background(),
+			req: &mcpsdk.CallToolRequest{
+				Extra: &mcpsdk.RequestExtra{
+					Header: http.Header{
+						AppSessionIDHeader: []string{"   "},
+						mcpSessionIDHeader: []string{"mcp-fallback"},
+					},
+				},
+			},
+			want: "mcp-fallback",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, resolveAppSessionID(tt.ctx, tt.req))
+		})
+	}
+}
+
+func TestAppSessionMiddleware_SetsContext(t *testing.T) {
+	var got string
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = AppSessionIDFromCtx(r.Context())
+		w.WriteHeader(http.StatusNoContent)
+	})
+	h := AppSessionMiddleware(inner)
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req.Header.Set(AppSessionIDHeader, "conv-abc")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusNoContent, rr.Code)
+	assert.Equal(t, "conv-abc", got)
+}
+
+func TestAppSessionMiddleware_NoHeaderLeavesEmpty(t *testing.T) {
+	var got string
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = AppSessionIDFromCtx(r.Context())
+		w.WriteHeader(http.StatusNoContent)
+	})
+	h := AppSessionMiddleware(inner)
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	assert.Empty(t, got)
+}
+
+func TestSessionFor_UsesAppHeaderWithoutMCPSession(t *testing.T) {
+	s := setupTestServer(&mockIntegration{name: "test", healthy: true})
+
+	req := &mcpsdk.CallToolRequest{
+		Extra: &mcpsdk.RequestExtra{
+			Header: http.Header{AppSessionIDHeader: []string{"agent-1"}},
+		},
+	}
+	sess := s.sessionFor(context.Background(), req)
+	require.NotNil(t, sess)
+	assert.Equal(t, "agent-1", sess.ID)
+
+	// Same header, no MCP session → same store entry.
+	sess2 := s.sessionFor(context.Background(), req)
+	assert.Same(t, sess, sess2)
+
+	// Different header → different session.
+	reqB := &mcpsdk.CallToolRequest{
+		Extra: &mcpsdk.RequestExtra{
+			Header: http.Header{AppSessionIDHeader: []string{"agent-2"}},
+		},
+	}
+	sessB := s.sessionFor(context.Background(), reqB)
+	assert.Equal(t, "agent-2", sessB.ID)
+	assert.NotSame(t, sess, sessB)
+}
+
+func TestSessionFor_ContextSessionWins(t *testing.T) {
+	s := setupTestServer(&mockIntegration{name: "test", healthy: true})
+	pre := newSession("preloaded")
+	pre.SetContext(map[string]any{"owner": "preset"})
+	ctx := withSession(context.Background(), pre)
+
+	req := &mcpsdk.CallToolRequest{
+		Extra: &mcpsdk.RequestExtra{
+			Header: http.Header{AppSessionIDHeader: []string{"ignored"}},
+		},
+	}
+	got := s.sessionFor(ctx, req)
+	assert.Same(t, pre, got)
+	assert.Equal(t, "preset", got.GetContext()["owner"])
+}
+
+func TestHandleSession_AppHeaderIsolatesContext(t *testing.T) {
+	s := setupTestServer(&mockIntegration{name: "test", healthy: true})
+	ctx := context.Background()
+
+	reqA := sessionRequest(map[string]any{
+		"action":  "set",
+		"context": map[string]any{"owner": "alpha"},
+	})
+	reqA.Extra = &mcpsdk.RequestExtra{
+		Header: http.Header{AppSessionIDHeader: []string{"sess-a"}},
+	}
+	result, err := s.handleSession(ctx, reqA)
+	require.NoError(t, err)
+	resp := parseSessionResponse(t, result)
+	assert.Equal(t, "sess-a", resp["session_id"])
+	assert.Equal(t, "alpha", resp["context"].(map[string]any)["owner"])
+
+	// Different app session must not see alpha's context.
+	reqB := sessionRequest(map[string]any{"action": "get"})
+	reqB.Extra = &mcpsdk.RequestExtra{
+		Header: http.Header{AppSessionIDHeader: []string{"sess-b"}},
+	}
+	result, err = s.handleSession(ctx, reqB)
+	require.NoError(t, err)
+	resp = parseSessionResponse(t, result)
+	assert.Equal(t, "sess-b", resp["session_id"])
+	assert.Empty(t, resp["context"])
+
+	// Same app session without MCP transport id still recovers context.
+	reqA2 := sessionRequest(map[string]any{"action": "get"})
+	reqA2.Extra = &mcpsdk.RequestExtra{
+		Header: http.Header{AppSessionIDHeader: []string{"sess-a"}},
+	}
+	result, err = s.handleSession(ctx, reqA2)
+	require.NoError(t, err)
+	resp = parseSessionResponse(t, result)
+	assert.Equal(t, "alpha", resp["context"].(map[string]any)["owner"])
+}
+
+func TestHandleExecute_AppHeaderPinsAcrossCalls(t *testing.T) {
+	mi := &mockIntegration{
+		name:    "echo",
+		healthy: true,
+		tools: []mcp.ToolDefinition{
+			{
+				Name:        "echo_ping",
+				Description: "Returns pong",
+				Parameters:  map[string]string{"message": "string"},
+			},
+		},
+		execFn: func(_ context.Context, _ mcp.ToolName, args map[string]any) (*mcp.ToolResult, error) {
+			data, _ := json.Marshal(map[string]any{"pong": args["message"]})
+			return &mcp.ToolResult{Data: string(data)}, nil
+		},
+	}
+	s := setupTestServer(mi)
+	ctx := context.Background()
+	appHeader := http.Header{AppSessionIDHeader: []string{"pin-sess"}}
+
+	execReq := executeRequest("echo_ping", map[string]any{"message": "hello"})
+	execReq.Extra = &mcpsdk.RequestExtra{Header: appHeader}
+	result, err := s.handleExecute(ctx, execReq)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	// Pin list for this app session should show $1; default session must stay empty.
+	listReq := pinRequest(map[string]any{"action": "list"})
+	listReq.Extra = &mcpsdk.RequestExtra{Header: appHeader}
+	listResult, err := s.handlePin(ctx, listReq)
+	require.NoError(t, err)
+	listResp := parseSessionResponse(t, listResult)
+	assert.EqualValues(t, 1, listResp["pinned_count"])
+
+	defaultList := pinRequest(map[string]any{"action": "list"})
+	defaultResult, err := s.handlePin(ctx, defaultList)
+	require.NoError(t, err)
+	defaultResp := parseSessionResponse(t, defaultResult)
+	assert.EqualValues(t, 0, defaultResp["pinned_count"])
+}
+
+func TestAppSessionIDHeaderConstant(t *testing.T) {
+	assert.Equal(t, "X-Switchboard-Session-Id", AppSessionIDHeader)
+}

--- a/server/session_handlers.go
+++ b/server/session_handlers.go
@@ -22,10 +22,7 @@ func (s *Server) handleSession(ctx context.Context, req *mcpsdk.CallToolRequest)
 		return errorResult("invalid arguments: " + err.Error()), nil
 	}
 
-	sess := sessionFromCtx(ctx)
-	if sess == nil {
-		sess = s.sessionStore.GetOrCreate(sessionIDFromReq(req.Session))
-	}
+	sess := s.sessionFor(ctx, req)
 
 	switch args.Action {
 	case "set":
@@ -74,10 +71,7 @@ func (s *Server) handleHistory(ctx context.Context, req *mcpsdk.CallToolRequest)
 		args.LastN = maxHistoryN
 	}
 
-	sess := sessionFromCtx(ctx)
-	if sess == nil {
-		sess = s.sessionStore.GetOrCreate(sessionIDFromReq(req.Session))
-	}
+	sess := s.sessionFor(ctx, req)
 
 	bcs := sess.RecentBreadcrumbs(args.LastN, mcp.ToolName(args.Tool))
 
@@ -107,10 +101,7 @@ func (s *Server) handlePin(ctx context.Context, req *mcpsdk.CallToolRequest) (*m
 		return errorResult("invalid arguments: " + err.Error()), nil
 	}
 
-	sess := sessionFromCtx(ctx)
-	if sess == nil {
-		sess = s.sessionStore.GetOrCreate(sessionIDFromReq(req.Session))
-	}
+	sess := s.sessionFor(ctx, req)
 
 	switch args.Action {
 	case "list":


### PR DESCRIPTION
## Summary
- Resolve pin/context/history keys from `X-Switchboard-Session-Id` first so Stateless MCP still isolates conversations when `Mcp-Session-Id` is empty (go-sdk 1.7+).
- Wrap HTTP handlers with `AppSessionMiddleware`; keep legacy `Mcp-Session-Id` and `"default"` fallbacks for older clients and one-shot scripts.

## Why
go-sdk 1.7 Stateless mode ignores transport session ids (SEP-2567 / sessionless MCP). Switchboard app sessions previously keyed off `ServerSession.ID()`, so every request collapsed onto `"default"`.

## API for clients
Send on every MCP HTTP request:
```
X-Switchboard-Session-Id: <uuid-per-conversation>
```

Priority: app header → `Mcp-Session-Id` → transport session id → `"default"`.

## Follow-up (hosted)
1. Redis `SessionStore` for multi-pod mcpd
2. Crush mints/sends the header
3. Bump go-sdk to 1.7.x