### PR TITLE
Expand Paperless administration and document retrieval

### DIFF
--- a/integrations/paperless/compact.yaml
+++ b/integrations/paperless/compact.yaml
@@ -2,55 +2,60 @@
 version: 1
 tools:
   paperless_list_documents:
-    spec:
-      - count
-      - next
-      - previous
-      - results[].id
-      - results[].title
-      - results[].created
-      - results[].added
-      - results[].modified
-      - results[].correspondent
-      - results[].document_type
-      - results[].tags
-      - results[].archive_serial_number
+    spec: [count, next, previous, "results[].id", "results[].title", "results[].created", "results[].added", "results[].modified", "results[].correspondent", "results[].document_type", "results[].tags", "results[].archive_serial_number"]
   paperless_search_documents:
-    spec:
-      - count
-      - next
-      - previous
-      - results[].id
-      - results[].title
-      - results[].created
-      - results[].added
-      - results[].modified
-      - results[].correspondent
-      - results[].document_type
-      - results[].tags
-      - results[].archive_serial_number
+    spec: [count, next, previous, "results[].id", "results[].title", "results[].created", "results[].added", "results[].modified", "results[].correspondent", "results[].document_type", "results[].tags", "results[].archive_serial_number"]
   paperless_get_document:
-    spec:
-      - id
-      - title
-      - content
-      - created
-      - added
-      - modified
-      - correspondent
-      - document_type
-      - storage_path
-      - tags
-      - custom_fields
-      - archive_serial_number
-      - original_file_name
+    spec: [id, title, created, added, modified, correspondent, document_type, storage_path, tags, custom_fields, archive_serial_number, original_file_name]
+  paperless_get_document_ocr_text:
+    spec: [document_id, offset, limit, total_chars, content, has_more, next_offset]
   paperless_list_tags:
     spec: [count, next, previous, "results[].id", "results[].name", "results[].color", "results[].document_count"]
+  paperless_get_tag:
+    spec: [id, name, color, text_color, document_count, matching_algorithm, match]
   paperless_list_correspondents:
     spec: [count, next, previous, "results[].id", "results[].name", "results[].document_count"]
+  paperless_get_correspondent:
+    spec: [id, name, document_count, matching_algorithm, match]
   paperless_list_document_types:
     spec: [count, next, previous, "results[].id", "results[].name", "results[].document_count"]
+  paperless_get_document_type:
+    spec: [id, name, document_count, matching_algorithm, match]
   paperless_list_storage_paths:
     spec: [count, next, previous, "results[].id", "results[].name", "results[].path", "results[].document_count"]
+  paperless_get_storage_path:
+    spec: [id, name, path, document_count, matching_algorithm, match]
   paperless_list_custom_fields:
     spec: [count, next, previous, "results[].id", "results[].name", "results[].data_type"]
+  paperless_get_custom_field:
+    spec: [id, name, data_type, extra_data]
+  paperless_list_saved_views:
+    spec: [count, next, previous, "results[].id", "results[].name", "results[].filter_rules", "results[].sort_field", "results[].sort_reverse"]
+  paperless_get_saved_view:
+    spec: [id, name, filter_rules, sort_field, sort_reverse]
+  paperless_list_workflows:
+    spec: [count, next, previous, "results[].id", "results[].name", "results[].order", "results[].enabled", "results[].triggers[].id", "results[].triggers[].type", "results[].triggers[].filter_filename", "results[].actions[].id", "results[].actions[].type", "results[].actions[].assign_tags"]
+  paperless_get_workflow:
+    spec: [id, name, order, enabled, "triggers[].id", "triggers[].type", "triggers[].filter_filename", "actions[].id", "actions[].type", "actions[].assign_tags"]
+  paperless_list_mail_rules:
+    spec: [count, next, previous, "results[].id", "results[].name", "results[].order", "results[].account", "results[].enabled"]
+  paperless_get_mail_rule:
+    spec: [id, name, order, account, enabled]
+  paperless_list_users:
+    spec: [count, next, previous, "results[].id", "results[].username", "results[].first_name", "results[].last_name", "results[].email", "results[].is_staff", "results[].is_superuser", "results[].groups"]
+  paperless_get_user:
+    spec: [id, username, first_name, last_name, email, is_staff, is_superuser, groups]
+  paperless_list_groups:
+    spec: [count, next, previous, "results[].id", "results[].name", "results[].permissions", "results[].user_set"]
+  paperless_get_group:
+    spec: [id, name, permissions, user_set]
+  paperless_list_tasks:
+    spec: [count, next, previous, "results[].id", "results[].task_id", "results[].task_type", "results[].status", "results[].date_created", "results[].date_started", "results[].date_done"]
+  paperless_get_task:
+    spec: [id, task_id, task_type, status, date_created, date_started, date_done]
+  paperless_get_task_summary:
+    spec: ["[].task_type", "[].total_count", "[].pending_count", "[].success_count", "[].failure_count", "[].last_run", "[].last_success", "[].last_failure"]
+  paperless_get_task_status_counts:
+    spec: [all, needs_attention, in_progress, completed]
+  paperless_list_active_tasks:
+    spec: ["[].id", "[].task_id", "[].task_type", "[].status", "[].date_created"]

