### PR TITLE
Add Paperless and Recoll document search integrations

### DIFF
--- a/.agents/skills/add-integration/SKILL.md
+++ b/.agents/skills/add-integration/SKILL.md
@@ -6,7 +6,7 @@ description: >
   Not for modifying existing integrations or fixing bugs in current adapters.
 metadata:
   author: switchboard
-  version: "1.0"
+  version: "1.1"
 ---
 
 # Add Integration
@@ -177,7 +177,37 @@ Every adapter must have these test categories (see existing `*_test.go` files):
 Follow `AGENTS.md > Adding a New Integration` steps 6-7 (register + config defaults), then verify:
 
 1. `go build ./...` && `go test ./...` && `go vet ./...` && `go tool golangci-lint run`
-2. Smoke test: start server, call `search` for new integration tools, `execute` one
+2. Run the isolated live smoke test below.
+
+### Isolated Live Smoke Test
+
+Never run a development Switchboard against the host configuration or default port. Use a dedicated temporary home directory and a non-standard port (`13847` below). This keeps the host Switchboard, its credentials, and its project catalog untouched.
+
+Start the development server in one terminal:
+
+```bash
+sandbox="$(mktemp -d)"
+export SWITCHBOARD_DEV_HOME="$sandbox/switchboard-home"
+HOME="$SWITCHBOARD_DEV_HOME" go run ./cmd/server --port 13847
+```
+
+Configure only the test credentials needed for the new integration in `$SWITCHBOARD_DEV_HOME/.config/switchboard/config.json`, using the development Web UI at `http://127.0.0.1:13847/` if appropriate. Do not copy the host Switchboard config into this directory.
+
+In a second terminal, give the test agent its own config root. Copy the existing Crush configuration only to retain its provider setup, then add an MCP entry pointing to the development server. The copy is isolated: the generated `crushrc` changes only the sandboxed configuration.
+
+```bash
+host_crush_config="${XDG_CONFIG_HOME:-$HOME/.config}/crush"
+export CRUSH_DEV_CONFIG="$sandbox/crush-config"
+mkdir -p "$CRUSH_DEV_CONFIG"
+cp -a "$host_crush_config" "$CRUSH_DEV_CONFIG/crush"
+cat >> "$CRUSH_DEV_CONFIG/crush/crushrc" <<'EOF'
+mcp add switchboard-dev --type http --url http://127.0.0.1:13847/mcp
+EOF
+XDG_CONFIG_HOME="$CRUSH_DEV_CONFIG" crush --cwd "$PWD" run \
+  "Use the switchboard-dev MCP only. Search for the new integration's tools, then execute a safe read-only tool and report the result."
+```
+
+The agent must first discover the tool with `search`, then call it with `execute`. Confirm the response represents real data and that the new tool is returned by search. Remove the sandbox after testing: `rm -rf "$sandbox"`.
 
 ## 6. Field Compaction
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,9 @@ Environment variables override credential values but do not change the durable e
 | Slack MCP (official hosted) | multi-identity `access_token` | configure via `identities` in JSON (see below) |
 | Metabase | `api_key` | `METABASE_API_KEY` |
 | Metabase | `url` | `METABASE_URL` |
+| Paperless-ngx | `token` | `PAPERLESS_TOKEN` |
+| Paperless-ngx | `url` | `PAPERLESS_URL` |
+| Recoll WebUI | `base_url` | `RECOLL_URL` |
 | AWS | `access_key_id` | `AWS_ACCESS_KEY_ID` |
 | AWS | `secret_access_key` | `AWS_SECRET_ACCESS_KEY` |
 | AWS | `session_token` | `AWS_SESSION_TOKEN` |
