### PR TITLE
Stop advertising MCP tool list changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/daltoniam/switchboard
 
-go 1.26.5
+go 1.26.6
 
 require (
 	cloud.google.com/go/compute v1.38.0

--- a/server/project_server.go
+++ b/server/project_server.go
@@ -113,7 +113,8 @@ func (pr *ProjectRouter) buildServer(def *project.Definition) *projectMCPServer 
 				"Project-scoped MCP server for %q. Use the search tool to discover available operations — do not guess tool names. Use project_context to retrieve project context.",
 				def.Name,
 			),
-			Logger: slog.Default(),
+			Logger:       slog.Default(),
+			Capabilities: staticMCPCapabilities(),
 		},
 	)
 

--- a/server/project_server_test.go
+++ b/server/project_server_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	mcp "github.com/daltoniam/switchboard"
 	"github.com/daltoniam/switchboard/project"
@@ -91,6 +92,33 @@ func projectToolRequest(name string, args map[string]any) *mcpsdk.CallToolReques
 			Arguments: json.RawMessage(data),
 		},
 	}
+}
+
+func TestProjectRouter_StaticToolListCapability(t *testing.T) {
+	def := &project.Definition{Version: "1", Name: "test-project"}
+	router, _ := setupProjectRouter(t, def, &mockIntegration{
+		name:    "github",
+		healthy: true,
+		tools:   []mcp.ToolDefinition{{Name: mcp.ToolName("github_list_issues"), Description: "List issues"}},
+	})
+	srv, err := router.getOrCreate("test-project")
+	require.NoError(t, err)
+
+	clientTransport, serverTransport := mcpsdk.NewInMemoryTransports()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	ss, err := srv.mcpSrv.Connect(ctx, serverTransport, nil)
+	require.NoError(t, err)
+	defer ss.Close() //nolint:errcheck
+
+	client := mcpsdk.NewClient(&mcpsdk.Implementation{Name: "crush", Version: "0.89.0"}, nil)
+	cs, err := client.Connect(ctx, clientTransport, nil)
+	require.NoError(t, err)
+	defer cs.Close() //nolint:errcheck
+
+	require.NotNil(t, cs.InitializeResult().Capabilities.Tools)
+	assert.False(t, cs.InitializeResult().Capabilities.Tools.ListChanged)
 }
 
 func TestProjectRouter_GetOrCreate(t *testing.T) {

--- a/server/server.go
+++ b/server/server.go
@@ -131,6 +131,18 @@ func WithExtraInstructions(text string) Option {
 	return func(s *Server) { s.extraInstructions = strings.TrimSpace(text) }
 }
 
+// staticMCPCapabilities advertises a stable tool list. Crush 0.89 / MCP
+// SDK 1.7 opens a long-lived subscriptions/listen stream whenever
+// tools.listChanged is true. Switchboard serves MCP from request-scoped
+// servers (especially hosted mcpd StatelessHandler), so that stream has
+// nowhere to live and the client tears down tools/list with it.
+func staticMCPCapabilities() *mcpsdk.ServerCapabilities {
+	return &mcpsdk.ServerCapabilities{
+		Logging: &mcpsdk.LoggingCapabilities{},
+		Tools:   &mcpsdk.ToolCapabilities{ListChanged: false},
+	}
+}
+
 // New creates a Server that exposes two MCP tools — search and execute —
 // following the Cloudflare "code mode" pattern for progressive discovery
 // and efficient tool execution.
@@ -156,7 +168,10 @@ func New(services *mcp.Services, opts ...Option) *Server {
 			Name:    "switchboard",
 			Version: version.String(),
 		},
-		&mcpsdk.ServerOptions{Instructions: instructions},
+		&mcpsdk.ServerOptions{
+			Instructions: instructions,
+			Capabilities: staticMCPCapabilities(),
+		},
 	)
 
 	s.scriptEngine = script.New(&toolExecutor{server: s})

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -3722,6 +3723,64 @@ func mustMarshal(v any) json.RawMessage {
 		panic(err)
 	}
 	return data
+}
+
+func TestStaticMCPCapabilities_DisableListChanged(t *testing.T) {
+	s := setupTestServer()
+
+	clientTransport, serverTransport := mcpsdk.NewInMemoryTransports()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	ss, err := s.mcpServer.Connect(ctx, serverTransport, nil)
+	require.NoError(t, err)
+	defer ss.Close() //nolint:errcheck
+
+	client := mcpsdk.NewClient(&mcpsdk.Implementation{Name: "crush", Version: "0.89.0"}, &mcpsdk.ClientOptions{
+		ToolListChangedHandler: func(context.Context, *mcpsdk.ToolListChangedRequest) {},
+	})
+	cs, err := client.Connect(ctx, clientTransport, nil)
+	require.NoError(t, err)
+	defer cs.Close() //nolint:errcheck
+
+	caps := cs.InitializeResult().Capabilities
+	require.NotNil(t, caps.Tools, "tools capability must still be advertised")
+	assert.False(t, caps.Tools.ListChanged, "listChanged must be false so Crush 0.89 does not open subscriptions/listen")
+
+	tools, err := cs.ListTools(ctx, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, tools.Tools)
+}
+
+func TestStatelessHandler_Crush089ListTools(t *testing.T) {
+	s := setupTestServer()
+	ts := httptest.NewServer(s.StatelessHandler())
+	t.Cleanup(ts.Close)
+
+	client := mcpsdk.NewClient(&mcpsdk.Implementation{Name: "crush", Version: "0.89.0"}, &mcpsdk.ClientOptions{
+		ToolListChangedHandler: func(context.Context, *mcpsdk.ToolListChangedRequest) {},
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cs, err := client.Connect(ctx, &mcpsdk.StreamableClientTransport{Endpoint: ts.URL}, nil)
+	require.NoError(t, err)
+	defer cs.Close() //nolint:errcheck
+
+	require.False(t, cs.InitializeResult().Capabilities.Tools.ListChanged)
+
+	tools, err := cs.ListTools(ctx, nil)
+	require.NoError(t, err)
+	var hasSearch, hasExecute bool
+	for _, tool := range tools.Tools {
+		switch tool.Name {
+		case "search":
+			hasSearch = true
+		case "execute":
+			hasExecute = true
+		}
+	}
+	assert.True(t, hasSearch && hasExecute, "expected search and execute after Crush-style connect")
 }
 
 func TestWithExtraInstructions(t *testing.T) {


### PR DESCRIPTION
## Summary
- Advertise a stable MCP tool list so Crush 0.89 does not open `subscriptions/listen`.
- Cover the Crush handshake on both the in-memory and stateless HTTP transports.

Crush 0.89 / MCP SDK 1.7 starts a long-lived subscription whenever initialize reports `tools.listChanged`. Switchboard serves request-scoped MCP servers, so that stream closes and `tools/list` fails with it.