--- a/integrations/paperless/compact_specs_test.go
+++ b/integrations/paperless/compact_specs_test.go
@@ -3,6 +3,7 @@ package paperless
 import (
 	"testing"
 
+	mcp "github.com/daltoniam/switchboard"
 	"github.com/daltoniam/switchboard/compact"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -28,4 +29,65 @@ func TestFieldCompactionSpecExcludesMutations(t *testing.T) {
 	assert.NotEmpty(t, fields)
 	_, ok = p.CompactSpec("paperless_update_document")
 	assert.False(t, ok)
+}
+
+func TestFieldCompactionShapes(t *testing.T) {
+	tests := []struct {
+		name  string
+		tool  mcp.ToolName
+		input string
+		want  string
+	}{
+		{
+			name:  "document list excludes OCR content",
+			tool:  "paperless_list_documents",
+			input: `{"count":1,"results":[{"id":7,"title":"Invoice","content":"sensitive OCR text"}]}`,
+			want:  `{"count":1,"results":[{"id":7,"title":"Invoice"}]}`,
+		},
+		{
+			name:  "document search excludes OCR content",
+			tool:  "paperless_search_documents",
+			input: `{"count":1,"results":[{"id":7,"title":"Invoice","content":"sensitive OCR text","__search_hit__":{"content":"also sensitive"}}]}`,
+			want:  `{"count":1,"results":[{"id":7,"title":"Invoice"}]}`,
+		},
+		{
+			name:  "document get excludes OCR content",
+			tool:  "paperless_get_document",
+			input: `{"id":7,"title":"Invoice","content":"sensitive OCR text"}`,
+			want:  `{"id":7,"title":"Invoice"}`,
+		},
+		{
+			name:  "OCR text page preserves pagination envelope",
+			tool:  "paperless_get_document_ocr_text",
+			input: `{"document_id":7,"offset":2,"limit":3,"total_chars":6,"content":"cde","has_more":true,"next_offset":5,"ignored":"value"}`,
+			want:  `{"document_id":7,"offset":2,"limit":3,"total_chars":6,"content":"cde","has_more":true,"next_offset":5}`,
+		},
+		{
+			name:  "task status counts use upstream fields",
+			tool:  "paperless_get_task_status_counts",
+			input: `{"all":8,"needs_attention":2,"in_progress":3,"completed":3,"pending":99}`,
+			want:  `{"all":8,"completed":3,"in_progress":3,"needs_attention":2}`,
+		},
+		{
+			name:  "task list uses version 10 task fields",
+			tool:  "paperless_list_tasks",
+			input: `{"count":1,"results":[{"id":7,"task_id":"celery-id","task_type":"consume_file","status":"SUCCESS","date_created":"2025-01-01T00:00:00Z","date_started":"2025-01-01T00:01:00Z","date_done":"2025-01-01T00:02:00Z","result_data":{"document_id":1}}]}`,
+			want:  `{"count":1,"results":[{"date_created":"2025-01-01T00:00:00Z","date_done":"2025-01-01T00:02:00Z","date_started":"2025-01-01T00:01:00Z","id":7,"status":"SUCCESS","task_id":"celery-id","task_type":"consume_file"}]}`,
+		},
+		{
+			name:  "workflow preserves nested triggers and actions",
+			tool:  "paperless_get_workflow",
+			input: `{"id":4,"name":"Route invoices","order":1,"enabled":true,"triggers":[{"id":5,"type":1,"filter_filename":"*.pdf"}],"actions":[{"id":6,"type":1,"assign_tags":[2]}],"ignored":true}`,
+			want:  `{"actions":[{"assign_tags":[2],"id":6,"type":1}],"enabled":true,"id":4,"name":"Route invoices","order":1,"triggers":[{"filter_filename":"*.pdf","id":5,"type":1}]}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fields, ok := New().(*paperless).CompactSpec(tt.tool)
+			require.True(t, ok)
+			got, err := mcp.CompactJSON([]byte(tt.input), fields)
+			require.NoError(t, err)
+			assert.JSONEq(t, tt.want, string(got))
+		})
+	}
 }

--- a/integrations/paperless/configuration.go
+++ b/integrations/paperless/configuration.go
@@ -1,0 +1,178 @@
+package paperless
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+// listResource returns a paginated Paperless collection. Resource-specific
+// filtering is deliberately passed through only as documented query values.
+func listResource(path string) handlerFunc {
+	return func(ctx context.Context, p *paperless, args map[string]any) (*mcp.ToolResult, error) {
+		r := mcp.NewArgs(args)
+		page := r.OptInt("page", 1)
+		pageSize := r.OptInt("page_size", 25)
+		if err := r.Err(); err != nil {
+			return mcp.ErrResult(err)
+		}
+		query := url.Values{"page": {strconv.Itoa(page)}, "page_size": {strconv.Itoa(pageSize)}}
+		data, err := p.get(ctx, path+"?"+query.Encode())
+		if err != nil {
+			return mcp.ErrResult(err)
+		}
+		return mcp.RawResult(data)
+	}
+}
+
+func getResource(path string) handlerFunc {
+	return func(ctx context.Context, p *paperless, args map[string]any) (*mcp.ToolResult, error) {
+		id, err := resourceID(args)
+		if err != nil {
+			return mcp.ErrResult(err)
+		}
+		data, err := p.get(ctx, fmt.Sprintf("%s%d/", path, id))
+		if err != nil {
+			return mcp.ErrResult(err)
+		}
+		return mcp.RawResult(data)
+	}
+}
+
+func createResource(path string) handlerFunc {
+	return func(ctx context.Context, p *paperless, args map[string]any) (*mcp.ToolResult, error) {
+		body, err := resourceData(args)
+		if err != nil {
+			return mcp.ErrResult(err)
+		}
+		data, err := p.doRequest(ctx, http.MethodPost, path, body)
+		if err != nil {
+			return mcp.ErrResult(err)
+		}
+		return mcp.RawResult(data)
+	}
+}
+
+func updateResource(path string) handlerFunc {
+	return func(ctx context.Context, p *paperless, args map[string]any) (*mcp.ToolResult, error) {
+		id, err := resourceID(args)
+		if err != nil {
+			return mcp.ErrResult(err)
+		}
+		body, err := resourceData(args)
+		if err != nil {
+			return mcp.ErrResult(err)
+		}
+		data, err := p.doRequest(ctx, http.MethodPatch, fmt.Sprintf("%s%d/", path, id), body)
+		if err != nil {
+			return mcp.ErrResult(err)
+		}
+		return mcp.RawResult(data)
+	}
+}
+
+func deleteResource(path string) handlerFunc {
+	return func(ctx context.Context, p *paperless, args map[string]any) (*mcp.ToolResult, error) {
+		id, err := resourceID(args)
+		if err != nil {
+			return mcp.ErrResult(err)
+		}
+		data, err := p.doRequest(ctx, http.MethodDelete, fmt.Sprintf("%s%d/", path, id), nil)
+		if err != nil {
+			return mcp.ErrResult(err)
+		}
+		return mcp.RawResult(data)
+	}
+}
+
+func resourceID(args map[string]any) (int, error) {
+	r := mcp.NewArgs(args)
+	id := r.Int("id")
+	if err := r.Err(); err != nil {
+		return 0, err
+	}
+	if id == 0 {
+		return 0, fmt.Errorf("id is required")
+	}
+	return id, nil
+}
+
+func resourceData(args map[string]any) (map[string]any, error) {
+	data, err := mcp.ArgMap(args, "data")
+	if err != nil {
+		return nil, err
+	}
+	if len(data) == 0 {
+		return nil, fmt.Errorf("data is required")
+	}
+	return data, nil
+}
+
+func getTaskSummary(ctx context.Context, p *paperless, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	days := r.OptInt("days", 30)
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := p.get(ctx, "/api/tasks/summary/?"+url.Values{"days": {strconv.Itoa(days)}}.Encode())
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func runTask(ctx context.Context, p *paperless, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	taskType := r.Str("task_type")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if taskType == "" {
+		return mcp.ErrResult(fmt.Errorf("task_type is required"))
+	}
+	data, err := p.doRequest(ctx, http.MethodPost, "/api/tasks/run/", map[string]any{"task_type": taskType})
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func acknowledgeTasks(ctx context.Context, p *paperless, args map[string]any) (*mcp.ToolResult, error) {
+	body, err := resourceData(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := p.doRequest(ctx, http.MethodPost, "/api/tasks/acknowledge/", body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func bulkEditDocuments(ctx context.Context, p *paperless, args map[string]any) (*mcp.ToolResult, error) {
+	body, err := resourceData(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := p.doRequest(ctx, http.MethodPost, "/api/documents/bulk_edit/", body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func bulkEditObjects(ctx context.Context, p *paperless, args map[string]any) (*mcp.ToolResult, error) {
+	body, err := resourceData(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := p.doRequest(ctx, http.MethodPost, "/api/bulk_edit_objects/", body)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}

--- a/integrations/paperless/configuration_test.go
+++ b/integrations/paperless/configuration_test.go
@@ -1,0 +1,101 @@
+package paperless
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigurationResourceOperations(t *testing.T) {
+	tests := []struct {
+		name       string
+		tool       mcp.ToolName
+		args       map[string]any
+		wantMethod string
+		wantPath   string
+	}{
+		{"list tags", "paperless_list_tags", map[string]any{"page": 2, "page_size": 10}, http.MethodGet, "/api/tags/"},
+		{"get correspondent", "paperless_get_correspondent", map[string]any{"id": 3}, http.MethodGet, "/api/correspondents/3/"},
+		{"create document type", "paperless_create_document_type", map[string]any{"data": map[string]any{"name": "Invoice"}}, http.MethodPost, "/api/document_types/"},
+		{"update storage path", "paperless_update_storage_path", map[string]any{"id": 4, "data": map[string]any{"name": "Archive"}}, http.MethodPatch, "/api/storage_paths/4/"},
+		{"delete saved view", "paperless_delete_saved_view", map[string]any{"id": 5}, http.MethodDelete, "/api/saved_views/5/"},
+		{"create workflow", "paperless_create_workflow", map[string]any{"data": map[string]any{
+			"name": "Route invoices", "enabled": true,
+			"triggers": []any{map[string]any{"type": 1, "filter_filename": "*.pdf"}},
+			"actions":  []any{map[string]any{"type": 1}},
+		}}, http.MethodPost, "/api/workflows/"},
+		{"create mail rule", "paperless_create_mail_rule", map[string]any{"data": map[string]any{"name": "Invoices"}}, http.MethodPost, "/api/mail_rules/"},
+		{"list users", "paperless_list_users", nil, http.MethodGet, "/api/users/"},
+		{"create group", "paperless_create_group", map[string]any{"data": map[string]any{"name": "Accounting"}}, http.MethodPost, "/api/groups/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, tt.wantMethod, r.Method)
+				assert.Equal(t, tt.wantPath, r.URL.Path)
+				if r.Method == http.MethodPost || r.Method == http.MethodPatch {
+					var body map[string]any
+					require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+					assert.NotEmpty(t, body)
+					if tt.tool == "paperless_create_workflow" {
+						triggers, ok := body["triggers"].([]any)
+						require.True(t, ok)
+						require.Len(t, triggers, 1)
+						trigger := triggers[0].(map[string]any)
+						assert.Equal(t, float64(1), trigger["type"])
+						assert.Equal(t, "*.pdf", trigger["filter_filename"])
+					}
+				}
+				if r.Method == http.MethodDelete {
+					w.WriteHeader(http.StatusNoContent)
+					return
+				}
+				_, _ = w.Write([]byte(`{"id":1,"name":"Example"}`))
+			}))
+			defer ts.Close()
+
+			p := &paperless{token: "token", baseURL: ts.URL, client: ts.Client()}
+			result, err := p.Execute(context.Background(), tt.tool, tt.args)
+			require.NoError(t, err)
+			assert.False(t, result.IsError, result.Data)
+		})
+	}
+}
+
+func TestTaskManagementOperations(t *testing.T) {
+	tests := []struct {
+		tool       mcp.ToolName
+		args       map[string]any
+		wantMethod string
+		wantPath   string
+	}{
+		{"paperless_list_tasks", map[string]any{"page": 2}, http.MethodGet, "/api/tasks/"},
+		{"paperless_get_task", map[string]any{"id": 8}, http.MethodGet, "/api/tasks/8/"},
+		{"paperless_get_task_summary", map[string]any{"days": 14}, http.MethodGet, "/api/tasks/summary/"},
+		{"paperless_get_task_status_counts", nil, http.MethodGet, "/api/tasks/status_counts/"},
+		{"paperless_list_active_tasks", nil, http.MethodGet, "/api/tasks/active/"},
+		{"paperless_run_task", map[string]any{"task_type": "train_classifier"}, http.MethodPost, "/api/tasks/run/"},
+		{"paperless_acknowledge_tasks", map[string]any{"data": map[string]any{"tasks": []any{8}}}, http.MethodPost, "/api/tasks/acknowledge/"},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.tool), func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, tt.wantMethod, r.Method)
+				assert.Equal(t, tt.wantPath, r.URL.Path)
+				_, _ = w.Write([]byte(`{"result":"OK"}`))
+			}))
+			defer ts.Close()
+			p := &paperless{token: "token", baseURL: ts.URL, client: ts.Client()}
+			result, err := p.Execute(context.Background(), tt.tool, tt.args)
+			require.NoError(t, err)
+			assert.False(t, result.IsError, result.Data)
+		})
+	}
+}

--- a/integrations/paperless/paperless.go
+++ b/integrations/paperless/paperless.go
@@ -5,14 +5,17 @@ import (
 	"bytes"
 	"context"
 	_ "embed"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
 	"mime/multipart"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	mcp "github.com/daltoniam/switchboard"
 	"github.com/daltoniam/switchboard/compact"
@@ -31,6 +34,14 @@ var (
 	_ mcp.PlaceholderHints           = (*paperless)(nil)
 )
 
+const (
+	paperlessHTTPTimeout       = 30 * time.Second
+	paperlessResponseSizeLimit = 2 * 1024 * 1024
+	paperlessDownloadSizeLimit = 1024 * 1024
+	defaultOCRTextLimit        = 10_000
+	maxOCRTextLimit            = 20_000
+)
+
 type paperless struct {
 	token   string
 	baseURL string
@@ -39,7 +50,7 @@ type paperless struct {
 
 // New creates a Paperless-ngx integration.
 func New() mcp.Integration {
-	return &paperless{client: &http.Client{}}
+	return &paperless{client: &http.Client{Timeout: paperlessHTTPTimeout}}
 }
 
 func (p *paperless) Name() string { return "paperless" }
@@ -59,7 +70,27 @@ func (p *paperless) Configure(_ context.Context, creds mcp.Credentials) error {
 	if p.baseURL == "" {
 		return fmt.Errorf("paperless: url is required")
 	}
+	parsed, err := url.ParseRequestURI(p.baseURL)
+	if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return fmt.Errorf("paperless: invalid url")
+	}
+	if parsed.Scheme == "http" && !isLoopbackHost(parsed.Hostname()) {
+		return fmt.Errorf("paperless: url must use https unless the host is loopback")
+	}
+	if p.client == nil {
+		p.client = &http.Client{Timeout: paperlessHTTPTimeout}
+	} else if p.client.Timeout == 0 {
+		p.client.Timeout = paperlessHTTPTimeout
+	}
 	return nil
+}
+
+func isLoopbackHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 func (p *paperless) Healthy(ctx context.Context) bool {
@@ -94,39 +125,47 @@ func (p *paperless) doRequest(ctx context.Context, method, path string, body any
 		}
 		reader = bytes.NewReader(data)
 	}
-	req, err := http.NewRequestWithContext(ctx, method, p.baseURL+path, reader)
-	if err != nil {
-		return nil, fmt.Errorf("create Paperless request: %w", err)
-	}
-	req.Header.Set("Authorization", "Token "+p.token)
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	resp, err := p.client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("make Paperless request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	data, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("read Paperless response: %w", err)
-	}
-	if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= http.StatusInternalServerError {
-		retryErr := &mcp.RetryableError{StatusCode: resp.StatusCode, Err: fmt.Errorf("paperless API error (%d): %s", resp.StatusCode, data)}
-		retryErr.RetryAfter = mcp.ParseRetryAfter(resp.Header.Get("Retry-After"))
-		return nil, retryErr
-	}
-	if resp.StatusCode >= http.StatusBadRequest {
-		return nil, fmt.Errorf("paperless API error (%d): %s", resp.StatusCode, data)
-	}
-	if resp.StatusCode == http.StatusNoContent || len(data) == 0 {
-		return []byte(`{"status":"success"}`), nil
-	}
-	return data, nil
+	data, _, err := p.doRequestWithLimit(ctx, method, path, reader, "application/json", paperlessResponseSizeLimit)
+	return data, err
 }
 
 func (p *paperless) get(ctx context.Context, path string) ([]byte, error) {
 	return p.doRequest(ctx, http.MethodGet, path, nil)
+}
+
+func (p *paperless) doRequestWithLimit(ctx context.Context, method, path string, body io.Reader, contentType string, limit int) ([]byte, http.Header, error) {
+	req, err := http.NewRequestWithContext(ctx, method, p.baseURL+path, body)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create Paperless request: %w", err)
+	}
+	req.Header.Set("Authorization", "Token "+p.token)
+	if body != nil {
+		req.Header.Set("Content-Type", contentType)
+	}
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("make Paperless request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, err := io.ReadAll(io.LimitReader(resp.Body, int64(limit)+1))
+	if err != nil {
+		return nil, nil, fmt.Errorf("read Paperless response: %w", err)
+	}
+	if len(data) > limit {
+		return nil, nil, fmt.Errorf("paperless response exceeds %d bytes", limit)
+	}
+	if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= http.StatusInternalServerError {
+		retryErr := &mcp.RetryableError{StatusCode: resp.StatusCode, Err: fmt.Errorf("paperless API error (%d): %s", resp.StatusCode, data)}
+		retryErr.RetryAfter = mcp.ParseRetryAfter(resp.Header.Get("Retry-After"))
+		return nil, nil, retryErr
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		return nil, nil, fmt.Errorf("paperless API error (%d): %s", resp.StatusCode, data)
+	}
+	if resp.StatusCode == http.StatusNoContent || len(data) == 0 {
+		return []byte(`{"status":"success"}`), resp.Header, nil
+	}
+	return data, resp.Header, nil
 }
 
 func listDocuments(ctx context.Context, p *paperless, args map[string]any) (*mcp.ToolResult, error) {
@@ -141,7 +180,7 @@ func listDocuments(ctx context.Context, p *paperless, args map[string]any) (*mcp
 	if err != nil {
 		return mcp.ErrResult(err)
 	}
-	return mcp.RawResult(data)
+	return withoutOCRContentFromDocumentList(data)
 }
 
 func searchDocuments(ctx context.Context, p *paperless, args map[string]any) (*mcp.ToolResult, error) {
@@ -160,7 +199,7 @@ func searchDocuments(ctx context.Context, p *paperless, args map[string]any) (*m
 	if err != nil {
 		return mcp.ErrResult(err)
 	}
-	return mcp.RawResult(data)
+	return withoutOCRContentFromDocumentList(data)
 }
 
 func createDocument(ctx context.Context, p *paperless, args map[string]any) (*mcp.ToolResult, error) {
@@ -201,33 +240,8 @@ func createDocument(ctx context.Context, p *paperless, args map[string]any) (*mc
 }
 
 func (p *paperless) doMultipartRequest(ctx context.Context, path string, body io.Reader, contentType string) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+path, body)
-	if err != nil {
-		return nil, fmt.Errorf("create Paperless request: %w", err)
-	}
-	req.Header.Set("Authorization", "Token "+p.token)
-	req.Header.Set("Content-Type", contentType)
-	resp, err := p.client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("make Paperless request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	data, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("read Paperless response: %w", err)
-	}
-	if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= http.StatusInternalServerError {
-		retryErr := &mcp.RetryableError{StatusCode: resp.StatusCode, Err: fmt.Errorf("paperless API error (%d): %s", resp.StatusCode, data)}
-		retryErr.RetryAfter = mcp.ParseRetryAfter(resp.Header.Get("Retry-After"))
-		return nil, retryErr
-	}
-	if resp.StatusCode >= http.StatusBadRequest {
-		return nil, fmt.Errorf("paperless API error (%d): %s", resp.StatusCode, data)
-	}
-	if resp.StatusCode == http.StatusNoContent || len(data) == 0 {
-		return []byte(`{"status":"success"}`), nil
-	}
-	return data, nil
+	data, _, err := p.doRequestWithLimit(ctx, http.MethodPost, path, body, contentType, paperlessResponseSizeLimit)
+	return data, err
 }
 
 func getDocument(ctx context.Context, p *paperless, args map[string]any) (*mcp.ToolResult, error) {
@@ -239,7 +253,103 @@ func getDocument(ctx context.Context, p *paperless, args map[string]any) (*mcp.T
 	if err != nil {
 		return mcp.ErrResult(err)
 	}
-	return mcp.RawResult(data)
+	return withoutOCRContent(data)
+}
+
+func getDocumentOCRText(ctx context.Context, p *paperless, args map[string]any) (*mcp.ToolResult, error) {
+	id, err := documentID(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	offset, limit, err := ocrTextPageArgs(args)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+
+	data, err := p.get(ctx, fmt.Sprintf("/api/documents/%d/", id))
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	var document struct {
+		Content string `json:"content"`
+	}
+	if err := json.Unmarshal(data, &document); err != nil {
+		return mcp.ErrResult(fmt.Errorf("decode Paperless document content: %w", err))
+	}
+
+	totalChars := len([]rune(document.Content))
+	if offset > totalChars {
+		offset = totalChars
+	}
+	content := []rune(document.Content)
+	end := offset + min(limit, totalChars-offset)
+	result := map[string]any{
+		"document_id": id,
+		"offset":      offset,
+		"limit":       limit,
+		"total_chars": totalChars,
+		"content":     string(content[offset:end]),
+		"has_more":    end < totalChars,
+	}
+	if end < totalChars {
+		result["next_offset"] = end
+	}
+	return mcp.JSONResult(result)
+}
+
+func withoutOCRContent(data []byte) (*mcp.ToolResult, error) {
+	var document map[string]json.RawMessage
+	if err := json.Unmarshal(data, &document); err != nil {
+		return mcp.ErrResult(fmt.Errorf("decode Paperless document: %w", err))
+	}
+	delete(document, "content")
+	return mcp.JSONResult(document)
+}
+
+func withoutOCRContentFromDocumentList(data []byte) (*mcp.ToolResult, error) {
+	var response map[string]json.RawMessage
+	if err := json.Unmarshal(data, &response); err != nil {
+		return mcp.ErrResult(fmt.Errorf("decode Paperless document list: %w", err))
+	}
+	var documents []map[string]json.RawMessage
+	if err := json.Unmarshal(response["results"], &documents); err != nil {
+		return mcp.ErrResult(fmt.Errorf("decode Paperless document results: %w", err))
+	}
+	for _, document := range documents {
+		delete(document, "content")
+	}
+	results, err := json.Marshal(documents)
+	if err != nil {
+		return mcp.ErrResult(fmt.Errorf("encode Paperless document results: %w", err))
+	}
+	response["results"] = results
+	return mcp.JSONResult(response)
+}
+
+func ocrTextPageArgs(args map[string]any) (offset, limit int, err error) {
+	if value, ok := args["offset"]; ok {
+		offset, err = mcp.ArgInt(map[string]any{"offset": value}, "offset")
+		if err != nil {
+			return 0, 0, err
+		}
+		if offset < 0 {
+			return 0, 0, fmt.Errorf("offset must be non-negative")
+		}
+	}
+	limit = defaultOCRTextLimit
+	if value, ok := args["limit"]; ok {
+		limit, err = mcp.ArgInt(map[string]any{"limit": value}, "limit")
+		if err != nil {
+			return 0, 0, err
+		}
+		if limit <= 0 {
+			return 0, 0, fmt.Errorf("limit must be positive")
+		}
+	}
+	if limit > maxOCRTextLimit {
+		return 0, 0, fmt.Errorf("limit must not exceed %d", maxOCRTextLimit)
+	}
+	return offset, limit, nil
 }
 
 func updateDocument(ctx context.Context, p *paperless, args map[string]any) (*mcp.ToolResult, error) {
@@ -280,11 +390,15 @@ func downloadDocument(ctx context.Context, p *paperless, args map[string]any) (*
 	if err != nil {
 		return mcp.ErrResult(err)
 	}
-	data, err := p.get(ctx, fmt.Sprintf("/api/documents/%d/download/", id))
+	data, header, err := p.doRequestWithLimit(ctx, http.MethodGet, fmt.Sprintf("/api/documents/%d/download/", id), nil, "", paperlessDownloadSizeLimit)
 	if err != nil {
 		return mcp.ErrResult(err)
 	}
-	return &mcp.ToolResult{Data: string(data)}, nil
+	return mcp.JSONResult(map[string]any{
+		"content_type":   header.Get("Content-Type"),
+		"bytes":          len(data),
+		"content_base64": base64.StdEncoding.EncodeToString(data),
+	})
 }
 
 func listMetadata(path string) handlerFunc {

--- a/integrations/paperless/paperless_test.go
+++ b/integrations/paperless/paperless_test.go
@@ -2,10 +2,13 @@ package paperless
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"io"
+	"mime"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	mcp "github.com/daltoniam/switchboard"
@@ -21,23 +24,35 @@ func TestNewAndConfigure(t *testing.T) {
 		"token": "paperless-token",
 		"url":   "https://paperless.example.com/",
 	}))
+	assert.Equal(t, paperlessHTTPTimeout, i.(*paperless).client.Timeout)
 
-	for name, creds := range map[string]mcp.Credentials{
-		"missing token": {"url": "https://paperless.example.com"},
-		"missing url":   {"token": "paperless-token"},
+	for _, loopbackURL := range []string{"http://localhost:8000", "http://127.0.0.1:8000", "http://[::1]:8000"} {
+		t.Run("allows loopback "+loopbackURL, func(t *testing.T) {
+			assert.NoError(t, New().Configure(context.Background(), mcp.Credentials{"token": "paperless-token", "url": loopbackURL}))
+		})
+	}
+
+	for name, tt := range map[string]struct {
+		creds mcp.Credentials
+		want  string
+	}{
+		"missing token":        {creds: mcp.Credentials{"url": "https://paperless.example.com"}, want: "token is required"},
+		"missing url":          {creds: mcp.Credentials{"token": "paperless-token"}, want: "url is required"},
+		"invalid url":          {creds: mcp.Credentials{"token": "paperless-token", "url": "not a URL"}, want: "invalid url"},
+		"insecure remote url":  {creds: mcp.Credentials{"token": "paperless-token", "url": "http://paperless.example.com"}, want: "https"},
+		"insecure private url": {creds: mcp.Credentials{"token": "paperless-token", "url": "http://192.168.1.5"}, want: "https"},
 	} {
 		t.Run(name, func(t *testing.T) {
-			err := New().Configure(context.Background(), creds)
+			err := New().Configure(context.Background(), tt.creds)
 			assert.Error(t, err)
-			assert.Contains(t, err.Error(), "required")
+			assert.Contains(t, err.Error(), tt.want)
 		})
 	}
 }
 
-func TestToolsAndDispatchParity(t *testing.T) {
-	i := New()
+func TestDispatchMap_AllToolsCovered(t *testing.T) {
 	seen := make(map[mcp.ToolName]bool)
-	for _, tool := range i.Tools() {
+	for _, tool := range New().Tools() {
 		assert.NotEmpty(t, tool.Name)
 		assert.Contains(t, string(tool.Name), "paperless_")
 		assert.NotEmpty(t, tool.Description)
@@ -46,8 +61,16 @@ func TestToolsAndDispatchParity(t *testing.T) {
 		_, handled := dispatch[tool.Name]
 		assert.True(t, handled, "tool %s has no dispatch handler", tool.Name)
 	}
+}
+
+func TestDispatchMap_NoOrphanHandlers(t *testing.T) {
+	toolsByName := make(map[mcp.ToolName]struct{})
+	for _, tool := range New().Tools() {
+		toolsByName[tool.Name] = struct{}{}
+	}
 	for name := range dispatch {
-		assert.True(t, seen[name], "dispatch handler %s has no tool definition", name)
+		_, defined := toolsByName[name]
+		assert.True(t, defined, "dispatch handler %s has no tool definition", name)
 	}
 }
 
@@ -103,6 +126,78 @@ func TestCreateDocumentArgumentErrors(t *testing.T) {
 	}
 }
 
+func TestDocumentReadsExcludeOCRContent(t *testing.T) {
+	const ocrText = "sensitive OCR text"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/documents/":
+			_, _ = w.Write([]byte(`{"count":1,"results":[{"id":7,"title":"Invoice","content":"` + ocrText + `"}]}`))
+		case "/api/documents/7/":
+			_, _ = w.Write([]byte(`{"id":7,"title":"Invoice","content":"` + ocrText + `"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(ts.Close)
+
+	p := &paperless{token: "paperless-token", baseURL: ts.URL, client: ts.Client()}
+	for _, tt := range []struct {
+		name string
+		tool mcp.ToolName
+		args map[string]any
+	}{
+		{name: "list", tool: "paperless_list_documents"},
+		{name: "search", tool: "paperless_search_documents", args: map[string]any{"query": "invoice"}},
+		{name: "get", tool: "paperless_get_document", args: map[string]any{"document_id": 7}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := p.Execute(context.Background(), tt.tool, tt.args)
+			require.NoError(t, err)
+			assert.False(t, result.IsError)
+			assert.NotContains(t, result.Data, ocrText)
+			assert.NotContains(t, result.Data, `"content"`)
+		})
+	}
+}
+
+func TestGetDocumentOCRTextReturnsPaginatedContent(t *testing.T) {
+	requests := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/documents/7/", r.URL.Path)
+		_, _ = w.Write([]byte(`{"id":7,"title":"Invoice","content":"abcdef","unrelated":"ignored"}`))
+	}))
+	t.Cleanup(ts.Close)
+
+	p := &paperless{token: "paperless-token", baseURL: ts.URL, client: ts.Client()}
+	result, err := p.Execute(context.Background(), "paperless_get_document_ocr_text", map[string]any{"document_id": 7, "offset": 2, "limit": 3})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.JSONEq(t, `{"document_id":7,"offset":2,"limit":3,"total_chars":6,"content":"cde","has_more":true,"next_offset":5}`, result.Data)
+	assert.Equal(t, 1, requests)
+}
+
+func TestGetDocumentOCRTextArgumentValidation(t *testing.T) {
+	p := &paperless{}
+	for _, tt := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{name: "negative offset", args: map[string]any{"document_id": 1, "offset": -1}, want: "offset must be non-negative"},
+		{name: "zero limit", args: map[string]any{"document_id": 1, "limit": 0}, want: "limit must be positive"},
+		{name: "limit over maximum", args: map[string]any{"document_id": 1, "limit": 20001}, want: "limit must not exceed"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := p.Execute(context.Background(), "paperless_get_document_ocr_text", tt.args)
+			require.NoError(t, err)
+			assert.True(t, result.IsError)
+			assert.Contains(t, result.Data, tt.want)
+		})
+	}
+}
+
 func TestExecuteDocumentOperations(t *testing.T) {
 	var gotQuery string
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -124,7 +219,8 @@ func TestExecuteDocumentOperations(t *testing.T) {
 				w.WriteHeader(http.StatusNoContent)
 			}
 		case "/api/documents/7/download/":
-			_, _ = w.Write([]byte("PDF bytes"))
+			w.Header().Set("Content-Type", "application/pdf")
+			_, _ = w.Write([]byte{0x00, 0xff, 0x10})
 		default:
 			http.NotFound(w, r)
 		}