@@ -260,6 +263,8 @@ Some integrations support OAuth flows through the web UI at `http://localhost:38
 | Datadog | API + App Key | Set `DD_API_KEY` and `DD_APP_KEY` env vars or enter in web UI |
 | AWS | IAM Credentials | Set `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` env vars, or uses default credential chain |
 | Metabase | API Key | Set `METABASE_API_KEY` and `METABASE_URL` env vars or enter in web UI |
+| Paperless-ngx | API Token | Set `PAPERLESS_TOKEN` and `PAPERLESS_URL` env vars or enter in web UI |
+| Recoll WebUI | Base URL | Set `RECOLL_URL` to the Recoll WebUI root (for example `http://localhost:8080`) or enter it in the web UI |
 | PostHog | Personal API Key | Set `POSTHOG_API_KEY` env var or enter in web UI |
 | Vercel | Personal Access Token | Set `VERCEL_API_TOKEN` env var or enter in web UI |
 | Postgres | Connection String | Set `DATABASE_URL` env var or enter in web UI |

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -55,11 +55,13 @@ import (
 	nomadInt "github.com/daltoniam/switchboard/integrations/nomad"
 	notionInt "github.com/daltoniam/switchboard/integrations/notion"
 	"github.com/daltoniam/switchboard/integrations/ollama"
+	"github.com/daltoniam/switchboard/integrations/paperless"
 	"github.com/daltoniam/switchboard/integrations/pganalyze"
 	"github.com/daltoniam/switchboard/integrations/postgres"
 	"github.com/daltoniam/switchboard/integrations/posthog"
 	"github.com/daltoniam/switchboard/integrations/projectinterop"
 	"github.com/daltoniam/switchboard/integrations/ramp"
+	"github.com/daltoniam/switchboard/integrations/recoll"
 	"github.com/daltoniam/switchboard/integrations/rwx"
 	"github.com/daltoniam/switchboard/integrations/salesforce"
 	"github.com/daltoniam/switchboard/integrations/sentry"
@@ -302,6 +304,8 @@ func runServer(stdioMode bool, port int, listenHost, grpcSocket string, discover
 		slackInt.New(),
 		slackmcp.New(),
 		metabase.New(),
+		paperless.New(),
+		recoll.New(),
 		awsInt.New(),
 		posthog.New(),
 		postgres.New(),

--- a/config/config.go
+++ b/config/config.go
@@ -43,6 +43,13 @@ var envMapping = map[string]map[string]string{
 		"api_key": "METABASE_API_KEY",
 		"url":     "METABASE_URL",
 	},
+	"paperless": {
+		"token": "PAPERLESS_TOKEN",
+		"url":   "PAPERLESS_URL",
+	},
+	"recoll": {
+		"base_url": "RECOLL_URL",
+	},
 	"aws": {
 		"access_key_id":     "AWS_ACCESS_KEY_ID",
 		"secret_access_key": "AWS_SECRET_ACCESS_KEY",
@@ -269,6 +276,14 @@ func defaultConfig() *mcp.Config {
 			"metabase": {
 				Enabled:     false,
 				Credentials: mcp.Credentials{"api_key": "", "url": ""},
+			},
+			"paperless": {
+				Enabled:     false,
+				Credentials: mcp.Credentials{"token": "", "url": ""},
+			},
+			"recoll": {
+				Enabled:     false,
+				Credentials: mcp.Credentials{"base_url": ""},
 			},
 			"aws": {
 				Enabled:     false,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -32,8 +32,8 @@ func TestLoad_CreatesDefaultWhenMissing(t *testing.T) {
 	_, err = os.Stat(path)
 	assert.NoError(t, err)
 
-	assert.Len(t, m.cfg.Integrations, 53)
-	for _, name := range []string{"github", "datadog", "linear", "sentry", "slack", "slackmcp", "metabase", "aws", "posthog", "postgres", "clickhouse", "elasticsearch", "pganalyze", "rwx", "projectinterop", "gmail", "gcal", "gdrive", "gdocs", "gsheets", "gslides", "gforms", "gchat", "gmeet", "gtasks", "gpeople", "notion", "ollama", "ynab", "stripe", "gcp", "suno", "amazon", "jira", "confluence", "salesforce", "cloudflare", "digitalocean", "fly", "kubernetes", "vercel", "snowflake", "acp", "web", "botidentity", "x", "signoz", "nomad", "agents", "switchboard", "netsuite", "ramp", "gong"} {
+	assert.Len(t, m.cfg.Integrations, 55)
+	for _, name := range []string{"github", "datadog", "linear", "sentry", "slack", "slackmcp", "metabase", "paperless", "recoll", "aws", "posthog", "postgres", "clickhouse", "elasticsearch", "pganalyze", "rwx", "projectinterop", "gmail", "gcal", "gdrive", "gdocs", "gsheets", "gslides", "gforms", "gchat", "gmeet", "gtasks", "gpeople", "notion", "ollama", "ynab", "stripe", "gcp", "suno", "amazon", "jira", "confluence", "salesforce", "cloudflare", "digitalocean", "fly", "kubernetes", "vercel", "snowflake", "acp", "web", "botidentity", "x", "signoz", "nomad", "agents", "switchboard", "netsuite", "ramp", "gong"} {
 		ic, ok := m.cfg.Integrations[name]
 		assert.True(t, ok, "missing default integration: %s", name)
 		assert.False(t, ic.Enabled)
@@ -154,7 +154,7 @@ func TestSave(t *testing.T) {
 
 	var cfg mcp.Config
 	require.NoError(t, json.Unmarshal(data, &cfg))
-	assert.Len(t, cfg.Integrations, 53)
+	assert.Len(t, cfg.Integrations, 55)
 }
 
 func TestGet(t *testing.T) {
@@ -163,7 +163,7 @@ func TestGet(t *testing.T) {
 
 	cfg := m.Get()
 	assert.NotNil(t, cfg)
-	assert.Len(t, cfg.Integrations, 53)
+	assert.Len(t, cfg.Integrations, 55)
 }
 
 func TestUpdate(t *testing.T) {
@@ -273,7 +273,7 @@ func TestEnabledIntegrations_Multiple(t *testing.T) {
 func TestDefaultConfig(t *testing.T) {
 	cfg := defaultConfig()
 	require.NotNil(t, cfg)
-	assert.Len(t, cfg.Integrations, 53)
+	assert.Len(t, cfg.Integrations, 55)
 
 	expected := map[string][]string{
 		"github":         {"token", "client_id", "token_source"},
@@ -283,6 +283,8 @@ func TestDefaultConfig(t *testing.T) {
 		"slack":          {"token", "cookie", "token_source"},
 		"slackmcp":       {"base_url"},
 		"metabase":       {"api_key", "url"},
+		"paperless":      {"token", "url"},
+		"recoll":         {"base_url"},
 		"aws":            {"access_key_id", "secret_access_key", "session_token", "region"},
 		"posthog":        {"api_key", "project_id", "base_url"},
 		"postgres":       {"connection_string", "host", "user", "read_only"},
@@ -581,13 +583,16 @@ func TestEnvMapping_ReturnsMapping(t *testing.T) {
 	assert.Equal(t, "KUBERNETES_IN_CLUSTER", m["kubernetes"]["in_cluster"])
 	assert.Equal(t, "KUBERNETES_CLUSTERS", m["kubernetes"]["clusters"])
 	assert.Equal(t, "KUBERNETES_ALLOW_MUTATIONS", m["kubernetes"]["allow_mutations"])
+	assert.Equal(t, "PAPERLESS_TOKEN", m["paperless"]["token"])
+	assert.Equal(t, "PAPERLESS_URL", m["paperless"]["url"])
+	assert.Equal(t, "RECOLL_URL", m["recoll"]["base_url"])
 	assert.Equal(t, "VERCEL_API_TOKEN", m["vercel"]["api_token"])
 	assert.Equal(t, "VERCEL_TEAM_ID", m["vercel"]["team_id"])
 	assert.Equal(t, "VERCEL_TEAM_SLUG", m["vercel"]["team_slug"])
 	assert.Equal(t, "VERCEL_BASE_URL", m["vercel"]["base_url"])
 	// 28 base integrations + 11 Google Workspace services sharing the
 	// GOOGLE_OAUTH_CLIENT_ID/SECRET env vars.
-	assert.Len(t, m, 42)
+	assert.Len(t, m, 44)
 	for _, name := range googleWorkspaceIntegrations {
 		assert.Equal(t, "GOOGLE_OAUTH_CLIENT_ID", m[name][mcp.CredKeyClientID])
 		assert.Equal(t, "GOOGLE_OAUTH_CLIENT_SECRET", m[name][mcp.CredKeyClientSecret])

--- a/integrations/paperless/compact.yaml
+++ b/integrations/paperless/compact.yaml
@@ -1,0 +1,56 @@
+# Switchboard compaction specs for the Paperless-ngx integration.
+version: 1
+tools:
+  paperless_list_documents:
+    spec:
+      - count
+      - next
+      - previous
+      - results[].id
+      - results[].title
+      - results[].created
+      - results[].added
+      - results[].modified
+      - results[].correspondent
+      - results[].document_type
+      - results[].tags
+      - results[].archive_serial_number
+  paperless_search_documents:
+    spec:
+      - count
+      - next
+      - previous
+      - results[].id
+      - results[].title
+      - results[].created
+      - results[].added
+      - results[].modified
+      - results[].correspondent
+      - results[].document_type
+      - results[].tags
+      - results[].archive_serial_number
+  paperless_get_document:
+    spec:
+      - id
+      - title
+      - content
+      - created
+      - added
+      - modified
+      - correspondent
+      - document_type
+      - storage_path
+      - tags
+      - custom_fields
+      - archive_serial_number
+      - original_file_name
+  paperless_list_tags:
+    spec: [count, next, previous, "results[].id", "results[].name", "results[].color", "results[].document_count"]
+  paperless_list_correspondents:
+    spec: [count, next, previous, "results[].id", "results[].name", "results[].document_count"]
+  paperless_list_document_types:
+    spec: [count, next, previous, "results[].id", "results[].name", "results[].document_count"]
+  paperless_list_storage_paths:
+    spec: [count, next, previous, "results[].id", "results[].name", "results[].path", "results[].document_count"]
+  paperless_list_custom_fields:
+    spec: [count, next, previous, "results[].id", "results[].name", "results[].data_type"]

--- a/integrations/paperless/compact_specs_test.go
+++ b/integrations/paperless/compact_specs_test.go
@@ -1,0 +1,31 @@
+package paperless
+
+import (
+	"testing"
+
+	"github.com/daltoniam/switchboard/compact"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestFieldCompactionSpecs(t *testing.T) {
+	var specFile compact.SpecFile
+	require.NoError(t, yaml.Unmarshal(compactYAML, &specFile))
+	require.NotEmpty(t, fieldCompactionSpecs)
+	assert.Equal(t, len(specFile.Tools), len(fieldCompactionSpecs))
+
+	for toolName := range fieldCompactionSpecs {
+		_, ok := dispatch[toolName]
+		assert.True(t, ok, "field compaction spec for %q has no dispatch handler", toolName)
+	}
+}
+
+func TestFieldCompactionSpecExcludesMutations(t *testing.T) {
+	p := &paperless{}
+	fields, ok := p.CompactSpec("paperless_list_documents")
+	assert.True(t, ok)
+	assert.NotEmpty(t, fields)
+	_, ok = p.CompactSpec("paperless_update_document")
+	assert.False(t, ok)
+}

--- a/integrations/paperless/paperless.go
+++ b/integrations/paperless/paperless.go
@@ -1,0 +1,312 @@
+// Package paperless integrates Paperless-ngx document management instances.
+package paperless
+
+import (
+	"bytes"
+	"context"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/daltoniam/switchboard/compact"
+)
+
+//go:embed compact.yaml
+var compactYAML []byte
+
+var compactResult = compact.MustLoadWithOverlay("paperless", compactYAML, compact.Options{Strict: false})
+var fieldCompactionSpecs = compactResult.Specs
+
+var (
+	_ mcp.Integration                = (*paperless)(nil)
+	_ mcp.FieldCompactionIntegration = (*paperless)(nil)
+	_ mcp.PlainTextCredentials       = (*paperless)(nil)
+	_ mcp.PlaceholderHints           = (*paperless)(nil)
+)
+
+type paperless struct {
+	token   string
+	baseURL string
+	client  *http.Client
+}
+
+// New creates a Paperless-ngx integration.
+func New() mcp.Integration {
+	return &paperless{client: &http.Client{}}
+}
+
+func (p *paperless) Name() string { return "paperless" }
+
+func (p *paperless) PlainTextKeys() []string { return []string{"url"} }
+
+func (p *paperless) Placeholders() map[string]string {
+	return map[string]string{"url": "https://paperless.example.com"}
+}
+
+func (p *paperless) Configure(_ context.Context, creds mcp.Credentials) error {
+	p.token = creds["token"]
+	p.baseURL = strings.TrimRight(creds["url"], "/")
+	if p.token == "" {
+		return fmt.Errorf("paperless: token is required")
+	}
+	if p.baseURL == "" {
+		return fmt.Errorf("paperless: url is required")
+	}
+	return nil
+}
+
+func (p *paperless) Healthy(ctx context.Context) bool {
+	if p.client == nil || p.token == "" || p.baseURL == "" {
+		return false
+	}
+	_, err := p.get(ctx, "/api/users/me/")
+	return err == nil
+}
+
+func (p *paperless) Tools() []mcp.ToolDefinition { return tools }
+
+func (p *paperless) CompactSpec(toolName mcp.ToolName) ([]mcp.CompactField, bool) {
+	fields, ok := fieldCompactionSpecs[toolName]
+	return fields, ok
+}
+
+func (p *paperless) Execute(ctx context.Context, toolName mcp.ToolName, args map[string]any) (*mcp.ToolResult, error) {
+	fn, ok := dispatch[toolName]
+	if !ok {
+		return mcp.ErrResult(fmt.Errorf("unknown tool: %s", toolName))
+	}
+	return fn(ctx, p, args)
+}
+
+func (p *paperless) doRequest(ctx context.Context, method, path string, body any) ([]byte, error) {
+	var reader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("marshal Paperless request: %w", err)
+		}
+		reader = bytes.NewReader(data)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, p.baseURL+path, reader)
+	if err != nil {
+		return nil, fmt.Errorf("create Paperless request: %w", err)
+	}
+	req.Header.Set("Authorization", "Token "+p.token)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("make Paperless request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read Paperless response: %w", err)
+	}
+	if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= http.StatusInternalServerError {
+		retryErr := &mcp.RetryableError{StatusCode: resp.StatusCode, Err: fmt.Errorf("paperless API error (%d): %s", resp.StatusCode, data)}
+		retryErr.RetryAfter = mcp.ParseRetryAfter(resp.Header.Get("Retry-After"))
+		return nil, retryErr
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		return nil, fmt.Errorf("paperless API error (%d): %s", resp.StatusCode, data)
+	}
+	if resp.StatusCode == http.StatusNoContent || len(data) == 0 {
+		return []byte(`{"status":"success"}`), nil
+	}
+	return data, nil
+}
+
+func (p *paperless) get(ctx context.Context, path string) ([]byte, error) {
+	return p.doRequest(ctx, http.MethodGet, path, nil)
+}
+
+func listDocuments(ctx context.Context, p *paperless, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	page := r.OptInt("page", 1)
+	pageSize := r.OptInt("page_size", 25)
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	query := url.Values{"page": {strconv.Itoa(page)}, "page_size": {strconv.Itoa(pageSize)}}
+	data, err := p.get(ctx, "/api/documents/?"+query.Encode())
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func searchDocuments(ctx context.Context, p *paperless, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	queryText := r.Str("query")
+	if queryText == "" && r.Err() == nil {
+		return mcp.ErrResult(fmt.Errorf("query is required"))
+	}
+	page := r.OptInt("page", 1)
+	pageSize := r.OptInt("page_size", 25)
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	query := url.Values{"query": {queryText}, "page": {strconv.Itoa(page)}, "page_size": {strconv.Itoa(pageSize)}}
+	data, err := p.get(ctx, "/api/documents/?"+query.Encode())
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func createDocument(ctx context.Context, p *paperless, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	title := r.Str("title")
+	content := r.Str("content")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if title == "" {
+		return mcp.ErrResult(fmt.Errorf("title is required"))
+	}
+	if content == "" {
+		return mcp.ErrResult(fmt.Errorf("content is required"))
+	}
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	if err := writer.WriteField("title", title); err != nil {
+		return mcp.ErrResult(fmt.Errorf("write Paperless title field: %w", err))
+	}
+	file, err := writer.CreateFormFile("document", "document.txt")
+	if err != nil {
+		return mcp.ErrResult(fmt.Errorf("create Paperless document field: %w", err))
+	}
+	if _, err := io.WriteString(file, content); err != nil {
+		return mcp.ErrResult(fmt.Errorf("write Paperless document content: %w", err))
+	}
+	if err := writer.Close(); err != nil {
+		return mcp.ErrResult(fmt.Errorf("close Paperless multipart request: %w", err))
+	}
+
+	data, err := p.doMultipartRequest(ctx, "/api/documents/post_document/", &body, writer.FormDataContentType())
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func (p *paperless) doMultipartRequest(ctx context.Context, path string, body io.Reader, contentType string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+path, body)
+	if err != nil {
+		return nil, fmt.Errorf("create Paperless request: %w", err)
+	}
+	req.Header.Set("Authorization", "Token "+p.token)
+	req.Header.Set("Content-Type", contentType)
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("make Paperless request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read Paperless response: %w", err)
+	}
+	if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= http.StatusInternalServerError {
+		retryErr := &mcp.RetryableError{StatusCode: resp.StatusCode, Err: fmt.Errorf("paperless API error (%d): %s", resp.StatusCode, data)}
+		retryErr.RetryAfter = mcp.ParseRetryAfter(resp.Header.Get("Retry-After"))
+		return nil, retryErr
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		return nil, fmt.Errorf("paperless API error (%d): %s", resp.StatusCode, data)
+	}
+	if resp.StatusCode == http.StatusNoContent || len(data) == 0 {
+		return []byte(`{"status":"success"}`), nil
+	}
+	return data, nil
+}
+
+func getDocument(ctx context.Context, p *paperless, args map[string]any) (*mcp.ToolResult, error) {
+	id, err := documentID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := p.get(ctx, fmt.Sprintf("/api/documents/%d/", id))
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func updateDocument(ctx context.Context, p *paperless, args map[string]any) (*mcp.ToolResult, error) {
+	id, err := documentID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	body := make(map[string]any)
+	for _, key := range []string{"title", "correspondent", "document_type", "storage_path", "archive_serial_number", "created", "added", "tags", "custom_fields"} {
+		if value, ok := args[key]; ok {
+			body[key] = value
+		}
+	}
+	if len(body) == 0 {
+		return mcp.ErrResult(fmt.Errorf("at least one document field is required"))
+	}
+	data, err := p.doRequest(ctx, http.MethodPatch, fmt.Sprintf("/api/documents/%d/", id), body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func deleteDocument(ctx context.Context, p *paperless, args map[string]any) (*mcp.ToolResult, error) {
+	id, err := documentID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := p.doRequest(ctx, http.MethodDelete, fmt.Sprintf("/api/documents/%d/", id), nil)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func downloadDocument(ctx context.Context, p *paperless, args map[string]any) (*mcp.ToolResult, error) {
+	id, err := documentID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := p.get(ctx, fmt.Sprintf("/api/documents/%d/download/", id))
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return &mcp.ToolResult{Data: string(data)}, nil
+}
+
+func listMetadata(path string) handlerFunc {
+	return func(ctx context.Context, p *paperless, _ map[string]any) (*mcp.ToolResult, error) {
+		data, err := p.get(ctx, path)
+		if err != nil {
+			return mcp.ErrResult(err)
+		}
+		return mcp.RawResult(data)
+	}
+}
+
+func documentID(args map[string]any) (int, error) {
+	r := mcp.NewArgs(args)
+	id := r.Int("document_id")
+	if err := r.Err(); err != nil {
+		return 0, err
+	}
+	if id == 0 {
+		return 0, fmt.Errorf("document_id is required")
+	}
+	return id, nil
+}
+
+type handlerFunc func(context.Context, *paperless, map[string]any) (*mcp.ToolResult, error)

--- a/integrations/paperless/paperless_test.go
+++ b/integrations/paperless/paperless_test.go
@@ -1,0 +1,191 @@
+package paperless
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAndConfigure(t *testing.T) {
+	i := New()
+	require.NotNil(t, i)
+	assert.Equal(t, "paperless", i.Name())
+	assert.NoError(t, i.Configure(context.Background(), mcp.Credentials{
+		"token": "paperless-token",
+		"url":   "https://paperless.example.com/",
+	}))
+
+	for name, creds := range map[string]mcp.Credentials{
+		"missing token": {"url": "https://paperless.example.com"},
+		"missing url":   {"token": "paperless-token"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := New().Configure(context.Background(), creds)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "required")
+		})
+	}
+}
+
+func TestToolsAndDispatchParity(t *testing.T) {
+	i := New()
+	seen := make(map[mcp.ToolName]bool)
+	for _, tool := range i.Tools() {
+		assert.NotEmpty(t, tool.Name)
+		assert.Contains(t, string(tool.Name), "paperless_")
+		assert.NotEmpty(t, tool.Description)
+		assert.False(t, seen[tool.Name], "duplicate tool %s", tool.Name)
+		seen[tool.Name] = true
+		_, handled := dispatch[tool.Name]
+		assert.True(t, handled, "tool %s has no dispatch handler", tool.Name)
+	}
+	for name := range dispatch {
+		assert.True(t, seen[name], "dispatch handler %s has no tool definition", name)
+	}
+}
+
+func TestCreateDocument(t *testing.T) {
+	var gotTitle, gotContent, gotFilename string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/documents/post_document/", r.URL.Path)
+		assert.Equal(t, "Token paperless-token", r.Header.Get("Authorization"))
+		require.NoError(t, r.ParseMultipartForm(1<<20))
+		gotTitle = r.FormValue("title")
+		file, header, err := r.FormFile("document")
+		require.NoError(t, err)
+		defer func() { _ = file.Close() }()
+		content, err := io.ReadAll(file)
+		require.NoError(t, err)
+		gotContent = string(content)
+		gotFilename = header.Filename
+		_, _ = w.Write([]byte(`{"task_id":"123"}`))
+	}))
+	defer ts.Close()
+
+	p := &paperless{token: "paperless-token", baseURL: ts.URL, client: ts.Client()}
+	result, err := p.Execute(context.Background(), "paperless_create_document", map[string]any{
+		"title":   "Live test document",
+		"content": "Safe test content",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "123")
+	assert.Equal(t, "Live test document", gotTitle)
+	assert.Equal(t, "Safe test content", gotContent)
+	assert.Equal(t, "document.txt", gotFilename)
+}
+
+func TestCreateDocumentArgumentErrors(t *testing.T) {
+	p := &paperless{}
+	for _, tt := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{name: "missing title", args: map[string]any{"content": "Safe test content"}, want: "title is required"},
+		{name: "missing content", args: map[string]any{"title": "Live test document"}, want: "content is required"},
+		{name: "invalid title type", args: map[string]any{"title": []string{"invalid"}, "content": "Safe test content"}, want: `parameter "title"`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := p.Execute(context.Background(), "paperless_create_document", tt.args)
+			require.NoError(t, err)
+			assert.True(t, result.IsError)
+			assert.Contains(t, result.Data, tt.want)
+		})
+	}
+}
+
+func TestExecuteDocumentOperations(t *testing.T) {
+	var gotQuery string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Token paperless-token", r.Header.Get("Authorization"))
+		switch r.URL.Path {
+		case "/api/documents/":
+			gotQuery = r.URL.RawQuery
+			_, _ = w.Write([]byte(`{"count":1,"results":[{"id":7,"title":"Invoice"}]}`))
+		case "/api/documents/7/":
+			switch r.Method {
+			case http.MethodGet:
+				_, _ = w.Write([]byte(`{"id":7,"title":"Invoice"}`))
+			case http.MethodPatch:
+				var body map[string]any
+				require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+				assert.Equal(t, "Paid invoice", body["title"])
+				_, _ = w.Write([]byte(`{"id":7,"title":"Paid invoice"}`))
+			case http.MethodDelete:
+				w.WriteHeader(http.StatusNoContent)
+			}
+		case "/api/documents/7/download/":
+			_, _ = w.Write([]byte("PDF bytes"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	p := &paperless{token: "paperless-token", baseURL: ts.URL, client: ts.Client()}
+	for _, tt := range []struct {
+		name string
+		tool mcp.ToolName
+		args map[string]any
+		want string
+	}{
+		{"list", "paperless_list_documents", map[string]any{"page": 2, "page_size": 25}, "Invoice"},
+		{"search", "paperless_search_documents", map[string]any{"query": "invoice"}, "Invoice"},
+		{"get", "paperless_get_document", map[string]any{"document_id": 7}, "Invoice"},
+		{"update", "paperless_update_document", map[string]any{"document_id": 7, "title": "Paid invoice"}, "Paid invoice"},
+		{"delete", "paperless_delete_document", map[string]any{"document_id": 7}, "success"},
+		{"download", "paperless_download_document", map[string]any{"document_id": 7}, "PDF bytes"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := p.Execute(context.Background(), tt.tool, tt.args)
+			require.NoError(t, err)
+			assert.False(t, result.IsError)
+			assert.Contains(t, result.Data, tt.want)
+		})
+	}
+	assert.Contains(t, gotQuery, "query=invoice")
+}
+
+func TestMetadataAndHTTPFailures(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/tags/", "/api/correspondents/", "/api/document_types/", "/api/storage_paths/", "/api/custom_fields/":
+			_, _ = w.Write([]byte(`{"count":1,"results":[{"id":1,"name":"Example"}]}`))
+		case "/api/users/me/":
+			_, _ = w.Write([]byte(`{"username":"admin"}`))
+		default:
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"detail":"Invalid token."}`))
+		}
+	}))
+	defer ts.Close()
+
+	p := &paperless{token: "token", baseURL: ts.URL, client: ts.Client()}
+	for _, tool := range []mcp.ToolName{"paperless_list_tags", "paperless_list_correspondents", "paperless_list_document_types", "paperless_list_storage_paths", "paperless_list_custom_fields"} {
+		result, err := p.Execute(context.Background(), tool, nil)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+		assert.Contains(t, result.Data, "Example")
+	}
+	assert.True(t, p.Healthy(context.Background()))
+
+	_, err := p.get(context.Background(), "/api/missing/")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "paperless API error (401)")
+}
+
+func TestExecuteUnknownTool(t *testing.T) {
+	result, err := New().Execute(context.Background(), "paperless_unknown", nil)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "unknown tool")
+}

--- a/integrations/paperless/tools.go
+++ b/integrations/paperless/tools.go
@@ -1,0 +1,69 @@
+package paperless
+
+import mcp "github.com/daltoniam/switchboard"
+
+var tools = []mcp.ToolDefinition{
+	{
+		Name:        "paperless_list_documents",
+		Description: "List archived Paperless-ngx documents with pagination. Start here to browse a document archive, invoices, receipts, and scanned records.",
+		Parameters:  map[string]string{"page": "Page number (default: 1)", "page_size": "Documents per page (default: 25)"},
+	},
+	{
+		Name:        "paperless_search_documents",
+		Description: "Search Paperless-ngx archived documents by full-text query, title, or OCR content. Start here to find scanned documents, invoices, receipts, and records.",
+		Parameters:  map[string]string{"query": "Full-text search query", "page": "Page number (default: 1)", "page_size": "Documents per page (default: 25)"},
+		Required:    []string{"query"},
+	},
+	{
+		Name:        "paperless_create_document",
+		Description: "Create and upload a plain-text document to Paperless-ngx for safe live testing. Use title and short non-sensitive content; this creates a real archive document.",
+		Parameters:  map[string]string{"title": "Document title", "content": "Plain-text document content"},
+		Required:    []string{"title", "content"},
+	},
+	{
+		Name:        "paperless_get_document",
+		Description: "Get metadata and OCR text for a specific Paperless-ngx document. Use after listing or searching documents.",
+		Parameters:  map[string]string{"document_id": "Document ID"},
+		Required:    []string{"document_id"},
+	},
+	{
+		Name:        "paperless_update_document",
+		Description: "Update Paperless-ngx document metadata such as title, tags, correspondent, document type, storage path, or custom fields. Use after get_document.",
+		Parameters: map[string]string{
+			"document_id": "Document ID", "title": "New title", "tags": "Tag ID array", "correspondent": "Correspondent ID", "document_type": "Document type ID", "storage_path": "Storage path ID", "archive_serial_number": "Archive serial number", "created": "Document creation date", "added": "Date added", "custom_fields": "Custom field value array",
+		},
+		Required: []string{"document_id"},
+	},
+	{
+		Name:        "paperless_delete_document",
+		Description: "Permanently delete a Paperless-ngx document. Use after get_document when the document should be removed.",
+		Parameters:  map[string]string{"document_id": "Document ID"},
+		Required:    []string{"document_id"},
+	},
+	{
+		Name:        "paperless_download_document",
+		Description: "Download the original file for a Paperless-ngx document. Use after get_document when the document file is needed.",
+		Parameters:  map[string]string{"document_id": "Document ID"},
+		Required:    []string{"document_id"},
+	},
+	{Name: "paperless_list_tags", Description: "List Paperless-ngx tags used to categorize archived documents.", Parameters: map[string]string{}},
+	{Name: "paperless_list_correspondents", Description: "List Paperless-ngx correspondents such as vendors, senders, and organizations.", Parameters: map[string]string{}},
+	{Name: "paperless_list_document_types", Description: "List Paperless-ngx document types used to classify archived records.", Parameters: map[string]string{}},
+	{Name: "paperless_list_storage_paths", Description: "List Paperless-ngx storage paths that organize archived document files.", Parameters: map[string]string{}},
+	{Name: "paperless_list_custom_fields", Description: "List Paperless-ngx custom fields available on archived documents.", Parameters: map[string]string{}},
+}
+
+var dispatch = map[mcp.ToolName]handlerFunc{
+	"paperless_list_documents":      listDocuments,
+	"paperless_search_documents":    searchDocuments,
+	"paperless_create_document":     createDocument,
+	"paperless_get_document":        getDocument,
+	"paperless_update_document":     updateDocument,
+	"paperless_delete_document":     deleteDocument,
+	"paperless_download_document":   downloadDocument,
+	"paperless_list_tags":           listMetadata("/api/tags/"),
+	"paperless_list_correspondents": listMetadata("/api/correspondents/"),
+	"paperless_list_document_types": listMetadata("/api/document_types/"),
+	"paperless_list_storage_paths":  listMetadata("/api/storage_paths/"),
+	"paperless_list_custom_fields":  listMetadata("/api/custom_fields/"),
+}

--- a/integrations/recoll/compact.yaml
+++ b/integrations/recoll/compact.yaml
@@ -1,0 +1,5 @@
+# Recoll WebUI search result projections.
+version: 1
+tools:
+  recoll_search:
+    spec: [query, count, 'results[].path', 'results[].mime_type']

--- a/integrations/recoll/compact_specs_test.go
+++ b/integrations/recoll/compact_specs_test.go
@@ -1,0 +1,33 @@
+package recoll
+
+import (
+	"testing"
+
+	"github.com/daltoniam/switchboard/compact"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestFieldCompactionSpecs_AllParse(t *testing.T) {
+	require.NotEmpty(t, fieldCompactionSpecs)
+}
+
+func TestFieldCompactionSpecs_NoDuplicateTools(t *testing.T) {
+	var specFile compact.SpecFile
+	require.NoError(t, yaml.Unmarshal(compactYAML, &specFile))
+	assert.Equal(t, len(specFile.Tools), len(fieldCompactionSpecs))
+}
+
+func TestFieldCompactionSpecs_NoOrphanSpecs(t *testing.T) {
+	for toolName := range fieldCompactionSpecs {
+		_, ok := dispatch[toolName]
+		assert.True(t, ok, "compaction spec %s has no dispatch handler", toolName)
+	}
+}
+
+func TestFieldCompactionSpecs_SearchShape(t *testing.T) {
+	fields, ok := New().(*recoll).CompactSpec("recoll_search")
+	assert.True(t, ok)
+	assert.NotEmpty(t, fields)
+}

--- a/integrations/recoll/recoll.go
+++ b/integrations/recoll/recoll.go
@@ -1,0 +1,126 @@
+// Package recoll provides access to the Recoll WebUI search endpoint.
+package recoll
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/daltoniam/switchboard/compact"
+)
+
+//go:embed compact.yaml
+var compactYAML []byte
+
+var compactResult = compact.MustLoadWithOverlay("recoll", compactYAML, compact.Options{Strict: false})
+var fieldCompactionSpecs = compactResult.Specs
+
+var (
+	_ mcp.Integration                = (*recoll)(nil)
+	_ mcp.PlainTextCredentials       = (*recoll)(nil)
+	_ mcp.PlaceholderHints           = (*recoll)(nil)
+	_ mcp.FieldCompactionIntegration = (*recoll)(nil)
+	_ mcp.ToolMaxBytesIntegration    = (*recoll)(nil)
+)
+
+type recoll struct {
+	baseURL string
+	client  *http.Client
+}
+
+// New creates a Recoll WebUI integration.
+func New() mcp.Integration {
+	return &recoll{client: &http.Client{Timeout: 30 * time.Second}}
+}
+
+func (r *recoll) Name() string { return "recoll" }
+
+func (r *recoll) Configure(_ context.Context, creds mcp.Credentials) error {
+	r.baseURL = strings.TrimRight(creds["base_url"], "/")
+	if r.baseURL == "" {
+		return fmt.Errorf("recoll: base_url is required")
+	}
+	if _, err := url.ParseRequestURI(r.baseURL); err != nil {
+		return fmt.Errorf("recoll: invalid base_url: %w", err)
+	}
+	if r.client == nil {
+		r.client = &http.Client{Timeout: 30 * time.Second}
+	}
+	return nil
+}
+
+func (r *recoll) Healthy(ctx context.Context) bool {
+	if r.client == nil || r.baseURL == "" {
+		return false
+	}
+	_, err := r.get(ctx, "/")
+	return err == nil
+}
+
+func (r *recoll) Tools() []mcp.ToolDefinition { return tools }
+
+func (r *recoll) CompactSpec(toolName mcp.ToolName) ([]mcp.CompactField, bool) {
+	fields, ok := fieldCompactionSpecs[toolName]
+	return fields, ok
+}
+
+func (r *recoll) MaxBytes(toolName mcp.ToolName) (int, bool) {
+	n, ok := compactResult.MaxBytes[toolName]
+	return n, ok
+}
+
+func (r *recoll) Execute(ctx context.Context, toolName mcp.ToolName, args map[string]any) (*mcp.ToolResult, error) {
+	if r.client == nil || r.baseURL == "" {
+		return &mcp.ToolResult{Data: "recoll: not configured", IsError: true}, nil
+	}
+	fn, ok := dispatch[toolName]
+	if !ok {
+		return &mcp.ToolResult{Data: fmt.Sprintf("unknown tool: %s", toolName), IsError: true}, nil
+	}
+	return fn(ctx, r, args)
+}
+
+func (r *recoll) PlainTextKeys() []string { return []string{"base_url"} }
+
+func (r *recoll) Placeholders() map[string]string {
+	return map[string]string{"base_url": "http://localhost:8080"}
+}
+
+func (r *recoll) get(ctx context.Context, path string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.baseURL+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("recoll: create request: %w", err)
+	}
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("recoll: request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 2*1024*1024))
+	if err != nil {
+		return nil, fmt.Errorf("recoll: read response: %w", err)
+	}
+	if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= http.StatusInternalServerError {
+		return nil, &mcp.RetryableError{
+			StatusCode: resp.StatusCode,
+			Err:        fmt.Errorf("recoll WebUI error (%d): %s", resp.StatusCode, string(data)),
+			RetryAfter: mcp.ParseRetryAfter(resp.Header.Get("Retry-After")),
+		}
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		return nil, fmt.Errorf("recoll WebUI error (%d): %s", resp.StatusCode, string(data))
+	}
+	if resp.StatusCode == http.StatusNoContent || len(data) == 0 {
+		return []byte(`{"status":"success"}`), nil
+	}
+	return data, nil
+}
+
+type handlerFunc func(context.Context, *recoll, map[string]any) (*mcp.ToolResult, error)

--- a/integrations/recoll/recoll_test.go
+++ b/integrations/recoll/recoll_test.go
@@ -1,0 +1,154 @@
+package recoll
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	i := New()
+	require.NotNil(t, i)
+	assert.Equal(t, "recoll", i.Name())
+}
+
+func TestConfigure(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		i := New()
+		err := i.Configure(context.Background(), mcp.Credentials{"base_url": "https://recoll.example.com/search/"})
+		require.NoError(t, err)
+		assert.Equal(t, "https://recoll.example.com/search", i.(*recoll).baseURL)
+	})
+
+	t.Run("missing base URL", func(t *testing.T) {
+		err := New().Configure(context.Background(), mcp.Credentials{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "base_url is required")
+	})
+}
+
+func TestTools(t *testing.T) {
+	i := New()
+	seen := make(map[mcp.ToolName]bool)
+	for _, tool := range i.Tools() {
+		assert.NotEmpty(t, tool.Name)
+		assert.NotEmpty(t, tool.Description)
+		assert.Contains(t, string(tool.Name), "recoll_")
+		assert.False(t, seen[tool.Name], "duplicate tool name: %s", tool.Name)
+		seen[tool.Name] = true
+	}
+
+	search, ok := seen["recoll_search"]
+	assert.True(t, ok && search)
+	for _, tool := range i.Tools() {
+		if tool.Name == "recoll_search" {
+			assert.Contains(t, tool.Description, "Start here")
+		}
+	}
+}
+
+func TestDispatchMap_AllToolsCovered(t *testing.T) {
+	for _, tool := range New().Tools() {
+		_, ok := dispatch[tool.Name]
+		assert.True(t, ok, "tool %s has no dispatch handler", tool.Name)
+	}
+}
+
+func TestDispatchMap_NoOrphanHandlers(t *testing.T) {
+	toolNames := make(map[mcp.ToolName]bool)
+	for _, tool := range New().Tools() {
+		toolNames[tool.Name] = true
+	}
+	for name := range dispatch {
+		assert.True(t, toolNames[name], "dispatch handler %s has no tool definition", name)
+	}
+}
+
+func TestExecute_UnknownTool(t *testing.T) {
+	r := &recoll{baseURL: "http://localhost", client: http.DefaultClient}
+	result, err := r.Execute(context.Background(), "recoll_nonexistent", nil)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "unknown tool")
+}
+
+func TestSearch_RoundTrip(t *testing.T) {
+	var gotQuery map[string][]string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		assert.Equal(t, http.MethodGet, req.Method)
+		assert.Equal(t, "/recoll/", req.URL.Path)
+		gotQuery = req.URL.Query()
+		_, _ = w.Write([]byte(`
+			<html><body>
+			<p>2 result(s) for <strong>quarterly &amp; report</strong></p>
+			<div class="result"><div class="path">/documents/quarterly-report.pdf</div><div class="meta"> YXBwbGljYXRpb24vcGRm</div></div>
+			<div class="result"><div class="path">/documents/notes.txt</div><div class="meta"> dGV4dC9wbGFpbg==</div></div>
+			</body></html>`))
+	}))
+	t.Cleanup(ts.Close)
+
+	r := configuredRecoll(t, ts.URL+"/recoll")
+	result, err := r.Execute(context.Background(), "recoll_search", map[string]any{"query": "quarterly & report"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError, result.Data)
+	assert.Equal(t, []string{"quarterly & report"}, gotQuery["q"])
+	assert.NotContains(t, gotQuery, "query")
+	assert.JSONEq(t, `{
+		"query":"quarterly & report",
+		"count":2,
+		"results":[
+			{"path":"/documents/quarterly-report.pdf","mime_type":"application/pdf"},
+			{"path":"/documents/notes.txt","mime_type":"text/plain"}
+		]
+	}`, result.Data)
+}
+
+func TestDoRequest(t *testing.T) {
+	t.Run("API error", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte("unauthorized"))
+		}))
+		t.Cleanup(ts.Close)
+
+		_, err := configuredRecoll(t, ts.URL).get(context.Background(), "/json")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "recoll WebUI error (401)")
+	})
+
+	t.Run("empty response", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		t.Cleanup(ts.Close)
+
+		data, err := configuredRecoll(t, ts.URL).get(context.Background(), "/json")
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"status":"success"}`, string(data))
+	})
+}
+
+func TestHealthy(t *testing.T) {
+	r := New().(*recoll)
+	assert.False(t, r.Healthy(context.Background()))
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		assert.Equal(t, "/", req.URL.Path)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(ts.Close)
+	r = configuredRecoll(t, ts.URL)
+	assert.True(t, r.Healthy(context.Background()))
+}
+
+func configuredRecoll(t *testing.T, baseURL string) *recoll {
+	t.Helper()
+	r := New().(*recoll)
+	require.NoError(t, r.Configure(context.Background(), mcp.Credentials{"base_url": baseURL}))
+	return r
+}

--- a/integrations/recoll/tools.go
+++ b/integrations/recoll/tools.go
@@ -1,0 +1,145 @@
+package recoll
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+
+	mcp "github.com/daltoniam/switchboard"
+	"golang.org/x/net/html"
+)
+
+var tools = []mcp.ToolDefinition{
+	{
+		Name:        "recoll_search",
+		Description: "Search indexed documents, files, PDFs, emails, and their full text through Recoll WebUI. Start here to find local documents and search desktop file contents.",
+		Parameters: map[string]string{
+			"query": "Search query passed to the Recoll WebUI",
+		},
+		Required: []string{"query"},
+	},
+}
+
+var dispatch = map[mcp.ToolName]handlerFunc{
+	"recoll_search": search,
+}
+
+func search(ctx context.Context, r *recoll, args map[string]any) (*mcp.ToolResult, error) {
+	reader := mcp.NewArgs(args)
+	query := reader.Str("query")
+	if err := reader.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	data, err := r.get(ctx, "/?"+url.Values{"q": {query}}.Encode())
+	if err != nil {
+		return mcp.ErrResult(fmt.Errorf("search Recoll documents: %w", err))
+	}
+
+	result, err := parseSearchResults(data, query)
+	if err != nil {
+		return mcp.ErrResult(fmt.Errorf("parse Recoll search results: %w", err))
+	}
+	return mcp.JSONResult(result)
+}
+
+type searchResponse struct {
+	Query   string         `json:"query"`
+	Count   int            `json:"count"`
+	Results []searchResult `json:"results"`
+}
+
+type searchResult struct {
+	Path     string `json:"path"`
+	MIMEType string `json:"mime_type,omitempty"`
+}
+
+var resultCountPattern = regexp.MustCompile(`(?i)\b([0-9]+)\s+result\(s\)\s+for\b`)
+
+func parseSearchResults(data []byte, query string) (searchResponse, error) {
+	doc, err := html.Parse(bytes.NewReader(data))
+	if err != nil {
+		return searchResponse{}, fmt.Errorf("parse HTML: %w", err)
+	}
+
+	response := searchResponse{Query: query}
+	forEachNode(doc, func(n *html.Node) {
+		if n.Type != html.ElementNode {
+			return
+		}
+		if hasClass(n, "result") {
+			response.Results = append(response.Results, searchResult{
+				Path:     textForClass(n, "path"),
+				MIMEType: decodeMIMETypes(textForClass(n, "meta")),
+			})
+			return
+		}
+		if n.Data == "p" && response.Count == 0 {
+			match := resultCountPattern.FindStringSubmatch(nodeText(n))
+			if len(match) == 2 {
+				response.Count, _ = strconv.Atoi(match[1])
+			}
+		}
+	})
+	return response, nil
+}
+
+func forEachNode(n *html.Node, fn func(*html.Node)) {
+	fn(n)
+	for child := n.FirstChild; child != nil; child = child.NextSibling {
+		forEachNode(child, fn)
+	}
+}
+
+func hasClass(n *html.Node, want string) bool {
+	for _, attr := range n.Attr {
+		if attr.Key != "class" {
+			continue
+		}
+		for _, class := range strings.Fields(attr.Val) {
+			if class == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func textForClass(n *html.Node, class string) string {
+	var text string
+	forEachNode(n, func(child *html.Node) {
+		if text == "" && child.Type == html.ElementNode && hasClass(child, class) {
+			text = nodeText(child)
+		}
+	})
+	return text
+}
+
+func nodeText(n *html.Node) string {
+	var b strings.Builder
+	forEachNode(n, func(child *html.Node) {
+		if child.Type == html.TextNode {
+			b.WriteString(child.Data)
+		}
+	})
+	return strings.TrimSpace(b.String())
+}
+
+func decodeMIMETypes(encoded string) string {
+	for _, value := range strings.Fields(encoded) {
+		decoded, err := base64.StdEncoding.DecodeString(value)
+		if err != nil {
+			continue
+		}
+		mimeType := string(decoded)
+		if strings.Contains(mimeType, "/") {
+			return mimeType
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary
- Add Paperless-ngx document search, metadata, download, update, deletion, and safe test-upload tools.
- Add Recoll WebUI search backed by its live HTML query endpoint.
- Document isolated development smoke testing and integration configuration.

## Verification
- `make ci`
- Isolated live smoke tests against Paperless-ngx and Recoll WebUI

💘 Generated with Crush