### PR TITLE
Add Stacklane-compatible Compose DEV stack

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,10 +1,43 @@
+# Air config for host `air` and Stacklane compose (air-verse/air v1.67.x schema).
+# Binary/tmp live under ./tmp (compose mounts a named volume at /src/tmp).
+
 root = "."
 tmp_dir = "tmp"
 
 [build]
-  entrypoint = "./tmp/main"
-  cmd = "templ generate && go build -o ./tmp/main ./cmd/server"
-  include_ext = ["go", "templ"]
-  exclude_dir = ["tmp", "dist", "node_modules", ".git"]
-  exclude_regex = ["_test\\.go$", "_templ\\.go$"]
+  args_bin = []
+  bin = "./tmp/switchboard"
+  # -buildvcs=false: bind-mounted .git is owned by the host UID; container git
+  # rejects it as "dubious ownership", which otherwise aborts VCS stamping.
+  # go tool templ is declared in go.mod (works on host and in Dockerfile.dev).
+  cmd = "go tool templ generate && go build -buildvcs=false -o ./tmp/switchboard ./cmd/server"
   delay = 1000
+  exclude_dir = ["tmp", "dist", "node_modules", ".git", "wasm/guest-rust/target"]
+  exclude_regex = ["_test\\.go$", "_templ\\.go$"]
+  exclude_unchanged = false
+  follow_symlink = false
+  include_ext = ["go", "templ"]
+  kill_delay = "2s"
+  log = "build-errors.log"
+  poll = false
+  rerun = false
+  send_interrupt = true
+  stop_on_error = false
+
+[color]
+  build = "yellow"
+  main = "magenta"
+  runner = "green"
+  watcher = "cyan"
+
+[log]
+  main_only = false
+  silent = false
+  time = false
+
+[misc]
+  clean_on_exit = false
+
+[screen]
+  clear_on_rebuild = false
+  keep_scroll = true

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+tmp
+dist
+coverage.out
+wasm/guest-rust/target
+**/.DS_Store

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,3 +88,16 @@ jobs:
       - name: Check Rust guest SDK compiles
         working-directory: wasm/guest-rust
         run: cargo check --target wasm32-unknown-unknown
+
+  compose:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compose lifecycle tests
+        run: bash scripts/compose-dev_test.sh
+
+      - name: Compose contract check
+        run: bash scripts/compose-dev.sh check
+        env:
+          STACKLANE_INSTANCE: ci

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,12 +11,15 @@
 | Target | Command | Make shortcut |
 |--------|---------|---------------|
 | Build | `go build -o switchboard ./cmd/server` | `make build` |
-| Test | `go test ./...` | `make test` |
-| Test + race | `go test -race -coverprofile=coverage.out ./...` | `make test-race` |
+| Test | `go test ./...` + compose lifecycle tests | `make test` |
+| Test + race | `go test -race -coverprofile=coverage.out ./...` + compose lifecycle tests | `make test-race` |
 | Vet | `go vet ./...` | `make vet` |
 | Lint | `go tool golangci-lint run` | `make lint` |
 | Format | `gofmt -w .` | `make fmt` |
 | **All CI checks** | build + vet + test-race + lint + security | **`make ci`** |
+| Compose check | `bash scripts/compose-dev.sh check` | `make compose-check` |
+| Compose up | `bash scripts/compose-dev.sh up` | `make compose-up` |
+| Compose down | `bash scripts/compose-dev.sh down` | `make compose-down` |
 
 ## Requirements Before Completing Code Changes
 
@@ -77,6 +80,7 @@ Co-Authored-By: <agent model name> <noreply@anthropic.com>
 | [docs/markdown-rendering.md](docs/markdown-rendering.md) | Adding markdown rendering to an integration (decision framework, shared utilities, implementation checklist) |
 | [docs/web-ui.md](docs/web-ui.md) | Modifying the web config UI |
 | [docs/google-setup.md](docs/google-setup.md) | Unified Google Workspace OAuth setup (BYO client, token fan-out) |
