### PR TITLE
Document Go 1.26.6 baseline

### DIFF
--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -28,7 +28,7 @@
 - **Testing**: `stretchr/testify` assertions. Tests in every package
 - **Linting**: `.golangci.yml` — errcheck, govet, ineffassign, nestif, staticcheck, unused
 - **CI**: `.github/workflows/ci.yml` — build, test (race), gofmt, golangci-lint, gosec, govulncheck
-- **Go 1.26** — deps: `go-sdk`, `go-github/v68`, `slack-go/slack`, `a-h/templ`, `lib/pq`, `clickhouse-go/v2`, `testify`
+- **Go 1.26.6** — deps: `go-sdk`, `go-github/v68`, `slack-go/slack`, `a-h/templ`, `lib/pq`, `clickhouse-go/v2`, `testify`
 
 ## CLI & Daemon
 


### PR DESCRIPTION
## Summary
- document the maintained Go 1.26.6 baseline in the web UI build-tooling guide
- preserve the existing `go.mod` directive and `setup-go` `go-version-file` configuration, which already resolve CI and release builds to Go 1.26.6

## Verification
- `GOMAXPROCS=2 GOFLAGS=-p=1 make ci`
- `go mod tidy -diff`
- `git diff --check`

## Scope notes
- This repository has one maintained Go module (`go.mod`), already declaring `go 1.26.6`.
- CI, release, and Crush review workflows already consume `go.mod` through `actions/setup-go`; no redundant hard-coded version was added.
- Historical planning text and agent guidance that intentionally use broader Go-version compatibility language were left unchanged.