@@ -143,7 +239,7 @@ func TestExecuteDocumentOperations(t *testing.T) {
 		{"get", "paperless_get_document", map[string]any{"document_id": 7}, "Invoice"},
 		{"update", "paperless_update_document", map[string]any{"document_id": 7, "title": "Paid invoice"}, "Paid invoice"},
 		{"delete", "paperless_delete_document", map[string]any{"document_id": 7}, "success"},
-		{"download", "paperless_download_document", map[string]any{"document_id": 7}, "PDF bytes"},
+		{"download", "paperless_download_document", map[string]any{"document_id": 7}, base64.StdEncoding.EncodeToString([]byte{0x00, 0xff, 0x10})},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := p.Execute(context.Background(), tt.tool, tt.args)
@@ -153,6 +249,49 @@ func TestExecuteDocumentOperations(t *testing.T) {
 		})
 	}
 	assert.Contains(t, gotQuery, "query=invoice")
+}
+
+func TestDownloadDocumentReturnsBinaryEnvelope(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/pdf; charset=binary")
+		_, _ = w.Write([]byte{0x00, 0xff, 0x10})
+	}))
+	t.Cleanup(ts.Close)
+
+	p := &paperless{token: "token", baseURL: ts.URL, client: ts.Client()}
+	result, err := p.Execute(context.Background(), "paperless_download_document", map[string]any{"document_id": 1})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"content_type":"application/pdf; charset=binary","bytes":3,"content_base64":"AP8Q"}`, result.Data)
+}
+
+func TestPaperlessResponseSizeLimits(t *testing.T) {
+	body := strings.Repeat("x", 2*1024*1024+1)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(ts.Close)
+
+	p := &paperless{token: "token", baseURL: ts.URL, client: ts.Client()}
+	_, err := p.doRequest(context.Background(), http.MethodGet, "/json", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "response exceeds")
+
+	_, err = p.doMultipartRequest(context.Background(), "/multipart", strings.NewReader("body"), mime.TypeByExtension(".txt"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "response exceeds")
+}
+
+func TestPaperlessDownloadSizeLimit(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, strings.Repeat("x", 1024*1024+1))
+	}))
+	t.Cleanup(ts.Close)
+
+	p := &paperless{token: "token", baseURL: ts.URL, client: ts.Client()}
+	result, err := p.Execute(context.Background(), "paperless_download_document", map[string]any{"document_id": 1})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "response exceeds")
 }
 
 func TestMetadataAndHTTPFailures(t *testing.T) {

--- a/integrations/paperless/tools.go
+++ b/integrations/paperless/tools.go
@@ -1,69 +1,110 @@
 package paperless
 
-import mcp "github.com/daltoniam/switchboard"
+import (
+	"maps"
 
-var tools = []mcp.ToolDefinition{
-	{
-		Name:        "paperless_list_documents",
-		Description: "List archived Paperless-ngx documents with pagination. Start here to browse a document archive, invoices, receipts, and scanned records.",
-		Parameters:  map[string]string{"page": "Page number (default: 1)", "page_size": "Documents per page (default: 25)"},
-	},
-	{
-		Name:        "paperless_search_documents",
-		Description: "Search Paperless-ngx archived documents by full-text query, title, or OCR content. Start here to find scanned documents, invoices, receipts, and records.",
-		Parameters:  map[string]string{"query": "Full-text search query", "page": "Page number (default: 1)", "page_size": "Documents per page (default: 25)"},
-		Required:    []string{"query"},
-	},
-	{
-		Name:        "paperless_create_document",
-		Description: "Create and upload a plain-text document to Paperless-ngx for safe live testing. Use title and short non-sensitive content; this creates a real archive document.",
-		Parameters:  map[string]string{"title": "Document title", "content": "Plain-text document content"},
-		Required:    []string{"title", "content"},
-	},
-	{
-		Name:        "paperless_get_document",
-		Description: "Get metadata and OCR text for a specific Paperless-ngx document. Use after listing or searching documents.",
-		Parameters:  map[string]string{"document_id": "Document ID"},
-		Required:    []string{"document_id"},
-	},
-	{
-		Name:        "paperless_update_document",
-		Description: "Update Paperless-ngx document metadata such as title, tags, correspondent, document type, storage path, or custom fields. Use after get_document.",
-		Parameters: map[string]string{
-			"document_id": "Document ID", "title": "New title", "tags": "Tag ID array", "correspondent": "Correspondent ID", "document_type": "Document type ID", "storage_path": "Storage path ID", "archive_serial_number": "Archive serial number", "created": "Document creation date", "added": "Date added", "custom_fields": "Custom field value array",
-		},
-		Required: []string{"document_id"},
-	},
-	{
-		Name:        "paperless_delete_document",
-		Description: "Permanently delete a Paperless-ngx document. Use after get_document when the document should be removed.",
-		Parameters:  map[string]string{"document_id": "Document ID"},
-		Required:    []string{"document_id"},
-	},
-	{
-		Name:        "paperless_download_document",
-		Description: "Download the original file for a Paperless-ngx document. Use after get_document when the document file is needed.",
-		Parameters:  map[string]string{"document_id": "Document ID"},
-		Required:    []string{"document_id"},
-	},
-	{Name: "paperless_list_tags", Description: "List Paperless-ngx tags used to categorize archived documents.", Parameters: map[string]string{}},
-	{Name: "paperless_list_correspondents", Description: "List Paperless-ngx correspondents such as vendors, senders, and organizations.", Parameters: map[string]string{}},
-	{Name: "paperless_list_document_types", Description: "List Paperless-ngx document types used to classify archived records.", Parameters: map[string]string{}},
-	{Name: "paperless_list_storage_paths", Description: "List Paperless-ngx storage paths that organize archived document files.", Parameters: map[string]string{}},
-	{Name: "paperless_list_custom_fields", Description: "List Paperless-ngx custom fields available on archived documents.", Parameters: map[string]string{}},
+	mcp "github.com/daltoniam/switchboard"
+)
+
+var tools = buildTools()
+
+var (
+	pageParameters = map[string]string{"page": "Page number (default: 1)", "page_size": "Results per page (default: 25)"}
+	idParameter    = map[string]string{"id": "Resource ID"}
+	dataParameter  = map[string]string{"data": "JSON object sent to the documented Paperless API resource"}
+)
+
+type configurationResource struct {
+	singular string
+	plural   string
+	purpose  string
+	danger   string
 }
 
-var dispatch = map[mcp.ToolName]handlerFunc{
-	"paperless_list_documents":      listDocuments,
-	"paperless_search_documents":    searchDocuments,
-	"paperless_create_document":     createDocument,
-	"paperless_get_document":        getDocument,
-	"paperless_update_document":     updateDocument,
-	"paperless_delete_document":     deleteDocument,
-	"paperless_download_document":   downloadDocument,
-	"paperless_list_tags":           listMetadata("/api/tags/"),
-	"paperless_list_correspondents": listMetadata("/api/correspondents/"),
-	"paperless_list_document_types": listMetadata("/api/document_types/"),
-	"paperless_list_storage_paths":  listMetadata("/api/storage_paths/"),
-	"paperless_list_custom_fields":  listMetadata("/api/custom_fields/"),
+var configurationResources = []configurationResource{
+	{"tag", "tags", "categorize archived documents", "Changing ownership or set_permissions can grant or revoke access to tagged documents."},
+	{"correspondent", "correspondents", "identify vendors, senders, and organizations", "Changing ownership or set_permissions can grant or revoke access to matching document metadata."},
+	{"document_type", "document_types", "classify archived records", "Changing ownership or set_permissions can grant or revoke access to document metadata."},
+	{"storage_path", "storage_paths", "organize archived document files", "Updating a storage path can asynchronously rename or move documents; ownership or set_permissions changes affect access."},
+	{"custom_field", "custom_fields", "store structured metadata on documents", "Changing or deleting a field can affect document metadata and its available values."},
+	{"saved_view", "saved_views", "reuse document search filters", "Changing ownership or set_permissions can share or restrict access to the saved view."},
+	{"mail_rule", "mail_rules", "route and process imported email", "Changes affect how future imported email is matched and processed."},
+	{"user", "users", "administer Paperless user accounts", "Security-sensitive: data may set passwords, staff or superuser privileges, group memberships, and account activation; changes immediately alter account access, and deletion removes the account and its access."},
+	{"group", "groups", "administer Paperless permission groups", "Security-sensitive: data may grant Django permissions and change member access to Paperless resources; deletion revokes access granted through the group."},
+}
+
+func buildTools() []mcp.ToolDefinition {
+	definitions := []mcp.ToolDefinition{
+		{Name: "paperless_list_documents", Description: "List archived Paperless-ngx documents with pagination. Start here to browse a document archive, invoices, receipts, and scanned records.", Parameters: pageParameters},
+		{Name: "paperless_search_documents", Description: "Search Paperless-ngx archived documents by full-text query, title, or OCR content. Start here to find scanned documents, invoices, receipts, and records.", Parameters: map[string]string{"query": "Full-text search query", "page": "Page number (default: 1)", "page_size": "Documents per page (default: 25)"}, Required: []string{"query"}},
+		{Name: "paperless_create_document", Description: "Create and upload a plain-text document to Paperless-ngx for safe live testing. Use title and short non-sensitive content; this creates a real archive document.", Parameters: map[string]string{"title": "Document title", "content": "Plain-text document content"}, Required: []string{"title", "content"}},
+		{Name: "paperless_get_document", Description: "Get metadata for a specific Paperless-ngx document, without OCR text. Use after listing or searching documents.", Parameters: map[string]string{"document_id": "Document ID"}, Required: []string{"document_id"}},
+		{Name: "paperless_get_document_ocr_text", Description: "Get a paginated slice of OCR text for a Paperless-ngx document. Use after get_document when document text is needed; continue with next_offset while has_more is true.", Parameters: map[string]string{"document_id": "Document ID", "offset": "Zero-based OCR character offset (default: 0)", "limit": "OCR characters to return (default: 10000, maximum: 20000)"}, Required: []string{"document_id"}},
+
+		{Name: "paperless_update_document", Description: "Update Paperless-ngx document metadata such as title, tags, correspondent, document type, storage path, or custom fields. Use after get_document.", Parameters: map[string]string{"document_id": "Document ID", "title": "New title", "tags": "Tag ID array", "correspondent": "Correspondent ID", "document_type": "Document type ID", "storage_path": "Storage path ID", "archive_serial_number": "Archive serial number", "created": "Document creation date", "added": "Date added", "custom_fields": "Custom field value array"}, Required: []string{"document_id"}},
+		{Name: "paperless_delete_document", Description: "Permanently delete a Paperless-ngx document. Use after get_document when the document should be removed.", Parameters: map[string]string{"document_id": "Document ID"}, Required: []string{"document_id"}},
+		{Name: "paperless_download_document", Description: "Download the original file for a Paperless-ngx document as a JSON envelope with content type, byte count, and base64 content. Use after get_document when the document file is needed.", Parameters: map[string]string{"document_id": "Document ID"}, Required: []string{"document_id"}},
+
+		{Name: "paperless_list_tasks", Description: "List asynchronous Paperless-ngx background tasks, including document consumption and workflow jobs. Start here to monitor task execution.", Parameters: pageParameters},
+		{Name: "paperless_get_task", Description: "Get a specific Paperless-ngx asynchronous task by ID. Use after list_tasks or an upload returns a task ID.", Parameters: idParameter, Required: []string{"id"}},
+		{Name: "paperless_get_task_summary", Description: "Get aggregate Paperless-ngx background-task execution statistics over recent days. Use for administration and task health monitoring.", Parameters: map[string]string{"days": "Days of task history (default: 30)"}},
+		{Name: "paperless_get_task_status_counts", Description: "Get counts of Paperless-ngx tasks in the upstream all, needs_attention, in_progress, and completed sections. Use for task health monitoring."},
+		{Name: "paperless_list_active_tasks", Description: "List currently pending and running Paperless-ngx background tasks. Use to investigate active document consumption or workflows."},
+		{Name: "paperless_run_task", Description: "Manually dispatch a supported Paperless-ngx background task. Requires a superuser and causes real server work; use only when explicitly requested.", Parameters: map[string]string{"task_type": "Documented Paperless task type"}, Required: []string{"task_type"}},
+		{Name: "paperless_acknowledge_tasks", Description: "Acknowledge Paperless-ngx task records to clear task attention state. This changes task management state; use only after reviewing tasks.", Parameters: dataParameter, Required: []string{"data"}},
+		{Name: "paperless_bulk_edit_documents", Description: "Run a documented asynchronous bulk operation on Paperless-ngx documents. Supports metadata, tags, permissions, reprocessing, and deletion; deletion is destructive, so use only when explicitly requested after listing documents.", Parameters: dataParameter, Required: []string{"data"}},
+		{Name: "paperless_bulk_edit_objects", Description: "Run a documented bulk permission or deletion operation for Paperless-ngx tags, correspondents, document types, or storage paths. Deletion is destructive; use only when explicitly requested after listing objects.", Parameters: dataParameter, Required: []string{"data"}},
+	}
+	definitions = append(definitions, workflowTools()...)
+	for _, resource := range configurationResources {
+		definitions = append(definitions, resourceTools(resource)...)
+	}
+	return definitions
+}
+
+func workflowTools() []mcp.ToolDefinition {
+	return []mcp.ToolDefinition{
+		{Name: "paperless_list_workflows", Description: "List Paperless-ngx workflows. Workflow triggers and actions are nested components, not standalone resources.", Parameters: pageParameters},
+		{Name: "paperless_get_workflow", Description: "Get a Paperless-ngx workflow with its nested trigger and action payloads. Use before changing automation.", Parameters: idParameter, Required: []string{"id"}},
+		{Name: "paperless_create_workflow", Description: "Create Paperless-ngx document automation. data must contain name, nested triggers, and nested actions using Paperless numeric type values (trigger 1=consumption, 2=document added, 3=document updated, 4=scheduled; action 1=assignment, 2=removal, 3=email, 4=webhook, 5=password removal, 6=move to trash, 7=remote OCR, 8=apply AI suggestions). A consumption trigger requires filter_filename, filter_path, or filter_mailrule. Actions can modify metadata, permissions, send email or webhooks, remove passwords, or move documents to trash; this affects future documents.", Parameters: dataParameter, Required: []string{"data"}},
+		{Name: "paperless_update_workflow", Description: "Update Paperless-ngx automation using nested triggers and actions in data; they are not reusable standalone resources. Use after get_workflow. Trigger/action payloads can grant or revoke document permissions, send email or webhooks, remove passwords, or move future documents to trash.", Parameters: mergeParameters(idParameter, dataParameter), Required: []string{"id", "data"}},
+		{Name: "paperless_delete_workflow", Description: "Permanently delete a Paperless-ngx workflow and stop its future automated processing. Use only after get_workflow confirms it should be removed.", Parameters: idParameter, Required: []string{"id"}},
+	}
+}
+
+func resourceTools(resource configurationResource) []mcp.ToolDefinition {
+	return []mcp.ToolDefinition{
+		{Name: mcp.ToolName("paperless_list_" + resource.plural), Description: "List Paperless-ngx " + resource.plural + " used to " + resource.purpose + ". Start here to discover available " + resource.plural + ".", Parameters: pageParameters},
+		{Name: mcp.ToolName("paperless_get_" + resource.singular), Description: "Get a specific Paperless-ngx " + resource.singular + ". Use after list_" + resource.plural + ".", Parameters: idParameter, Required: []string{"id"}},
+		{Name: mcp.ToolName("paperless_create_" + resource.singular), Description: "Create a Paperless-ngx " + resource.singular + " to " + resource.purpose + ". Send documented API fields in data; this creates real configuration. " + resource.danger, Parameters: dataParameter, Required: []string{"data"}},
+		{Name: mcp.ToolName("paperless_update_" + resource.singular), Description: "Update a Paperless-ngx " + resource.singular + ". Use after get_" + resource.singular + " and send documented API fields in data. " + resource.danger, Parameters: mergeParameters(idParameter, dataParameter), Required: []string{"id", "data"}},
+		{Name: mcp.ToolName("paperless_delete_" + resource.singular), Description: "Permanently delete a Paperless-ngx " + resource.singular + ". Use only after get_" + resource.singular + " confirms it should be removed. " + resource.danger, Parameters: idParameter, Required: []string{"id"}},
+	}
+}
+
+func mergeParameters(left, right map[string]string) map[string]string {
+	result := make(map[string]string, len(left)+len(right))
+	maps.Copy(result, left)
+	maps.Copy(result, right)
+	return result
+}
+
+var dispatch = buildDispatch()
+
+func buildDispatch() map[mcp.ToolName]handlerFunc {
+	d := map[mcp.ToolName]handlerFunc{
+		"paperless_list_documents": listDocuments, "paperless_search_documents": searchDocuments, "paperless_create_document": createDocument, "paperless_get_document": getDocument, "paperless_get_document_ocr_text": getDocumentOCRText, "paperless_update_document": updateDocument, "paperless_delete_document": deleteDocument, "paperless_download_document": downloadDocument,
+		"paperless_list_tasks": listResource("/api/tasks/"), "paperless_get_task": getResource("/api/tasks/"), "paperless_get_task_summary": getTaskSummary, "paperless_get_task_status_counts": listMetadata("/api/tasks/status_counts/"), "paperless_list_active_tasks": listMetadata("/api/tasks/active/"), "paperless_run_task": runTask, "paperless_acknowledge_tasks": acknowledgeTasks,
+		"paperless_bulk_edit_documents": bulkEditDocuments, "paperless_bulk_edit_objects": bulkEditObjects,
+	}
+	resources := append([]configurationResource{{singular: "workflow", plural: "workflows"}}, configurationResources...)
+	for _, resource := range resources {
+		path := "/api/" + resource.plural + "/"
+		d[mcp.ToolName("paperless_list_"+resource.plural)] = listResource(path)
+		d[mcp.ToolName("paperless_get_"+resource.singular)] = getResource(path)
+		d[mcp.ToolName("paperless_create_"+resource.singular)] = createResource(path)
+		d[mcp.ToolName("paperless_update_"+resource.singular)] = updateResource(path)
+		d[mcp.ToolName("paperless_delete_"+resource.singular)] = deleteResource(path)
+	}
+	return d
 }

--- a/integrations/recoll/recoll_test.go
+++ b/integrations/recoll/recoll_test.go
@@ -77,6 +77,20 @@ func TestExecute_UnknownTool(t *testing.T) {
 	assert.Contains(t, result.Data, "unknown tool")
 }
 
+func TestSearchRejectsBlankQuery(t *testing.T) {
+	requests := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requests++
+	}))
+	t.Cleanup(ts.Close)
+
+	result, err := configuredRecoll(t, ts.URL).Execute(context.Background(), "recoll_search", map[string]any{"query": " \t\n "})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "query is required")
+	assert.Zero(t, requests)
+}
+
 func TestSearch_RoundTrip(t *testing.T) {
 	var gotQuery map[string][]string
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -106,6 +120,16 @@ func TestSearch_RoundTrip(t *testing.T) {
 			{"path":"/documents/notes.txt","mime_type":"text/plain"}
 		]
 	}`, result.Data)