+| [docs/dev-compose.md](docs/dev-compose.md) | Stacklane-compatible Docker Compose DEV stack (worktree isolation) |
 
 ## Skills
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1.7
+# Switchboard DEV image — Air hot-reload, source bind-mounted at runtime.
+# Pins match go.mod (Go 1.26.6). Do not use for production (see Dockerfile).
+
+ARG GO_VERSION=1.26.6
+# air-verse/air is MIT. Pin >=1.62: older 1.61.x overwrote .air.toml with flag defaults.
+ARG AIR_VERSION=v1.67.4
+
+FROM golang:1.26.6-bookworm@sha256:116d58cbd88c1297624acc6e967a060012422bacf9930927e23fb719189c6f36
+
+ARG AIR_VERSION
+ENV CGO_ENABLED=0 \
+    GO111MODULE=on \
+    GOPATH=/go \
+    GOCACHE=/go-cache \
+    GOMODCACHE=/go/pkg/mod \
+    HOME=/root \
+    PATH=/go/bin:/usr/local/go/bin:$PATH
+
+# curl is used by the compose healthcheck against /api/health.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends git ca-certificates curl \
+ && rm -rf /var/lib/apt/lists/* \
+ && go install github.com/air-verse/air@${AIR_VERSION} \
+ && air -v \
+ && mkdir -p /tmp/air /go-cache /root/.config/switchboard /src/tmp
+
+WORKDIR /src
+
+# Air as PID1 so SIGTERM reaches the watcher directly.
+# Compose bind-mounts source over /src; binary/tmp live on a named volume.
+CMD ["air", "-c", ".air.toml"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build generate test test-race vet lint fmt security gosec govulncheck ci clean install deploy help wasm-build wasm-test
+.PHONY: build generate test test-race vet lint fmt security gosec govulncheck ci clean install deploy help wasm-build wasm-test compose-check compose-up compose-status compose-endpoints compose-logs compose-down compose-destroy
 
 BIN        := dist/switchboard
 INSTALL_DIR := $(HOME)/.local/bin
@@ -35,9 +35,11 @@ wasm-test: wasm-build ## Build WASM modules and run WASM tests
 
 test: ## Run tests
 	go test ./...
+	bash scripts/compose-dev_test.sh
 
 test-race: ## Run tests with race detector
 	go test -race -coverprofile=coverage.out ./...
+	bash scripts/compose-dev_test.sh
 
 ## Analysis
 
@@ -61,6 +63,29 @@ security: gosec govulncheck ## Run all security checks
 ## CI
 
 ci: build vet test-race lint security ## Run all CI checks locally
+
+## Stacklane compose (dev)
+
+compose-check: ## Fail-closed Stacklane compose contract check
+	bash scripts/compose-dev.sh check
+
+compose-up: ## check + build + start DEV compose stack
+	bash scripts/compose-dev.sh up
+
+compose-status: ## Compose ps + FQDN / loopback endpoints
+	bash scripts/compose-dev.sh status
+
+compose-endpoints: ## Print Stacklane FQDNs + direct loopback URLs
+	bash scripts/compose-dev.sh endpoints
+
+compose-logs: ## Follow compose logs (Ctrl-C leaves the stack running)
+	bash scripts/compose-dev.sh logs
+
+compose-down: ## Stop compose stack (volumes preserved)
+	bash scripts/compose-dev.sh down
+
+compose-destroy: ## Remove compose stack AND volumes (CONFIRM=switchboard-<instance>-destroy)
+	bash scripts/compose-dev.sh destroy
 
 ## Install & Deploy
 

--- a/README.md
+++ b/README.md
@@ -288,6 +288,16 @@ Then run with live-reload:
 air
 ```
 
+Host `air` / `make build` remain the non-Docker path. For a worktree-isolated
+Docker Compose DEV stack (ephemeral loopback publish + optional Stacklane
+FQDNs, no provider tokens required) see [docs/dev-compose.md](docs/dev-compose.md):
+
+```bash
+make compose-up
+make compose-status
+make compose-down
+```
+
 ## License
 
 Switchboard is source-available under the [Elastic License 2.0](LICENSE).

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,56 @@
+# Switchboard Stacklane-compatible local DEV stack.
+# Lifecycle: scripts/compose-dev.sh (always pass -p switchboard-<instance>).
+# Publish ONLY 127.0.0.1::<containerPort> (ephemeral host port). Never 0.0.0.0 / fixed host ports.
+#
+# No provider tokens required — the web UI starts with integrations disabled.
+# Optional host tokens are NOT interpolated here so rendered config stays secret-free.
+# Compose project name is set only via `docker compose -p` (never hardcoded here).
+#
+# Production/released image stack remains docker-compose.yml (host fallback).
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    working_dir: /src
+    # Air as PID1 (image CMD); no shell wrapper swallowing signals.
+    command: ["air", "-c", ".air.toml"]
+    environment:
+      STACKLANE_INSTANCE: ${STACKLANE_INSTANCE:?set by scripts/compose-dev.sh}
+      HOME: /root
+      # Bind all container interfaces; host publish remains loopback ephemeral.
+      # Caches stay inside named volumes (GOPATH/GOCACHE).
+      GOPATH: /go
+      GOCACHE: /go-cache
+      GOMODCACHE: /go/pkg/mod
+    volumes:
+      # Entire repo source RW for Air rebuilds.
+      - .:/src
+      - switchboard_go_mod_cache:/go/pkg/mod
+      - switchboard_go_build_cache:/go-cache
+      # Air binary + build-errors.log (not on the host bind-mounted tracked tree).
+      - switchboard_air_tmp:/src/tmp
+      # Fresh config dir — UI persists here; no host secrets are mounted.
+      - switchboard_config:/root/.config/switchboard
+    ports:
+      - "127.0.0.1::3847"
+    labels:
+      stacklane.enable: "true"
+      stacklane.project: "switchboard"
+      stacklane.instance: ${STACKLANE_INSTANCE:?set by scripts/compose-dev.sh}
+      stacklane.endpoint: "app"
+      stacklane.port: "3847"
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:3847/api/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 180s
+    restart: unless-stopped
+
+volumes:
+  switchboard_go_mod_cache:
+  switchboard_go_build_cache:
+  switchboard_air_tmp:
+  switchboard_config:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,6 @@
+# Production/released image stack (host fallback). Fixed host port is intentional
+# for the published image, not for multi-worktree DEV. Use docker-compose.dev.yml
+# via scripts/compose-dev.sh for Stacklane-compatible local development.
 services:
   switchboard:
     image: ghcr.io/daltoniam/switchboard:latest

--- a/docs/dev-compose.md
+++ b/docs/dev-compose.md
@@ -1,0 +1,104 @@
+# Stacklane-compatible Docker Compose DEV stack
+
+Parallel worktree-friendly local stack: Switchboard HTTP + web UI with Air
+hot-reload, published only on `127.0.0.1::<containerPort>` (ephemeral host
+ports) with Stacklane labels for stable FQDNs when the Stacklane daemon is
+installed.
+
+**No GitHub/Linear/provider tokens are required.** The UI starts with
+integrations disabled. Configure credentials later through the web UI or by
+mounting a config volume if you choose.
+
+Host fallback is **unchanged**:
+
+- `air` / `make build` / `make install` for non-Docker development
+- production `Dockerfile` + `docker-compose.yml` (`ghcr.io/daltoniam/switchboard:latest`)
+
+## Prerequisites
+
+- Docker Engine + Compose v2
+- Optional: Stacklane daemon for `app.<instance>.switchboard.test:3847`
+- Stacklane install/daemon is **separate**. This stack works with **direct
+  loopback ephemeral ports** if the daemon is absent (`stacklane: BLOCKED` in
+  status is OK).
+
+## Copy-paste commands
+
+```bash
+make compose-up
+make compose-status
+make compose-logs
+make compose-down
+CONFIRM=switchboard-<instance>-destroy make compose-destroy
+```
+
+Fail-closed contract check only:
+
+```bash
+make compose-check
+# or
+bash scripts/compose-dev.sh check
+```
+
+Override instance slug (sanitized to `[a-z0-9-]`, max 48):
+
+```bash
+STACKLANE_INSTANCE=my-feature make compose-up
+```
+
+Default instance is the worktree directory name (e.g. `stacklane-compose`),
+else branch name, else `dev`. Compose project is always
+`switchboard-<instance>` via `docker compose -p` (never hardcoded in the YAML).
+
+`logs` follows service output. **Ctrl-C leaves the stack running**; use
+`make compose-down` to stop.
+
+`down` never passes `-v`. `destroy` requires
+`CONFIRM=switchboard-<instance>-destroy` and then removes named volumes for
+**that compose project only**.
+
+## Endpoints
+
+| Path | Meaning |
+|------|---------|
+| `http://app.<instance>.switchboard.test:3847` | App via Stacklane VIP public port **3847** |
+| `http://127.0.0.1:<ephemeral>/` | Direct UI (compose published port) |
+| `http://127.0.0.1:<ephemeral>/api/health` | Health (`{"status":"healthy"}`) |
+| `http://127.0.0.1:<ephemeral>/mcp` | MCP endpoint |
+
+Print mappings:
+
+```bash
+make compose-endpoints
+# or
+bash scripts/compose-dev.sh endpoints
+```
+
+## Architecture
+
+- **app** (`Dockerfile.dev`): golang `1.26.6-bookworm`, Air
+  (`github.com/air-verse/air` MIT, pinned `v1.67.4`) as PID1, repo bind-mounted
+  at `/src`, named volumes for Go mod/build caches, `/src/tmp` binary output,
+  and `/root/.config/switchboard`.
+- **Publish form:** only `127.0.0.1::3847` (ephemeral host port). Never
+  `0.0.0.0`, empty host IP, fixed host ports, or host network.
+- **Labels:** `stacklane.enable=true`, `stacklane.project=switchboard`,
+  `stacklane.instance=${STACKLANE_INSTANCE}`, `stacklane.endpoint=app`,
+  `stacklane.port=3847`. Container listen port equals public port, so
+  `stacklane.target_port` is omitted.
+- **Healthcheck:** `curl -fsS http://127.0.0.1:3847/api/health`.
+- **Auth:** no provider env interpolation. Optional tokens stay on the host
+  path; the DEV stack does not require them.
+
+## Files
+
+| File | Role |
+|------|------|
+| `docker-compose.dev.yml` | Stacklane DEV compose (this stack) |
+| `docker-compose.yml` | Existing production image stack (host fallback) |
+| `Dockerfile.dev` | Air + Go toolchain image |
+| `Dockerfile` | Production scratch image (unchanged) |
+| `scripts/compose-dev.sh` | Lifecycle: check/up/status/endpoints/logs/down/destroy |
+| `paseo.json` | Workspace scripts wrapping the Make targets |
+
+Do not mutate Stacklane daemon, DNS, or systemd from this lifecycle.

--- a/paseo.json
+++ b/paseo.json
@@ -1,0 +1,12 @@
+{
+  "scripts": {
+    "check": { "command": "make compose-check" },
+    "up": { "command": "make compose-up" },
+    "down": { "command": "make compose-down" },
+    "status": { "command": "make compose-status" },
+    "endpoints": { "command": "make compose-endpoints" },
+    "logs": { "command": "make compose-logs" },
+    "test": { "command": "make test" },
+    "ci": { "command": "make ci" }
+  }
+}

--- a/scripts/compose-dev.sh
+++ b/scripts/compose-dev.sh
@@ -1,0 +1,574 @@
+#!/usr/bin/env bash
+# Switchboard Stacklane compose lifecycle.
+# Always uses: docker compose -p "switchboard-<instance>" -f "$ROOT/docker-compose.dev.yml"
+set -euo pipefail
+
+# Neutralize accidental ambient Compose controls before assigning locals.
+# STACKLANE_INSTANCE remains a documented operator input and is derived below.
+unset COMPOSE_FILE COMPOSE_PROFILES COMPOSE_PROJECT_NAME
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE_FILE="${ROOT}/docker-compose.dev.yml"
+PROJECT_SLUG="switchboard"
+
+die() { echo "error: $*" >&2; exit 1; }
+info() { echo "switchboard-compose: $*" >&2; }
+
+# sanitize_instance: lowercase, non [a-z0-9-] → -, collapse dashes, trim, max 48, fallback dev
+sanitize_instance() {
+  local s="${1:-}"
+  s="$(printf '%s' "$s" | tr '[:upper:]' '[:lower:]')"
+  s="$(printf '%s' "$s" | sed -E 's/[^a-z0-9-]+/-/g; s/-+/-/g; s/^-+//; s/-+$//')"
+  if [[ ${#s} -gt 48 ]]; then
+    s="${s:0:48}"
+    s="$(printf '%s' "$s" | sed -E 's/-+$//')"
+  fi
+  if [[ -z "$s" ]]; then
+    s="dev"
+  fi
+  printf '%s' "$s"
+}
+
+derive_instance() {
+  if [[ -n "${STACKLANE_INSTANCE:-}" ]]; then
+    sanitize_instance "$STACKLANE_INSTANCE"
+    return
+  fi
+  local wt
+  wt="$(basename "$ROOT")"
+  if [[ -n "$wt" && "$wt" != "." && "$wt" != "/" ]]; then
+    sanitize_instance "$wt"
+    return
+  fi
+  local branch=""
+  if command -v git >/dev/null 2>&1; then
+    branch="$(git -C "$ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+  fi
+  if [[ -n "$branch" && "$branch" != "HEAD" ]]; then
+    sanitize_instance "$branch"
+    return
+  fi
+  sanitize_instance "dev"
+}
+
+detect_base_domain() {
+  if [[ -n "${STACKLANE_BASE_DOMAIN:-}" ]]; then
+    printf '%s' "$STACKLANE_BASE_DOMAIN"
+    return
+  fi
+  if ! command -v stacklane >/dev/null 2>&1; then
+    printf 'test'
+    return
+  fi
+  local detected=""
+  detected="$(
+    timeout 3s stacklane status -o json 2>/dev/null \
+      | python3 -c 'import json,sys,re
+try:
+    data=json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+val=data.get("base_domain") if isinstance(data, dict) else ""
+if isinstance(val, str) and re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9.-]{0,126}", val):
+    print(val)
+' || true
+  )"
+  if [[ -n "$detected" ]]; then
+    printf '%s' "$detected"
+    return
+  fi
+  printf 'test'
+}
+
+require_docker() {
+  command -v docker >/dev/null 2>&1 || die "docker not found"
+  docker compose version >/dev/null 2>&1 || die "docker compose not available"
+  [[ -f "$COMPOSE_FILE" ]] || die "missing $COMPOSE_FILE"
+  command -v python3 >/dev/null 2>&1 || die "python3 required for compose check"
+}
+
+compose() {
+  docker compose -p "$COMPOSE_PROJECT" --project-directory "$ROOT" -f "$COMPOSE_FILE" "$@"
+}
+
+export_stack_env() {
+  INSTANCE="$(derive_instance)"
+  COMPOSE_PROJECT="${PROJECT_SLUG}-${INSTANCE}"
+  STACKLANE_BASE_DOMAIN="$(detect_base_domain)"
+  export STACKLANE_INSTANCE="$INSTANCE"
+  export STACKLANE_BASE_DOMAIN
+  export COMPOSE_PROJECT_NAME="$COMPOSE_PROJECT"
+}
+
+host_port_for() {
+  local svc="$1"
+  local target="$2"
+  local mapping
+  mapping="$(compose port "$svc" "$target" 2>/dev/null || true)"
+  if [[ -z "$mapping" ]]; then
+    printf ''
+    return
+  fi
+  printf '%s' "${mapping##*:}"
+}
+
+stacklane_status_line() {
+  if ! command -v stacklane >/dev/null 2>&1; then
+    printf 'stacklane: BLOCKED (daemon/cli absent — direct loopback ports still work)\n'
+    return
+  fi
+  if timeout 3s stacklane status >/dev/null 2>&1; then
+    local app_fqdn="app.${INSTANCE}.${PROJECT_SLUG}.${STACKLANE_BASE_DOMAIN}"
+    if timeout 3s stacklane resolve "$app_fqdn" >/dev/null 2>&1; then
+      printf 'stacklane: OK\n'
+    else
+      printf 'stacklane: degraded (daemon up; %s not resolved yet)\n' "$app_fqdn"
+    fi
+  else
+    printf 'stacklane: BLOCKED (daemon not reachable)\n'
+  fi
+}
+
+print_endpoints() {
+  local app_hp base
+  app_hp="$(host_port_for app 3847)"
+  base="${STACKLANE_BASE_DOMAIN}"
+
+  echo "app.${INSTANCE}.${PROJECT_SLUG}.${base}:3847  (via Stacklane VIP)"
+  if [[ -n "$app_hp" ]]; then
+    echo "direct app:  http://127.0.0.1:${app_hp}/"
+    echo "direct health: http://127.0.0.1:${app_hp}/api/health"
+  else
+    echo "direct app:  (not published — stack down?)"
+  fi
+  stacklane_status_line
+  echo "instance: ${INSTANCE}"
+  echo "compose project: ${COMPOSE_PROJECT}"
+  echo "stacklane base_domain: ${base}"
+}
+
+wait_healthy() {
+  local timeout_s="${1:-360}"
+  local start now elapsed
+  local cid="${COMPOSE_PROJECT}-app-1"
+  start="$(date +%s)"
+  info "waiting for app healthy (timeout ${timeout_s}s)…"
+  while true; do
+    now="$(date +%s)"
+    elapsed=$((now - start))
+    if (( elapsed > timeout_s )); then
+      compose ps || true
+      die "app not healthy within ${timeout_s}s"
+    fi
+    local app_h
+    app_h="$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$cid" 2>/dev/null || echo missing)"
+    if [[ "$app_h" == "healthy" ]]; then
+      info "app healthy"
+      return 0
+    fi
+    sleep 2
+  done
+}
+
+# Fail-closed render + contract assertions. Never prints rendered JSON or Compose stderr.
+cmd_check() {
+  require_docker
+  export_stack_env
+  command -v python3 >/dev/null 2>&1 || die "python3 required for compose check"
+
+  COMPOSE_CHECK_UMASK="$(umask)"
+  umask 077
+  COMPOSE_CHECK_TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/switchboard-compose-check.XXXXXX")"
+  chmod 700 "$COMPOSE_CHECK_TMPDIR"
+  cleanup_check() {
+    rm -rf "${COMPOSE_CHECK_TMPDIR:-}"
+    umask "${COMPOSE_CHECK_UMASK:-022}"
+    trap - EXIT
+  }
+  trap cleanup_check EXIT
+  local tmpdir="$COMPOSE_CHECK_TMPDIR"
+
+  local out errf
+  out="${tmpdir}/compose.config.json"
+  errf="${tmpdir}/compose.config.err"
+  touch "$out" "$errf"
+  chmod 600 "$out" "$errf"
+
+  info "rendering compose config for instance=${INSTANCE} project=${COMPOSE_PROJECT}"
+  if ! timeout 60s docker compose -p "$COMPOSE_PROJECT" --project-directory "$ROOT" -f "$COMPOSE_FILE" \
+      config --format json >"$out" 2>"$errf"; then
+    echo "FAIL: compose-config-render" >&2
+    exit 1
+  fi
+
+  if ! python3 - "$out" "$INSTANCE" "$COMPOSE_PROJECT" "$PROJECT_SLUG" <<'PY'
+import json, sys, re
+
+path, expect_instance, expect_project, project_slug = sys.argv[1:5]
+try:
+    with open(path, "r", encoding="utf-8") as f:
+        cfg = json.load(f)
+except Exception:
+    print("FAIL: compose-config-parse", file=sys.stderr)
+    sys.exit(1)
+
+errors = []
+
+def err(rule):
+    errors.append(rule)
+
+services = cfg.get("services") or {}
+if "app" not in services:
+    err("missing-service-app")
+
+name = cfg.get("name") or ""
+if name and name != expect_project:
+    err("compose-project-identity")
+
+volumes_top = cfg.get("volumes") or {}
+vol_keys = set(volumes_top.keys())
+named_required = (
+    "switchboard_go_mod_cache",
+    "switchboard_go_build_cache",
+    "switchboard_air_tmp",
+    "switchboard_config",
+)
+for req in named_required:
+    if req not in vol_keys and not any(req in k for k in vol_keys):
+        err(f"named-volume-{req}")
+
+def labels_map(sc):
+    labels = sc.get("labels") or {}
+    if isinstance(labels, list):
+        out = {}
+        for item in labels:
+            if isinstance(item, str) and "=" in item:
+                k, v = item.split("=", 1)
+                out[k] = v
+        return out
+    if isinstance(labels, dict):
+        return {str(k): str(v) for k, v in labels.items()}
+    return {}
+
+def volume_entries(sc):
+    return sc.get("volumes") or []
+
+def has_bind(sc, target):
+    for v in volume_entries(sc):
+        if isinstance(v, dict):
+            tgt = v.get("target") or v.get("destination") or ""
+            typ = (v.get("type") or "").lower()
+            if typ == "bind" and tgt.rstrip("/") == target.rstrip("/"):
+                return True
+        elif isinstance(v, str) and f":{target}" in v:
+            return True
+    return False
+
+def has_named(sc, name_part):
+    for v in volume_entries(sc):
+        if isinstance(v, dict):
+            src = str(v.get("source") or "")
+            typ = (v.get("type") or "").lower()
+            if name_part in src and (typ in ("", "volume") or True):
+                return True
+        elif isinstance(v, str) and name_part in v:
+            return True
+    return False
+
+def env_map(sc):
+    env = sc.get("environment") or {}
+    if isinstance(env, list):
+        out = {}
+        for e in env:
+            if isinstance(e, str):
+                if "=" in e:
+                    k, v = e.split("=", 1)
+                    out[k] = v
+                else:
+                    out[e] = ""
+        return out
+    if isinstance(env, dict):
+        return {str(k): "" if v is None else str(v) for k, v in env.items()}
+    return {}
+
+app = services.get("app") or {}
+if (app.get("network_mode") or "") == "host":
+    err("no-host-network")
+if str(app.get("pid") or "").strip().lower() == "host":
+    err("no-host-pid")
+priv = app.get("privileged")
+if priv is True or (isinstance(priv, str) and priv.strip().lower() in ("true", "1", "yes", "on")):
+    err("no-privileged")
+
+ports = app.get("ports") or []
+if not ports:
+    err("publish-required")
+for p in ports:
+    if not isinstance(p, dict):
+        err("publish-object")
+        continue
+    hip = p.get("host_ip")
+    if hip != "127.0.0.1":
+        err("publish-loopback")
+    published = p.get("published")
+    if published not in (None, "", 0, "0"):
+        err("publish-ephemeral")
+    target = p.get("target")
+    try:
+        if int(target) != 3847:
+            err("publish-target-port")
+    except (TypeError, ValueError):
+        err("publish-target-port")
+
+labels = labels_map(app)
+enable = str(labels.get("stacklane.enable", ""))
+if enable not in ("true", "1"):
+    err("label-enable")
+if str(labels.get("stacklane.project", "")) != project_slug:
+    err("label-project")
+if str(labels.get("stacklane.instance", "")) != expect_instance:
+    err("label-instance")
+if str(labels.get("stacklane.endpoint", "")) != "app":
+    err("label-endpoint")
+if str(labels.get("stacklane.port", "")) != "3847":
+    err("label-port")
+target_port = labels.get("stacklane.target_port")
+if target_port not in (None, "", "3847"):
+    err("label-target-port")
+
+if not has_bind(app, "/src"):
+    err("source-bind-mount")
+for nv in named_required:
+    if not has_named(app, nv):
+        err(f"named-volume-mount-{nv}")
+
+hc = app.get("healthcheck") or {}
+test = hc.get("test") or []
+test_s = test if isinstance(test, str) else " ".join(str(x) for x in test)
+if "/api/health" not in test_s or "3847" not in test_s:
+    err("healthcheck")
+
+env = env_map(app)
+secret_keys = (
+    "GITHUB_TOKEN",
+    "LINEAR_API_KEY",
+    "SLACK_TOKEN",
+    "SENTRY_AUTH_TOKEN",
+    "DD_API_KEY",
+    "DD_APP_KEY",
+)
+for key in secret_keys:
+    val = env.get(key)
+    if val:
+        err("no-provider-secrets")
+        break
+
+blob = json.dumps({"labels": labels, "env": env, "name": name})
+if re.search(r"\.local\b", blob):
+    err("no-local-domain")
+
+if errors:
+    for e in errors:
+        print(f"FAIL: {e}", file=sys.stderr)
+    sys.exit(1)
+print(f"ok: rendered-contract instance={expect_instance} project={expect_project}", file=sys.stderr)
+sys.exit(0)
+PY
+  then
+    echo "FAIL: rendered-contract" >&2
+    exit 1
+  fi
+
+  # Optional mutation probes: defective snippets must be detected.
+  if ! python3 - "$COMPOSE_FILE" "$tmpdir" "$ROOT" <<'PY'
+import json, os, pathlib, subprocess, sys
+
+base_path = pathlib.Path(sys.argv[1])
+tmpdir = pathlib.Path(sys.argv[2])
+root = pathlib.Path(sys.argv[3])
+src = base_path.read_text()
+
+def write_mut(name, text):
+    p = tmpdir / f"mut-{name}.yml"
+    p.write_text(text)
+    return p
+
+mutations = [
+    ("wildcard-host", src.replace('"127.0.0.1::3847"', '"0.0.0.0::3847"'), "publish-loopback"),
+    ("fixed-host-port", src.replace('"127.0.0.1::3847"', '"127.0.0.1:3847:3847"'), "publish-ephemeral"),
+    ("missing-enable-label", src.replace('\n      stacklane.enable: "true"\n', "\n"), "label-enable"),
+]
+
+failures = 0
+for name, text, expect in mutations:
+    mut_path = write_mut(name, text)
+    out = tmpdir / f"mut-{name}.json"
+    errf = tmpdir / f"mut-{name}.err"
+    env = os.environ.copy()
+    env["STACKLANE_INSTANCE"] = "mutprobe"
+    env["STACKLANE_BASE_DOMAIN"] = env.get("STACKLANE_BASE_DOMAIN", "test")
+    env["COMPOSE_PROJECT_NAME"] = "switchboard-mutprobe"
+    try:
+        proc = subprocess.run(
+            [
+                "docker", "compose", "-p", "switchboard-mutprobe",
+                "--project-directory", str(root),
+                "-f", str(mut_path),
+                "config", "--format", "json",
+            ],
+            check=False,
+            env=env,
+            stdout=out.open("w"),
+            stderr=errf.open("w"),
+            timeout=60,
+        )
+    except Exception:
+        print(f"ok: mutation-{name}-config-rejected", file=sys.stderr)
+        continue
+    if proc.returncode != 0:
+        print(f"ok: mutation-{name}-config-rejected", file=sys.stderr)
+        continue
+    try:
+        cfg = json.loads(out.read_text())
+    except Exception:
+        print(f"ok: mutation-{name}-invalid-json", file=sys.stderr)
+        continue
+    services = cfg.get("services") or {}
+    app = services.get("app") or {}
+    bad = False
+    if name == "wildcard-host":
+        for p in app.get("ports") or []:
+            if isinstance(p, dict) and p.get("host_ip") != "127.0.0.1":
+                bad = True
+    elif name == "fixed-host-port":
+        for p in app.get("ports") or []:
+            if isinstance(p, dict) and p.get("published") not in (None, "", 0, "0"):
+                bad = True
+    elif name == "missing-enable-label":
+        labels = app.get("labels") or {}
+        if isinstance(labels, list):
+            kv = {}
+            for item in labels:
+                if isinstance(item, str) and "=" in item:
+                    k, v = item.split("=", 1)
+                    kv[k] = v
+            labels = kv
+        if str(labels.get("stacklane.enable", "")) not in ("true", "1"):
+            bad = True
+    if not bad:
+        print(f"FAIL: mutation-{name}", file=sys.stderr)
+        failures += 1
+    else:
+        print(f"ok: mutation-{name}", file=sys.stderr)
+
+if failures:
+    sys.exit(2)
+sys.exit(0)
+PY
+  then
+    echo "FAIL: mutation-probes" >&2
+    exit 1
+  fi
+
+  info "ok: check"
+  cleanup_check
+}
+
+cmd_up() {
+  require_docker
+  export_stack_env
+  cmd_check
+  info "building images (project=${COMPOSE_PROJECT} instance=${INSTANCE})…"
+  compose build
+  info "starting stack…"
+  compose up -d --remove-orphans
+  wait_healthy 360
+  print_endpoints
+}
+
+cmd_status() {
+  require_docker
+  export_stack_env
+  compose ps
+  echo
+  print_endpoints
+}
+
+cmd_logs() {
+  require_docker
+  export_stack_env
+  # Ctrl-C stops following only; it does not tear the stack down.
+  if [[ $# -eq 0 ]]; then
+    compose logs -f
+  else
+    compose logs "$@"
+  fi
+}
+
+cmd_down() {
+  require_docker
+  export_stack_env
+  info "stopping stack (volumes preserved; never uses -v)…"
+  compose down --remove-orphans
+}
+
+cmd_destroy() {
+  export_stack_env
+  local expect="${COMPOSE_PROJECT}-destroy"
+  if [[ "${CONFIRM:-}" != "$expect" ]]; then
+    die "refusing destroy: set CONFIRM=${expect} to remove volumes for project ${COMPOSE_PROJECT}"
+  fi
+  require_docker
+  info "destroying stack AND volumes for ${COMPOSE_PROJECT}…"
+  compose down -v --remove-orphans
+}
+
+cmd_endpoints() {
+  require_docker
+  export_stack_env
+  print_endpoints
+}
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/compose-dev.sh <command>
+
+Commands:
+  check       Fail-closed Stacklane/compose contract validation
+  up          check + build + up -d + wait healthy + print endpoints
+  status      compose ps + endpoint table
+  endpoints   print FQDNs + direct loopback mappings
+  logs        follow compose logs (Ctrl-C leaves the stack running)
+  down        compose down (never -v; volumes preserved)
+  destroy     compose down -v (requires CONFIRM=<compose-project>-destroy)
+
+Environment:
+  STACKLANE_INSTANCE     override instance slug (else worktree dirname / branch / dev)
+  STACKLANE_BASE_DOMAIN  FQDN base (default: host daemon base_domain, else test)
+  CONFIRM                required for destroy; must equal switchboard-<instance>-destroy
+
+Notes:
+  - Host fallback is unchanged: `air` / `make build` / production docker-compose.yml.
+  - No GitHub/Linear/provider tokens are required; the web UI starts with integrations disabled.
+  - Stacklane daemon is optional; direct 127.0.0.1 ephemeral ports always work.
+  - Compose project is always switchboard-<instance> via `docker compose -p`.
+EOF
+}
+
+main() {
+  local cmd="${1:-}"
+  shift || true
+  case "$cmd" in
+    check) cmd_check "$@" ;;
+    up) cmd_up "$@" ;;
+    status) cmd_status "$@" ;;
+    endpoints) cmd_endpoints "$@" ;;
+    logs) cmd_logs "$@" ;;
+    down) cmd_down "$@" ;;
+    destroy) cmd_destroy "$@" ;;
+    -h|--help|help|"") usage; [[ -n "$cmd" ]] || exit 1 ;;
+    *) die "unknown command: $cmd (try --help)" ;;
+  esac
+}
+
+main "$@"

--- a/scripts/compose-dev_test.sh
+++ b/scripts/compose-dev_test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Lifecycle contract tests for scripts/compose-dev.sh (no long-running stack).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="${ROOT}/scripts/compose-dev.sh"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+ok() { echo "ok: $*" >&2; }
+
+[[ -x "$SCRIPT" ]] || fail "compose-dev.sh must be executable"
+[[ -f "${ROOT}/docker-compose.dev.yml" ]] || fail "missing docker-compose.dev.yml"
+[[ -f "${ROOT}/Dockerfile.dev" ]] || fail "missing Dockerfile.dev"
+[[ -f "${ROOT}/paseo.json" ]] || fail "missing paseo.json"
+
+help_out="$("$SCRIPT" --help)"
+printf '%s\n' "$help_out" | grep -q 'check' || fail "help missing check"
+printf '%s\n' "$help_out" | grep -q 'up' || fail "help missing up"
+printf '%s\n' "$help_out" | grep -q 'status' || fail "help missing status"
+printf '%s\n' "$help_out" | grep -q 'endpoints' || fail "help missing endpoints"
+printf '%s\n' "$help_out" | grep -q 'logs' || fail "help missing logs"
+printf '%s\n' "$help_out" | grep -q 'down' || fail "help missing down"
+printf '%s\n' "$help_out" | grep -q 'destroy' || fail "help missing destroy"
+ok "help verbs"
+
+if "$SCRIPT" destroy >/tmp/switchboard-compose-destroy.err 2>&1; then
+  fail "destroy without CONFIRM must fail"
+fi
+grep -q 'refusing destroy' /tmp/switchboard-compose-destroy.err || fail "destroy refusal message"
+ok "destroy refused without CONFIRM"
+
+if CONFIRM=wrong-destroy "$SCRIPT" destroy >/tmp/switchboard-compose-destroy2.err 2>&1; then
+  fail "destroy with wrong CONFIRM must fail"
+fi
+grep -q 'refusing destroy' /tmp/switchboard-compose-destroy2.err || fail "wrong CONFIRM must refuse"
+ok "destroy refused with wrong CONFIRM"
+
+if awk '/^cmd_down\(\)/,/^}/ {print}' "$SCRIPT" | grep -vE '^[[:space:]]*#' | grep -qE 'down[[:space:]].*-v|[[:space:]]-v([[:space:]]|$)'; then
+  fail "cmd_down must not pass -v"
+fi
+ok "down never uses -v"
+
+if ! awk '/^cmd_destroy\(\)/,/^}/ {print}' "$SCRIPT" | grep -vE '^[[:space:]]*#' | grep -q -- 'down -v'; then
+  fail "cmd_destroy must use down -v"
+fi
+ok "destroy uses down -v after CONFIRM"
+
+if ! grep -q 'docker compose -p "$COMPOSE_PROJECT"' "$SCRIPT"; then
+  fail "lifecycle must pass docker compose -p"
+fi
+ok "compose -p present"
+
+if grep -qE 'GITHUB_TOKEN|LINEAR_API_KEY' "${ROOT}/docker-compose.dev.yml"; then
+  fail "dev compose must not interpolate provider tokens"
+fi
+ok "dev compose has no provider tokens"
+
+if grep -q '3847:3847' "${ROOT}/docker-compose.dev.yml"; then
+  fail "dev compose must not use fixed host ports"
+fi
+if ! grep -q '127.0.0.1::3847' "${ROOT}/docker-compose.dev.yml"; then
+  fail "dev compose must publish 127.0.0.1::3847"
+fi
+ok "dev publish form"
+
+python3 - "$ROOT/paseo.json" <<'PY'
+import json, sys
+path = sys.argv[1]
+data = json.load(open(path, encoding="utf-8"))
+scripts = data.get("scripts") or {}
+required = ("check", "up", "down", "status", "endpoints", "logs", "test", "ci")
+missing = [k for k in required if k not in scripts]
+if missing:
+    print(f"FAIL: paseo.json missing {missing}", file=sys.stderr)
+    sys.exit(1)
+PY
+ok "paseo.json scripts"
+
+echo "ok: compose-dev lifecycle tests"


### PR DESCRIPTION
## Summary
Adds a worktree-isolated Docker Compose DEV stack so parallel checkouts can run Switchboard without host-port collisions.

- New `docker-compose.dev.yml` publishes only `127.0.0.1::3847` with Stacklane labels (`project=switchboard`, `endpoint=app`, public port 3847).
- `scripts/compose-dev.sh` is the lifecycle wrapper (`check`/`up`/`status`/`endpoints`/`logs`/`down`/`destroy`) and always uses `docker compose -p switchboard-<instance>`.
- `paseo.json` exposes plain lifecycle scripts only (no `type:service`, no `$PASEO_PORT`).
- Production `docker-compose.yml` stays the published-image fallback with its existing fixed host port.
- Host `air` / `make build` remain the non-Docker path. `wasm/guest-rust` is untouched.

## Test plan
- [x] `bash scripts/compose-dev_test.sh` (destroy CONFIRM, no `-v` on down, publish form, paseo.json scripts)
- [x] `STACKLANE_INSTANCE=slc-check bash scripts/compose-dev.sh check` (rendered contract + mutation probes)
- [x] `make test` (Go tests + compose lifecycle tests)
- [x] `make ci` (build, vet, race, lint, gosec, govulncheck)
- [ ] GitHub CI: `build`, `test`, `lint`, `security`, `rust-sdk`, new `compose` job