+}
+
+func TestParseSearchResultsFallsBackToResultLength(t *testing.T) {
+	result, err := parseSearchResults([]byte(`<html><body>
+		<div class="result"><div class="path">/documents/one.txt</div></div>
+		<div class="result"><div class="path">/documents/two.txt</div></div>
+	</body></html>`), "notes")
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.Count)
+	assert.Len(t, result.Results, 2)
 }
 
 func TestDoRequest(t *testing.T) {

--- a/integrations/recoll/tools.go
+++ b/integrations/recoll/tools.go
@@ -35,6 +35,9 @@ func search(ctx context.Context, r *recoll, args map[string]any) (*mcp.ToolResul
 	if err := reader.Err(); err != nil {
 		return mcp.ErrResult(err)
 	}
+	if strings.TrimSpace(query) == "" {
+		return mcp.ErrResult(fmt.Errorf("query is required"))
+	}
 
 	data, err := r.get(ctx, "/?"+url.Values{"q": {query}}.Encode())
 	if err != nil {
@@ -86,6 +89,9 @@ func parseSearchResults(data []byte, query string) (searchResponse, error) {
 			}
 		}
 	})
+	if response.Count == 0 {
+		response.Count = len(response.Results)
+	}
 	return response, nil
 }
 


### PR DESCRIPTION
## Summary
- Add Paperless administration, workflow, task, and bulk-operation tools.
- Keep OCR text in a paginated drill-down tool and bound all upstream responses.
- Address Paperless and Recoll post-merge review feedback.

## Verification
- `make ci`
- Isolated Crush smoke test against Paperless-ngx, including paginated OCR retrieval

💘 Generated with Crush