### PR TITLE
Add Intercom customer support integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,8 @@ Environment variables override credential values but do not change the durable e
 | Gong | `base_url` | `GONG_BASE_URL` (optional — default `https://api.gong.io`) |
 | HubSpot | `access_token` | `HUBSPOT_ACCESS_TOKEN` |
 | HubSpot | `base_url` | `HUBSPOT_BASE_URL` (optional — default `https://api.hubapi.com`) |
+| Intercom | `access_token` | `INTERCOM_ACCESS_TOKEN` |
+| Intercom | `base_url` | `INTERCOM_BASE_URL` (optional — default `https://api.intercom.io`; EU `https://api.eu.intercom.io`, AU `https://api.au.intercom.io`) |
 | Ramp | `access_token` | `RAMP_ACCESS_TOKEN` |
 | Ramp | `base_url` | `RAMP_BASE_URL` (optional — default `https://api.ramp.com`, use `https://demo-api.ramp.com` for sandbox) |
 | NetSuite | `account_id` | `NETSUITE_ACCOUNT_ID` |

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -48,6 +48,7 @@ import (
 	"github.com/daltoniam/switchboard/integrations/gslides"
 	"github.com/daltoniam/switchboard/integrations/gtasks"
 	"github.com/daltoniam/switchboard/integrations/hubspot"
+	"github.com/daltoniam/switchboard/integrations/intercom"
 	"github.com/daltoniam/switchboard/integrations/jira"
 	"github.com/daltoniam/switchboard/integrations/kubernetes"
 	"github.com/daltoniam/switchboard/integrations/linear"
@@ -322,6 +323,7 @@ func runServer(stdioMode bool, port int, listenHost, grpcSocket string, discover
 		gmailIntegration,
 		gong.New(),
 		hubspot.New(),
+		intercom.New(),
 		gcalIntegration,
 		gdriveIntegration,
 		gdocsIntegration,

--- a/config/config.go
+++ b/config/config.go
@@ -188,6 +188,10 @@ var envMapping = map[string]map[string]string{
 		"access_token": "HUBSPOT_ACCESS_TOKEN",
 		"base_url":     "HUBSPOT_BASE_URL",
 	},
+	"intercom": {
+		"access_token": "INTERCOM_ACCESS_TOKEN",
+		"base_url":     "INTERCOM_BASE_URL",
+	},
 	"ramp": {
 		"access_token": "RAMP_ACCESS_TOKEN",
 		"base_url":     "RAMP_BASE_URL",
@@ -382,6 +386,10 @@ func defaultConfig() *mcp.Config {
 				Credentials: mcp.Credentials{"access_key": "", "access_key_secret": "", "base_url": ""},
 			},
 			"hubspot": {
+				Enabled:     false,
+				Credentials: mcp.Credentials{"access_token": "", "base_url": ""},
+			},
+			"intercom": {
 				Enabled:     false,
 				Credentials: mcp.Credentials{"access_token": "", "base_url": ""},
 			},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -32,8 +32,8 @@ func TestLoad_CreatesDefaultWhenMissing(t *testing.T) {
 	_, err = os.Stat(path)
 	assert.NoError(t, err)
 
-	assert.Len(t, m.cfg.Integrations, 56)
-	for _, name := range []string{"github", "datadog", "linear", "sentry", "slack", "slackmcp", "metabase", "paperless", "recoll", "aws", "posthog", "postgres", "clickhouse", "elasticsearch", "pganalyze", "rwx", "projectinterop", "gmail", "gcal", "gdrive", "gdocs", "gsheets", "gslides", "gforms", "gchat", "gmeet", "gtasks", "gpeople", "notion", "ollama", "ynab", "stripe", "gcp", "suno", "amazon", "jira", "confluence", "salesforce", "cloudflare", "digitalocean", "fly", "kubernetes", "vercel", "snowflake", "acp", "web", "botidentity", "x", "signoz", "nomad", "agents", "switchboard", "netsuite", "ramp", "gong", "hubspot"} {
+	assert.Len(t, m.cfg.Integrations, 57)
+	for _, name := range []string{"github", "datadog", "linear", "sentry", "slack", "slackmcp", "metabase", "paperless", "recoll", "aws", "posthog", "postgres", "clickhouse", "elasticsearch", "pganalyze", "rwx", "projectinterop", "gmail", "gcal", "gdrive", "gdocs", "gsheets", "gslides", "gforms", "gchat", "gmeet", "gtasks", "gpeople", "notion", "ollama", "ynab", "stripe", "gcp", "suno", "amazon", "jira", "confluence", "salesforce", "cloudflare", "digitalocean", "fly", "kubernetes", "vercel", "snowflake", "acp", "web", "botidentity", "x", "signoz", "nomad", "agents", "switchboard", "netsuite", "ramp", "gong", "hubspot", "intercom"} {
 		ic, ok := m.cfg.Integrations[name]
 		assert.True(t, ok, "missing default integration: %s", name)
 		assert.False(t, ic.Enabled)
@@ -154,7 +154,7 @@ func TestSave(t *testing.T) {
 
 	var cfg mcp.Config
 	require.NoError(t, json.Unmarshal(data, &cfg))
-	assert.Len(t, cfg.Integrations, 56)
+	assert.Len(t, cfg.Integrations, 57)
 }
 
 func TestGet(t *testing.T) {
@@ -163,7 +163,7 @@ func TestGet(t *testing.T) {
 
 	cfg := m.Get()
 	assert.NotNil(t, cfg)
-	assert.Len(t, cfg.Integrations, 56)
+	assert.Len(t, cfg.Integrations, 57)
 }
 
 func TestUpdate(t *testing.T) {
@@ -273,7 +273,7 @@ func TestEnabledIntegrations_Multiple(t *testing.T) {
 func TestDefaultConfig(t *testing.T) {
 	cfg := defaultConfig()
 	require.NotNil(t, cfg)
-	assert.Len(t, cfg.Integrations, 56)
+	assert.Len(t, cfg.Integrations, 57)
 
 	expected := map[string][]string{
 		"github":         {"token", "client_id", "token_source"},
@@ -298,6 +298,7 @@ func TestDefaultConfig(t *testing.T) {
 		"ynab":           {"api_key"},
 		"gong":           {"access_key", "access_key_secret", "base_url"},
 		"hubspot":        {"access_token", "base_url"},
+		"intercom":       {"access_token", "base_url"},
 		"ramp":           {"access_token", "base_url"},
 		"gcp":            {"project_id", "credentials_json"},
 		"confluence":     {"email", "api_token", "domain"},
@@ -571,6 +572,8 @@ func TestEnvMapping_ReturnsMapping(t *testing.T) {
 	assert.Equal(t, "GONG_ACCESS_KEY_SECRET", m["gong"]["access_key_secret"])
 	assert.Equal(t, "HUBSPOT_ACCESS_TOKEN", m["hubspot"]["access_token"])
 	assert.Equal(t, "HUBSPOT_BASE_URL", m["hubspot"]["base_url"])
+	assert.Equal(t, "INTERCOM_ACCESS_TOKEN", m["intercom"]["access_token"])
+	assert.Equal(t, "INTERCOM_BASE_URL", m["intercom"]["base_url"])
 	assert.Equal(t, "RAMP_ACCESS_TOKEN", m["ramp"]["access_token"])
 	assert.Equal(t, "RAMP_BASE_URL", m["ramp"]["base_url"])
 	assert.Equal(t, "NETSUITE_ACCOUNT_ID", m["netsuite"]["account_id"])
@@ -593,9 +596,9 @@ func TestEnvMapping_ReturnsMapping(t *testing.T) {
 	assert.Equal(t, "VERCEL_TEAM_ID", m["vercel"]["team_id"])
 	assert.Equal(t, "VERCEL_TEAM_SLUG", m["vercel"]["team_slug"])
 	assert.Equal(t, "VERCEL_BASE_URL", m["vercel"]["base_url"])
-	// 34 base integrations + 11 Google Workspace services sharing the
+	// 35 base integrations + 11 Google Workspace services sharing the
 	// GOOGLE_OAUTH_CLIENT_ID/SECRET env vars.
-	assert.Len(t, m, 45)
+	assert.Len(t, m, 46)
 	for _, name := range googleWorkspaceIntegrations {
 		assert.Equal(t, "GOOGLE_OAUTH_CLIENT_ID", m[name][mcp.CredKeyClientID])
 		assert.Equal(t, "GOOGLE_OAUTH_CLIENT_SECRET", m[name][mcp.CredKeyClientSecret])

--- a/integrations/intercom/compact.yaml
+++ b/integrations/intercom/compact.yaml
@@ -277,3 +277,11 @@ tools:
         spec:
             - data[].id
             - data[].name
+    intercom_list_ticket_types:
+        spec:
+            - data[].id
+            - data[].name
+            - data[].description
+            - data[].category
+            - data[].archived
+            - data[].icon

--- a/integrations/intercom/compact.yaml
+++ b/integrations/intercom/compact.yaml
@@ -1,0 +1,279 @@
+# Switchboard compaction specs for the intercom integration.
+#
+# Schema: tools.<tool_name>: { spec: [<spec_lines>], max_bytes?: <int> }
+#
+# Full spec syntax (paths, arrays, aliases, exclusions): docs/field-compaction.md.
+
+version: 1
+tools:
+    intercom_search_conversations:
+        spec:
+            - conversations[].id
+            - conversations[].title
+            - conversations[].state
+            - conversations[].open
+            - conversations[].read
+            - conversations[].priority
+            - conversations[].created_at
+            - conversations[].updated_at
+            - conversations[].waiting_since
+            - conversations[].snoozed_until
+            - conversations[].admin_assignee_id
+            - conversations[].team_assignee_id
+            - conversations[].source.subject
+            - conversations[].source.type
+            - conversations[].source.author.name
+            - conversations[].source.author.email
+            - conversations[].contacts
+            - conversations[].tags
+            - pages.next.starting_after
+            - pages.page
+            - pages.per_page
+            - pages.total_pages
+            - total_count
+    intercom_list_conversations:
+        spec:
+            - conversations[].id
+            - conversations[].title
+            - conversations[].state
+            - conversations[].open
+            - conversations[].read
+            - conversations[].priority
+            - conversations[].created_at
+            - conversations[].updated_at
+            - conversations[].waiting_since
+            - conversations[].snoozed_until
+            - conversations[].admin_assignee_id
+            - conversations[].team_assignee_id
+            - conversations[].source.subject
+            - conversations[].source.type
+            - conversations[].source.author.name
+            - conversations[].source.author.email
+            - conversations[].contacts
+            - conversations[].tags
+            - pages.next.starting_after
+            - pages.page
+            - pages.per_page
+            - pages.total_pages
+            - total_count
+    intercom_get_conversation:
+        max_bytes: 200000
+        spec:
+            - id
+            - title
+            - state
+            - open
+            - read
+            - priority
+            - created_at
+            - updated_at
+            - waiting_since
+            - snoozed_until
+            - admin_assignee_id
+            - team_assignee_id
+            - source.subject
+            - source.type
+            - source.body
+            - source.author.id
+            - source.author.name
+            - source.author.email
+            - source.author.type
+            - contacts
+            - tags
+            - conversation_parts.conversation_parts[].id
+            - conversation_parts.conversation_parts[].part_type
+            - conversation_parts.conversation_parts[].body
+            - conversation_parts.conversation_parts[].created_at
+            - conversation_parts.conversation_parts[].author.id
+            - conversation_parts.conversation_parts[].author.name
+            - conversation_parts.conversation_parts[].author.email
+            - conversation_parts.conversation_parts[].author.type
+    intercom_search_contacts:
+        spec:
+            - data[].id
+            - data[].role
+            - data[].email
+            - data[].name
+            - data[].phone
+            - data[].external_id
+            - data[].created_at
+            - data[].updated_at
+            - data[].last_seen_at
+            - data[].unsubscribed_from_emails
+            - pages.next.starting_after
+            - pages.page
+            - pages.per_page
+            - pages.total_pages
+            - total_count
+    intercom_list_contacts:
+        spec:
+            - data[].id
+            - data[].role
+            - data[].email
+            - data[].name
+            - data[].phone
+            - data[].external_id
+            - data[].created_at
+            - data[].updated_at
+            - data[].last_seen_at
+            - data[].unsubscribed_from_emails
+            - pages.next.starting_after
+            - pages.page
+            - pages.per_page
+            - pages.total_pages
+            - total_count
+    intercom_get_contact:
+        spec:
+            - id
+            - role
+            - email
+            - name
+            - phone
+            - external_id
+            - created_at
+            - updated_at
+            - last_seen_at
+            - signed_up_at
+            - unsubscribed_from_emails
+            - custom_attributes
+            - companies.data
+    intercom_list_companies:
+        spec:
+            - data[].id
+            - data[].name
+            - data[].company_id
+            - data[].plan
+            - data[].size
+            - data[].website
+            - data[].industry
+            - data[].monthly_spend
+            - data[].created_at
+            - data[].updated_at
+            - pages.next
+            - pages.page
+            - pages.per_page
+            - pages.total_pages
+            - total_count
+    intercom_get_company:
+        spec:
+            - id
+            - name
+            - company_id
+            - plan
+            - size
+            - website
+            - industry
+            - monthly_spend
+            - created_at
+            - updated_at
+            - custom_attributes
+            - user_count
+    intercom_search_tickets:
+        spec:
+            - tickets[].id
+            - tickets[].ticket_id
+            - tickets[].ticket_state
+            - tickets[].open
+            - tickets[].created_at
+            - tickets[].updated_at
+            - tickets[].admin_assignee_id
+            - tickets[].team_assignee_id
+            - tickets[].ticket_type
+            - tickets[].ticket_attributes
+            - tickets[].contacts
+            - pages.next.starting_after
+            - pages.page
+            - pages.per_page
+            - pages.total_pages
+            - total_count
+    intercom_get_ticket:
+        spec:
+            - id
+            - ticket_id
+            - ticket_state
+            - open
+            - created_at
+            - updated_at
+            - admin_assignee_id
+            - team_assignee_id
+            - ticket_type
+            - ticket_attributes
+            - contacts
+            - ticket_parts
+    intercom_search_articles:
+        spec:
+            - data.articles[].id
+            - data.articles[].title
+            - data.articles[].description
+            - data.articles[].state
+            - data.articles[].url
+            - data.articles[].author_id
+            - data.articles[].created_at
+            - data.articles[].updated_at
+            - data.highlights
+            - total_count
+            - pages.next.starting_after
+            - pages.page
+            - pages.per_page
+    intercom_list_articles:
+        spec:
+            - data[].id
+            - data[].title
+            - data[].description
+            - data[].state
+            - data[].url
+            - data[].author_id
+            - data[].created_at
+            - data[].updated_at
+            - pages.next.starting_after
+            - pages.page
+            - pages.per_page
+            - pages.total_pages
+            - total_count
+    intercom_get_article:
+        max_bytes: 200000
+        spec:
+            - id
+            - title
+            - description
+            - body
+            - state
+            - url
+            - author_id
+            - created_at
+            - updated_at
+            - parent_id
+            - parent_type
+    intercom_list_admins:
+        spec:
+            - admins[].id
+            - admins[].name
+            - admins[].email
+            - admins[].away_mode_enabled
+            - admins[].has_inbox_seat
+            - admins[].team_ids
+    intercom_get_me:
+        spec:
+            - id
+            - name
+            - email
+            - type
+            - away_mode_enabled
+            - has_inbox_seat
+            - team_ids
+            - app.id_code
+            - app.name
+    intercom_list_teams:
+        spec:
+            - teams[].id
+            - teams[].name
+            - teams[].admin_ids
+    intercom_get_team:
+        spec:
+            - id
+            - name
+            - admin_ids
+    intercom_list_tags:
+        spec:
+            - data[].id
+            - data[].name

--- a/integrations/intercom/compact_specs_test.go
+++ b/integrations/intercom/compact_specs_test.go
@@ -60,6 +60,7 @@ func TestFieldCompactionSpecs_ShapeParity(t *testing.T) {
 		"intercom_list_teams":           `{"type":"team.list","teams":[{"id":"t1","name":"Support","admin_ids":["a1"]}]}`,
 		"intercom_get_team":             `{"id":"t1","name":"Support","admin_ids":["a1"]}`,
 		"intercom_list_tags":            `{"type":"list","data":[{"id":"tag1","name":"billing"}]}`,
+		"intercom_list_ticket_types":    `{"type":"list","data":[{"id":"tt1","name":"Bug","description":"product bugs","category":"Customer","archived":false,"icon":"🐞"}]}`,
 	}
 
 	for toolName, payload := range handlerOutputs {

--- a/integrations/intercom/compact_specs_test.go
+++ b/integrations/intercom/compact_specs_test.go
@@ -1,0 +1,76 @@
+package intercom
+
+import (
+	"testing"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/daltoniam/switchboard/compact"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestFieldCompactionSpecs_AllParse(t *testing.T) {
+	require.NotEmpty(t, fieldCompactionSpecs, "fieldCompactionSpecs should not be empty")
+}
+
+func TestFieldCompactionSpecs_NoDuplicateTools(t *testing.T) {
+	var sf compact.SpecFile
+	require.NoError(t, yaml.Unmarshal(compactYAML, &sf))
+	assert.Equal(t, len(sf.Tools), len(fieldCompactionSpecs))
+}
+
+func TestFieldCompactionSpecs_NoOrphanSpecs(t *testing.T) {
+	for toolName := range fieldCompactionSpecs {
+		_, ok := dispatch[toolName]
+		assert.True(t, ok, "field compaction spec for %q has no dispatch handler", toolName)
+	}
+}
+
+func TestFieldCompactionSpec_ReturnsFieldsForListTool(t *testing.T) {
+	c := &intercom{}
+	fields, ok := c.CompactSpec("intercom_search_conversations")
+	require.True(t, ok, "intercom_search_conversations should have field compaction spec")
+	assert.NotEmpty(t, fields)
+}
+
+func TestFieldCompactionSpec_ReturnsFalseForUnknownTool(t *testing.T) {
+	c := &intercom{}
+	_, ok := c.CompactSpec("intercom_nonexistent")
+	assert.False(t, ok, "unknown tools should return false")
+}
+
+func TestFieldCompactionSpecs_ShapeParity(t *testing.T) {
+	handlerOutputs := map[string]string{
+		"intercom_search_conversations": `{"total_count":1,"pages":{"page":1,"per_page":20,"total_pages":1,"next":{"starting_after":"c1"}},"conversations":[{"id":"1","title":"Help","state":"open","open":true,"read":true,"priority":"not_priority","created_at":1,"updated_at":2,"waiting_since":3,"snoozed_until":0,"admin_assignee_id":"a1","team_assignee_id":"t1","source":{"subject":"Help","type":"conversation","author":{"name":"Ada","email":"a@b.com"}},"contacts":{"contacts":[{"id":"u1"}]},"tags":{"tags":[{"id":"tag1","name":"billing"}]}}]}`,
+		"intercom_list_conversations":   `{"total_count":1,"pages":{"page":1,"per_page":20,"total_pages":1,"next":{"starting_after":"c1"}},"conversations":[{"id":"1","title":"Help","state":"open","open":true,"read":true,"priority":"not_priority","created_at":1,"updated_at":2,"waiting_since":3,"snoozed_until":0,"admin_assignee_id":"a1","team_assignee_id":"t1","source":{"subject":"Help","type":"conversation","author":{"name":"Ada","email":"a@b.com"}},"contacts":{"contacts":[{"id":"u1"}]},"tags":{"tags":[{"id":"tag1","name":"billing"}]}}]}`,
+		"intercom_get_conversation":     `{"id":"1","title":"Help","state":"open","open":true,"read":true,"priority":"not_priority","created_at":1,"updated_at":2,"waiting_since":3,"snoozed_until":0,"admin_assignee_id":"a1","team_assignee_id":"t1","source":{"subject":"Help","type":"conversation","body":"<p>hi</p>","author":{"id":"u1","name":"Ada","email":"a@b.com","type":"user"}},"contacts":{"contacts":[{"id":"u1"}]},"tags":{"tags":[{"id":"tag1"}]},"conversation_parts":{"conversation_parts":[{"id":"p1","part_type":"comment","body":"<p>reply</p>","created_at":4,"author":{"id":"a1","name":"Admin","email":"ad@b.com","type":"admin"}}]}}`,
+		"intercom_search_contacts":      `{"total_count":1,"pages":{"page":1,"per_page":20,"total_pages":1,"next":{"starting_after":"u1"}},"data":[{"id":"u1","role":"user","email":"a@b.com","name":"Ada","phone":"+1","external_id":"x1","created_at":1,"updated_at":2,"last_seen_at":3,"unsubscribed_from_emails":false}]}`,
+		"intercom_list_contacts":        `{"total_count":1,"pages":{"page":1,"per_page":20,"total_pages":1,"next":{"starting_after":"u1"}},"data":[{"id":"u1","role":"user","email":"a@b.com","name":"Ada","phone":"+1","external_id":"x1","created_at":1,"updated_at":2,"last_seen_at":3,"unsubscribed_from_emails":false}]}`,
+		"intercom_get_contact":          `{"id":"u1","role":"user","email":"a@b.com","name":"Ada","phone":"+1","external_id":"x1","created_at":1,"updated_at":2,"last_seen_at":3,"signed_up_at":1,"unsubscribed_from_emails":false,"custom_attributes":{"plan":"pro"},"companies":{"data":[{"id":"co1"}]}}`,
+		"intercom_list_companies":       `{"total_count":1,"pages":{"page":1,"per_page":20,"total_pages":1,"next":"n1"},"data":[{"id":"co1","name":"Acme","company_id":"acme","plan":"pro","size":10,"website":"https://acme.test","industry":"saas","monthly_spend":100,"created_at":1,"updated_at":2}]}`,
+		"intercom_get_company":          `{"id":"co1","name":"Acme","company_id":"acme","plan":"pro","size":10,"website":"https://acme.test","industry":"saas","monthly_spend":100,"created_at":1,"updated_at":2,"custom_attributes":{"tier":"a"},"user_count":3}`,
+		"intercom_search_tickets":       `{"total_count":1,"pages":{"page":1,"per_page":20,"total_pages":1,"next":{"starting_after":"t1"}},"tickets":[{"id":"t1","ticket_id":"12","ticket_state":"submitted","open":true,"created_at":1,"updated_at":2,"admin_assignee_id":"a1","team_assignee_id":"tm1","ticket_type":{"id":"tt1","name":"Bug"},"ticket_attributes":{"_default_title_":"Help"},"contacts":{"contacts":[{"id":"u1"}]}}]}`,
+		"intercom_get_ticket":           `{"id":"t1","ticket_id":"12","ticket_state":"submitted","open":true,"created_at":1,"updated_at":2,"admin_assignee_id":"a1","team_assignee_id":"tm1","ticket_type":{"id":"tt1","name":"Bug"},"ticket_attributes":{"_default_title_":"Help"},"contacts":{"contacts":[{"id":"u1"}]},"ticket_parts":{"ticket_parts":[{"id":"p1"}]}}`,
+		"intercom_search_articles":      `{"total_count":1,"pages":{"page":1,"per_page":20,"next":{"starting_after":"a1"}},"data":{"articles":[{"id":"a1","title":"Billing","description":"how to pay","state":"published","url":"https://help.test/a1","author_id":1,"created_at":1,"updated_at":2}]},"highlights":{"a1":["pay"]}}`,
+		"intercom_list_articles":        `{"total_count":1,"pages":{"page":1,"per_page":20,"total_pages":1,"next":{"starting_after":"a1"}},"data":[{"id":"a1","title":"Billing","description":"how to pay","state":"published","url":"https://help.test/a1","author_id":1,"created_at":1,"updated_at":2}]}`,
+		"intercom_get_article":          `{"id":"a1","title":"Billing","description":"how to pay","body":"<p>pay here</p>","state":"published","url":"https://help.test/a1","author_id":1,"created_at":1,"updated_at":2,"parent_id":"c1","parent_type":"collection"}`,
+		"intercom_list_admins":          `{"type":"admin.list","admins":[{"id":"a1","name":"Ada","email":"a@b.com","away_mode_enabled":false,"has_inbox_seat":true,"team_ids":["t1"]}]}`,
+		"intercom_get_me":               `{"id":"a1","name":"Ada","email":"a@b.com","type":"admin","away_mode_enabled":false,"has_inbox_seat":true,"team_ids":["t1"],"app":{"id_code":"abc","name":"Acme"}}`,
+		"intercom_list_teams":           `{"type":"team.list","teams":[{"id":"t1","name":"Support","admin_ids":["a1"]}]}`,
+		"intercom_get_team":             `{"id":"t1","name":"Support","admin_ids":["a1"]}`,
+		"intercom_list_tags":            `{"type":"list","data":[{"id":"tag1","name":"billing"}]}`,
+	}
+
+	for toolName, payload := range handlerOutputs {
+		t.Run(toolName, func(t *testing.T) {
+			fields, ok := fieldCompactionSpecs[mcp.ToolName(toolName)]
+			require.True(t, ok, "missing compaction spec for %s", toolName)
+			compacted, err := mcp.CompactJSON([]byte(payload), fields)
+			require.NoError(t, err)
+			assert.NotEqual(t, "{}", string(compacted), "compaction returned empty object for %s: %s", toolName, compacted)
+			assert.NotEqual(t, "[]", string(compacted), "compaction returned empty array for %s", toolName)
+			assert.NotEqual(t, "[{}]", string(compacted), "compaction returned array of empty objects for %s: %s", toolName, compacted)
+		})
+	}
+}

--- a/integrations/intercom/handlers.go
+++ b/integrations/intercom/handlers.go
@@ -437,7 +437,7 @@ func searchTickets(ctx context.Context, c *intercom, args map[string]any) (*mcp.
 		}
 		query = q
 	} else if state != "" {
-		query = equalityQuery("ticket_state", state)
+		query = equalityQuery("state", state)
 	} else {
 		query = equalityQuery("open", true)
 	}
@@ -669,17 +669,29 @@ func listTags(ctx context.Context, c *intercom, _ map[string]any) (*mcp.ToolResu
 	return mcp.RawResult(data)
 }
 
+func listTicketTypes(ctx context.Context, c *intercom, _ map[string]any) (*mcp.ToolResult, error) {
+	data, err := c.get(ctx, "/ticket_types")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
 func applyReplyActor(payload map[string]any, replyType, adminID, userID string) error {
-	if replyType == "admin" {
+	switch replyType {
+	case "admin":
 		if adminID == "" {
 			return fmt.Errorf("admin_id is required when type is admin")
 		}
 		payload["admin_id"] = adminID
 		return nil
+	case "user":
+		if userID == "" {
+			return fmt.Errorf("intercom_user_id is required when type is user")
+		}
+		payload["intercom_user_id"] = userID
+		return nil
+	default:
+		return fmt.Errorf("type must be admin or user, got %q", replyType)
 	}
-	if userID == "" {
-		return fmt.Errorf("intercom_user_id is required when type is user")
-	}
-	payload["intercom_user_id"] = userID
-	return nil
 }

--- a/integrations/intercom/handlers.go
+++ b/integrations/intercom/handlers.go
@@ -356,8 +356,8 @@ func createContact(ctx context.Context, c *intercom, args map[string]any) (*mcp.
 	if err := r.Err(); err != nil {
 		return mcp.ErrResult(err)
 	}
-	if len(payload) == 0 {
-		return mcp.ErrResult(fmt.Errorf("provide at least one of email, external_id, or name"))
+	if payload["email"] == nil && payload["external_id"] == nil {
+		return mcp.ErrResult(fmt.Errorf("provide email or external_id"))
 	}
 	data, err := c.post(ctx, "/contacts", payload)
 	if err != nil {

--- a/integrations/intercom/handlers.go
+++ b/integrations/intercom/handlers.go
@@ -152,13 +152,8 @@ func replyConversation(ctx context.Context, c *intercom, args map[string]any) (*
 		"type":         replyType,
 		"body":         body,
 	}
-	if replyType == "admin" {
-		if adminID == "" {
-			return mcp.ErrResult(fmt.Errorf("admin_id is required when type is admin"))
-		}
-		payload["admin_id"] = adminID
-	} else if userID != "" {
-		payload["intercom_user_id"] = userID
+	if err := applyReplyActor(payload, replyType, adminID, userID); err != nil {
+		return mcp.ErrResult(err)
 	}
 	if len(attachments) > 0 {
 		payload["attachment_urls"] = attachments
@@ -488,15 +483,23 @@ func createTicket(ctx context.Context, c *intercom, args map[string]any) (*mcp.T
 	} else if contactID != "" {
 		payload["contacts"] = []any{map[string]any{"id": contactID}}
 	}
+	if _, ok := payload["contacts"]; !ok {
+		return mcp.ErrResult(fmt.Errorf("provide contact_id or contacts"))
+	}
 	if title != "" {
 		payload["ticket_attributes"] = map[string]any{"_default_title_": title, "_default_description_": description}
 	} else if description != "" {
 		payload["ticket_attributes"] = map[string]any{"_default_description_": description}
 	}
+	assignment := map[string]any{}
 	if adminAssignee != "" {
-		payload["assignment"] = map[string]any{"admin_assignee_id": adminAssignee, "team_assignee_id": teamAssignee}
-	} else if teamAssignee != "" {
-		payload["assignment"] = map[string]any{"team_assignee_id": teamAssignee}
+		assignment["admin_assignee_id"] = adminAssignee
+	}
+	if teamAssignee != "" {
+		assignment["team_assignee_id"] = teamAssignee
+	}
+	if len(assignment) > 0 {
+		payload["assignment"] = assignment
 	}
 	data, err := c.post(ctx, "/tickets", payload)
 	if err != nil {
@@ -508,6 +511,7 @@ func createTicket(ctx context.Context, c *intercom, args map[string]any) (*mcp.T
 func updateTicket(ctx context.Context, c *intercom, args map[string]any) (*mcp.ToolResult, error) {
 	r := mcp.NewArgs(args)
 	id := r.Str("ticket_id")
+	assigneeID := r.Str("assignee_id")
 	adminAssignee := r.Str("admin_assignee_id")
 	teamAssignee := r.Str("team_assignee_id")
 	attrsRaw := r.Str("ticket_attributes")
@@ -522,10 +526,15 @@ func updateTicket(ctx context.Context, c *intercom, args map[string]any) (*mcp.T
 		}
 		payload["open"] = open
 	}
-	if adminAssignee != "" {
-		payload["assignment"] = map[string]any{"admin_assignee_id": adminAssignee, "team_assignee_id": teamAssignee}
-	} else if teamAssignee != "" {
-		payload["assignment"] = map[string]any{"team_assignee_id": teamAssignee}
+	if assigneeID == "" {
+		if adminAssignee != "" {
+			assigneeID = adminAssignee
+		} else {
+			assigneeID = teamAssignee
+		}
+	}
+	if assigneeID != "" {
+		payload["assignee_id"] = assigneeID
 	}
 	if attrsRaw != "" {
 		attrs, err := parseJSONObject(attrsRaw)
@@ -563,13 +572,8 @@ func replyTicket(ctx context.Context, c *intercom, args map[string]any) (*mcp.To
 		"type":         replyType,
 		"body":         body,
 	}
-	if replyType == "admin" {
-		if adminID == "" {
-			return mcp.ErrResult(fmt.Errorf("admin_id is required when type is admin"))
-		}
-		payload["admin_id"] = adminID
-	} else if userID != "" {
-		payload["intercom_user_id"] = userID
+	if err := applyReplyActor(payload, replyType, adminID, userID); err != nil {
+		return mcp.ErrResult(err)
 	}
 	data, err := c.post(ctx, "/tickets/"+url.PathEscape(id)+"/reply", payload)
 	if err != nil {
@@ -663,4 +667,19 @@ func listTags(ctx context.Context, c *intercom, _ map[string]any) (*mcp.ToolResu
 		return mcp.ErrResult(err)
 	}
 	return mcp.RawResult(data)
+}
+
+func applyReplyActor(payload map[string]any, replyType, adminID, userID string) error {
+	if replyType == "admin" {
+		if adminID == "" {
+			return fmt.Errorf("admin_id is required when type is admin")
+		}
+		payload["admin_id"] = adminID
+		return nil
+	}
+	if userID == "" {
+		return fmt.Errorf("intercom_user_id is required when type is user")
+	}
+	payload["intercom_user_id"] = userID
+	return nil
 }

--- a/integrations/intercom/handlers.go
+++ b/integrations/intercom/handlers.go
@@ -1,0 +1,666 @@
+package intercom
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+func parseJSONObject(raw string) (map[string]any, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	var out map[string]any
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		return nil, fmt.Errorf("invalid JSON object: %w", err)
+	}
+	return out, nil
+}
+
+func parseJSONArray(raw string) ([]any, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	var out []any
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		return nil, fmt.Errorf("invalid JSON array: %w", err)
+	}
+	return out, nil
+}
+
+func searchBody(query any, perPage int, startingAfter, sortField, sortOrder string) map[string]any {
+	body := map[string]any{"query": query}
+	pagination := map[string]any{"per_page": perPage}
+	if startingAfter != "" {
+		pagination["starting_after"] = startingAfter
+	}
+	body["pagination"] = pagination
+	if sortField != "" {
+		sort := map[string]any{"field": sortField}
+		if sortOrder != "" {
+			sort["order"] = sortOrder
+		}
+		body["sort"] = sort
+	}
+	return body
+}
+
+func equalityQuery(field string, value any) map[string]any {
+	return map[string]any{
+		"field":    field,
+		"operator": "=",
+		"value":    value,
+	}
+}
+
+func listQuery(args map[string]any, extra map[string]string) map[string]string {
+	r := mcp.NewArgs(args)
+	perPage := r.OptInt("per_page", 20)
+	startingAfter := r.Str("starting_after")
+	_ = r.Err()
+	params := map[string]string{
+		"per_page":       strconv.Itoa(perPage),
+		"starting_after": startingAfter,
+	}
+	for k, v := range extra {
+		params[k] = v
+	}
+	return params
+}
+
+func searchConversations(ctx context.Context, c *intercom, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	queryRaw := r.Str("query")
+	state := r.Str("state")
+	perPage := r.OptInt("per_page", 20)
+	startingAfter := r.Str("starting_after")
+	sortField := r.Str("sort_field")
+	sortOrder := r.Str("sort_order")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	var query any
+	if queryRaw != "" {
+		q, err := parseJSONObject(queryRaw)
+		if err != nil {
+			return mcp.ErrResult(err)
+		}
+		query = q
+	} else if state != "" {
+		query = equalityQuery("state", state)
+	} else {
+		query = equalityQuery("open", true)
+	}
+	data, err := c.post(ctx, "/conversations/search", searchBody(query, perPage, startingAfter, sortField, sortOrder))
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func listConversations(ctx context.Context, c *intercom, args map[string]any) (*mcp.ToolResult, error) {
+	params := listQuery(args, nil)
+	data, err := c.get(ctx, "/conversations%s", queryEncode(params))
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func getConversation(ctx context.Context, c *intercom, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("conversation_id")
+	displayAs := r.Str("display_as")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if displayAs == "" {
+		displayAs = "plaintext"
+	}
+	params := map[string]string{"display_as": displayAs}
+	data, err := c.get(ctx, "/conversations/%s%s", url.PathEscape(id), queryEncode(params))
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func replyConversation(ctx context.Context, c *intercom, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("conversation_id")
+	body := r.Str("body")
+	adminID := r.Str("admin_id")
+	messageType := r.Str("message_type")
+	replyType := r.Str("type")
+	userID := r.Str("intercom_user_id")
+	attachments := r.StrSlice("attachment_urls")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if messageType == "" {
+		messageType = "comment"
+	}
+	if replyType == "" {
+		replyType = "admin"
+	}
+	payload := map[string]any{
+		"message_type": messageType,
+		"type":         replyType,
+		"body":         body,
+	}
+	if replyType == "admin" {
+		if adminID == "" {
+			return mcp.ErrResult(fmt.Errorf("admin_id is required when type is admin"))
+		}
+		payload["admin_id"] = adminID
+	} else if userID != "" {
+		payload["intercom_user_id"] = userID
+	}
+	if len(attachments) > 0 {
+		payload["attachment_urls"] = attachments
+	}
+	data, err := c.post(ctx, "/conversations/"+url.PathEscape(id)+"/reply", payload)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func closeConversation(ctx context.Context, c *intercom, args map[string]any) (*mcp.ToolResult, error) {
+	return manageConversation(ctx, c, args, "close")
+}
+
+func reopenConversation(ctx context.Context, c *intercom, args map[string]any) (*mcp.ToolResult, error) {
+	return manageConversation(ctx, c, args, "open")
+}
+
+func manageConversation(ctx context.Context, c *intercom, args map[string]any, messageType string) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("conversation_id")
+	adminID := r.Str("admin_id")
+	body := r.Str("body")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	payload := map[string]any{
+		"message_type": messageType,
+		"type":         "admin",
+		"admin_id":     adminID,
+	}
+	if body != "" {
+		payload["body"] = body
+	}
+	data, err := c.post(ctx, "/conversations/"+url.PathEscape(id)+"/parts", payload)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func snoozeConversation(ctx context.Context, c *intercom, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("conversation_id")
+	adminID := r.Str("admin_id")
+	until := r.Int64("snoozed_until")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	payload := map[string]any{
+		"message_type":  "snoozed",
+		"type":          "admin",
+		"admin_id":      adminID,
+		"snoozed_until": until,
+	}
+	data, err := c.post(ctx, "/conversations/"+url.PathEscape(id)+"/parts", payload)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func assignConversation(ctx context.Context, c *intercom, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("conversation_id")
+	adminID := r.Str("admin_id")
+	assigneeID := r.Str("assignee_id")
+	body := r.Str("body")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	payload := map[string]any{
+		"message_type": "assignment",
+		"type":         "admin",
+		"admin_id":     adminID,
+		"assignee_id":  assigneeID,
+	}
+	if body != "" {
+		payload["body"] = body
+	}
+	data, err := c.post(ctx, "/conversations/"+url.PathEscape(id)+"/parts", payload)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func tagConversation(ctx context.Context, c *intercom, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("conversation_id")
+	tagID := r.Str("tag_id")
+	adminID := r.Str("admin_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	payload := map[string]any{
+		"id":       tagID,
+		"admin_id": adminID,
+	}
+	data, err := c.post(ctx, "/conversations/"+url.PathEscape(id)+"/tags", payload)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func searchContacts(ctx context.Context, c *intercom, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	queryRaw := r.Str("query")
+	email := r.Str("email")
+	perPage := r.OptInt("per_page", 20)
+	startingAfter := r.Str("starting_after")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	var query any
+	if queryRaw != "" {
+		q, err := parseJSONObject(queryRaw)
+		if err != nil {
+			return mcp.ErrResult(err)
+		}
+		query = q
+	} else if email != "" {
+		query = equalityQuery("email", email)
+	} else {
+		return mcp.ErrResult(fmt.Errorf("provide email or query"))
+	}
+	data, err := c.post(ctx, "/contacts/search", searchBody(query, perPage, startingAfter, "", ""))
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func listContacts(ctx context.Context, c *intercom, args map[string]any) (*mcp.ToolResult, error) {
+	params := listQuery(args, nil)
+	data, err := c.get(ctx, "/contacts%s", queryEncode(params))
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func getContact(ctx context.Context, c *intercom, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("contact_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := c.get(ctx, "/contacts/%s", url.PathEscape(id))
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func contactPayload(r *mcp.Args) (map[string]any, error) {
+	email := r.Str("email")
+	externalID := r.Str("external_id")
+	name := r.Str("name")
+	phone := r.Str("phone")
+	role := r.Str("role")
+	customRaw := r.Str("custom_attributes")
+	if err := r.Err(); err != nil {
+		return nil, err
+	}
+	payload := map[string]any{}
+	if email != "" {
+		payload["email"] = email
+	}
+	if externalID != "" {
+		payload["external_id"] = externalID
+	}
+	if name != "" {
+		payload["name"] = name
+	}
+	if phone != "" {
+		payload["phone"] = phone
+	}
+	if role != "" {
+		payload["role"] = role
+	}
+	if customRaw != "" {
+		attrs, err := parseJSONObject(customRaw)
+		if err != nil {
+			return nil, err
+		}
+		payload["custom_attributes"] = attrs
+	}
+	return payload, nil
+}
+
+func createContact(ctx context.Context, c *intercom, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	payload, err := contactPayload(r)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if len(payload) == 0 {
+		return mcp.ErrResult(fmt.Errorf("provide at least one of email, external_id, or name"))
+	}
+	data, err := c.post(ctx, "/contacts", payload)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func updateContact(ctx context.Context, c *intercom, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("contact_id")
+	payload, err := contactPayload(r)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := c.put(ctx, "/contacts/"+url.PathEscape(id), payload)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func listCompanies(ctx context.Context, c *intercom, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	name := r.Str("name")
+	companyID := r.Str("company_id")
+	page := r.OptInt("page", 1)
+	perPage := r.OptInt("per_page", 20)
+	startingAfter := r.Str("starting_after")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	params := map[string]string{
+		"name":           name,
+		"company_id":     companyID,
+		"page":           strconv.Itoa(page),
+		"per_page":       strconv.Itoa(perPage),
+		"starting_after": startingAfter,
+	}
+	data, err := c.get(ctx, "/companies%s", queryEncode(params))
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func getCompany(ctx context.Context, c *intercom, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := c.get(ctx, "/companies/%s", url.PathEscape(id))
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func searchTickets(ctx context.Context, c *intercom, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	queryRaw := r.Str("query")
+	state := r.Str("state")
+	perPage := r.OptInt("per_page", 20)
+	startingAfter := r.Str("starting_after")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	var query any
+	if queryRaw != "" {
+		q, err := parseJSONObject(queryRaw)
+		if err != nil {
+			return mcp.ErrResult(err)
+		}
+		query = q
+	} else if state != "" {
+		query = equalityQuery("ticket_state", state)
+	} else {
+		query = equalityQuery("open", true)
+	}
+	data, err := c.post(ctx, "/tickets/search", searchBody(query, perPage, startingAfter, "", ""))
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func getTicket(ctx context.Context, c *intercom, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("ticket_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := c.get(ctx, "/tickets/%s", url.PathEscape(id))
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func createTicket(ctx context.Context, c *intercom, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	ticketTypeID := r.Str("ticket_type_id")
+	contactID := r.Str("contact_id")
+	contactsRaw := r.Str("contacts")
+	title := r.Str("title")
+	description := r.Str("description")
+	adminAssignee := r.Str("admin_assignee_id")
+	teamAssignee := r.Str("team_assignee_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	payload := map[string]any{"ticket_type_id": ticketTypeID}
+	if contactsRaw != "" {
+		contacts, err := parseJSONArray(contactsRaw)
+		if err != nil {
+			return mcp.ErrResult(err)
+		}
+		payload["contacts"] = contacts
+	} else if contactID != "" {
+		payload["contacts"] = []any{map[string]any{"id": contactID}}
+	}
+	if title != "" {
+		payload["ticket_attributes"] = map[string]any{"_default_title_": title, "_default_description_": description}
+	} else if description != "" {
+		payload["ticket_attributes"] = map[string]any{"_default_description_": description}
+	}
+	if adminAssignee != "" {
+		payload["assignment"] = map[string]any{"admin_assignee_id": adminAssignee, "team_assignee_id": teamAssignee}
+	} else if teamAssignee != "" {
+		payload["assignment"] = map[string]any{"team_assignee_id": teamAssignee}
+	}
+	data, err := c.post(ctx, "/tickets", payload)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func updateTicket(ctx context.Context, c *intercom, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("ticket_id")
+	adminAssignee := r.Str("admin_assignee_id")
+	teamAssignee := r.Str("team_assignee_id")
+	attrsRaw := r.Str("ticket_attributes")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	payload := map[string]any{}
+	if _, ok := args["open"]; ok {
+		open, err := mcp.ArgBool(args, "open")
+		if err != nil {
+			return mcp.ErrResult(err)
+		}
+		payload["open"] = open
+	}
+	if adminAssignee != "" {
+		payload["assignment"] = map[string]any{"admin_assignee_id": adminAssignee, "team_assignee_id": teamAssignee}
+	} else if teamAssignee != "" {
+		payload["assignment"] = map[string]any{"team_assignee_id": teamAssignee}
+	}
+	if attrsRaw != "" {
+		attrs, err := parseJSONObject(attrsRaw)
+		if err != nil {
+			return mcp.ErrResult(err)
+		}
+		payload["ticket_attributes"] = attrs
+	}
+	data, err := c.put(ctx, "/tickets/"+url.PathEscape(id), payload)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func replyTicket(ctx context.Context, c *intercom, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("ticket_id")
+	body := r.Str("body")
+	adminID := r.Str("admin_id")
+	messageType := r.Str("message_type")
+	replyType := r.Str("type")
+	userID := r.Str("intercom_user_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	if messageType == "" {
+		messageType = "comment"
+	}
+	if replyType == "" {
+		replyType = "admin"
+	}
+	payload := map[string]any{
+		"message_type": messageType,
+		"type":         replyType,
+		"body":         body,
+	}
+	if replyType == "admin" {
+		if adminID == "" {
+			return mcp.ErrResult(fmt.Errorf("admin_id is required when type is admin"))
+		}
+		payload["admin_id"] = adminID
+	} else if userID != "" {
+		payload["intercom_user_id"] = userID
+	}
+	data, err := c.post(ctx, "/tickets/"+url.PathEscape(id)+"/reply", payload)
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func searchArticles(ctx context.Context, c *intercom, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	phrase := r.Str("phrase")
+	perPage := r.OptInt("per_page", 20)
+	startingAfter := r.Str("starting_after")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	params := map[string]string{
+		"phrase":         phrase,
+		"per_page":       strconv.Itoa(perPage),
+		"starting_after": startingAfter,
+	}
+	data, err := c.get(ctx, "/articles/search%s", queryEncode(params))
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func listArticles(ctx context.Context, c *intercom, args map[string]any) (*mcp.ToolResult, error) {
+	params := listQuery(args, nil)
+	data, err := c.get(ctx, "/articles%s", queryEncode(params))
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func getArticle(ctx context.Context, c *intercom, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("article_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := c.get(ctx, "/articles/%s", url.PathEscape(id))
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func listAdmins(ctx context.Context, c *intercom, _ map[string]any) (*mcp.ToolResult, error) {
+	data, err := c.get(ctx, "/admins")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func getMe(ctx context.Context, c *intercom, _ map[string]any) (*mcp.ToolResult, error) {
+	data, err := c.get(ctx, "/me")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func listTeams(ctx context.Context, c *intercom, _ map[string]any) (*mcp.ToolResult, error) {
+	data, err := c.get(ctx, "/teams")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func getTeam(ctx context.Context, c *intercom, args map[string]any) (*mcp.ToolResult, error) {
+	r := mcp.NewArgs(args)
+	id := r.Str("team_id")
+	if err := r.Err(); err != nil {
+		return mcp.ErrResult(err)
+	}
+	data, err := c.get(ctx, "/teams/%s", url.PathEscape(id))
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}
+
+func listTags(ctx context.Context, c *intercom, _ map[string]any) (*mcp.ToolResult, error) {
+	data, err := c.get(ctx, "/tags")
+	if err != nil {
+		return mcp.ErrResult(err)
+	}
+	return mcp.RawResult(data)
+}

--- a/integrations/intercom/intercom.go
+++ b/integrations/intercom/intercom.go
@@ -205,4 +205,5 @@ var dispatch = map[mcp.ToolName]handlerFunc{
 	mcp.ToolName("intercom_list_teams"):           listTeams,
 	mcp.ToolName("intercom_get_team"):             getTeam,
 	mcp.ToolName("intercom_list_tags"):            listTags,
+	mcp.ToolName("intercom_list_ticket_types"):    listTicketTypes,
 }

--- a/integrations/intercom/intercom.go
+++ b/integrations/intercom/intercom.go
@@ -1,0 +1,208 @@
+package intercom
+
+import (
+	"bytes"
+	"context"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/daltoniam/switchboard/compact"
+)
+
+//go:embed compact.yaml
+var compactYAML []byte
+
+var compactResult = compact.MustLoadWithOverlay("intercom", compactYAML, compact.Options{Strict: false})
+var fieldCompactionSpecs = compactResult.Specs
+var maxBytesByTool = compactResult.MaxBytes
+
+type intercom struct {
+	accessToken string
+	client      *http.Client
+	baseURL     string
+}
+
+const (
+	maxResponseSize = 10 * 1024 * 1024 // 10 MB
+	apiVersion      = "2.16"
+	defaultBaseURL  = "https://api.intercom.io"
+)
+
+var (
+	_ mcp.Integration                = (*intercom)(nil)
+	_ mcp.FieldCompactionIntegration = (*intercom)(nil)
+	_ mcp.ToolMaxBytesIntegration    = (*intercom)(nil)
+	_ mcp.MarkdownIntegration        = (*intercom)(nil)
+	_ mcp.PlainTextCredentials       = (*intercom)(nil)
+	_ mcp.PlaceholderHints           = (*intercom)(nil)
+	_ mcp.OptionalCredentials        = (*intercom)(nil)
+)
+
+func (c *intercom) PlainTextKeys() []string { return []string{"base_url"} }
+
+func (c *intercom) Placeholders() map[string]string {
+	return map[string]string{
+		"access_token": "Intercom access token from Developer Hub",
+		"base_url":     "https://api.intercom.io (default), https://api.eu.intercom.io, or https://api.au.intercom.io",
+	}
+}
+
+func (c *intercom) OptionalKeys() []string { return []string{"base_url"} }
+
+func New() mcp.Integration {
+	return &intercom{
+		client:  &http.Client{Timeout: 30 * time.Second},
+		baseURL: defaultBaseURL,
+	}
+}
+
+func (c *intercom) Name() string { return "intercom" }
+
+func (c *intercom) Configure(_ context.Context, creds mcp.Credentials) error {
+	c.accessToken = creds["access_token"]
+	if c.accessToken == "" {
+		return fmt.Errorf("intercom: access_token is required")
+	}
+	if v := creds["base_url"]; v != "" {
+		c.baseURL = strings.TrimRight(v, "/")
+	}
+	return nil
+}
+
+func (c *intercom) Healthy(ctx context.Context) bool {
+	_, err := c.get(ctx, "/me")
+	return err == nil
+}
+
+func (c *intercom) Tools() []mcp.ToolDefinition {
+	return tools
+}
+
+func (c *intercom) CompactSpec(toolName mcp.ToolName) ([]mcp.CompactField, bool) {
+	fields, ok := fieldCompactionSpecs[toolName]
+	return fields, ok
+}
+
+func (c *intercom) MaxBytes(toolName mcp.ToolName) (int, bool) {
+	n, ok := maxBytesByTool[toolName]
+	return n, ok
+}
+
+func (c *intercom) Execute(ctx context.Context, toolName mcp.ToolName, args map[string]any) (*mcp.ToolResult, error) {
+	fn, ok := dispatch[toolName]
+	if !ok {
+		return &mcp.ToolResult{Data: fmt.Sprintf("unknown tool: %s", toolName), IsError: true}, nil
+	}
+	return fn(ctx, c, args)
+}
+
+func (c *intercom) doRequest(ctx context.Context, method, path string, body any) (json.RawMessage, error) {
+	var bodyReader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return nil, err
+		}
+		bodyReader = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bodyReader)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.accessToken)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Intercom-Version", apiVersion)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == 429 || resp.StatusCode >= 500 {
+		re := &mcp.RetryableError{StatusCode: resp.StatusCode, Err: fmt.Errorf("intercom API error (%d): %s", resp.StatusCode, string(data))}
+		re.RetryAfter = mcp.ParseRetryAfter(resp.Header.Get("Retry-After"))
+		return nil, re
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("intercom API error (%d): %s", resp.StatusCode, string(data))
+	}
+	if resp.StatusCode == 204 || len(data) == 0 {
+		return json.RawMessage(`{"status":"success"}`), nil
+	}
+	return json.RawMessage(data), nil
+}
+
+func (c *intercom) get(ctx context.Context, pathFmt string, args ...any) (json.RawMessage, error) {
+	return c.doRequest(ctx, http.MethodGet, fmt.Sprintf(pathFmt, args...), nil)
+}
+
+func (c *intercom) post(ctx context.Context, path string, body any) (json.RawMessage, error) {
+	return c.doRequest(ctx, http.MethodPost, path, body)
+}
+
+func (c *intercom) put(ctx context.Context, path string, body any) (json.RawMessage, error) {
+	return c.doRequest(ctx, http.MethodPut, path, body)
+}
+
+type handlerFunc func(ctx context.Context, c *intercom, args map[string]any) (*mcp.ToolResult, error)
+
+func queryEncode(params map[string]string) string {
+	vals := url.Values{}
+	for k, v := range params {
+		if v != "" {
+			vals.Set(k, v)
+		}
+	}
+	if len(vals) == 0 {
+		return ""
+	}
+	return "?" + vals.Encode()
+}
+
+var dispatch = map[mcp.ToolName]handlerFunc{
+	mcp.ToolName("intercom_search_conversations"): searchConversations,
+	mcp.ToolName("intercom_list_conversations"):   listConversations,
+	mcp.ToolName("intercom_get_conversation"):     getConversation,
+	mcp.ToolName("intercom_reply_conversation"):   replyConversation,
+	mcp.ToolName("intercom_close_conversation"):   closeConversation,
+	mcp.ToolName("intercom_reopen_conversation"):  reopenConversation,
+	mcp.ToolName("intercom_snooze_conversation"):  snoozeConversation,
+	mcp.ToolName("intercom_assign_conversation"):  assignConversation,
+	mcp.ToolName("intercom_tag_conversation"):     tagConversation,
+	mcp.ToolName("intercom_search_contacts"):      searchContacts,
+	mcp.ToolName("intercom_list_contacts"):        listContacts,
+	mcp.ToolName("intercom_get_contact"):          getContact,
+	mcp.ToolName("intercom_create_contact"):       createContact,
+	mcp.ToolName("intercom_update_contact"):       updateContact,
+	mcp.ToolName("intercom_list_companies"):       listCompanies,
+	mcp.ToolName("intercom_get_company"):          getCompany,
+	mcp.ToolName("intercom_search_tickets"):       searchTickets,
+	mcp.ToolName("intercom_get_ticket"):           getTicket,
+	mcp.ToolName("intercom_create_ticket"):        createTicket,
+	mcp.ToolName("intercom_update_ticket"):        updateTicket,
+	mcp.ToolName("intercom_reply_ticket"):         replyTicket,
+	mcp.ToolName("intercom_search_articles"):      searchArticles,
+	mcp.ToolName("intercom_list_articles"):        listArticles,
+	mcp.ToolName("intercom_get_article"):          getArticle,
+	mcp.ToolName("intercom_list_admins"):          listAdmins,
+	mcp.ToolName("intercom_get_me"):               getMe,
+	mcp.ToolName("intercom_list_teams"):           listTeams,
+	mcp.ToolName("intercom_get_team"):             getTeam,
+	mcp.ToolName("intercom_list_tags"):            listTags,
+}

--- a/integrations/intercom/intercom_test.go
+++ b/integrations/intercom/intercom_test.go
@@ -232,6 +232,18 @@ func TestReplyConversation_MissingAdminID(t *testing.T) {
 	assert.Contains(t, result.Data, "admin_id is required")
 }
 
+func TestReplyConversation_MissingUserID(t *testing.T) {
+	c := &intercom{accessToken: "tok", client: &http.Client{}, baseURL: "http://localhost"}
+	result, err := c.Execute(context.Background(), "intercom_reply_conversation", map[string]any{
+		"conversation_id": "c1",
+		"body":            "hello",
+		"type":            "user",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "intercom_user_id is required")
+}
+
 func TestCloseConversation(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/conversations/c1/parts", r.URL.Path)
@@ -358,6 +370,26 @@ func TestUpdateTicket_OpenFalse(t *testing.T) {
 	require.False(t, result.IsError)
 }
 
+func TestUpdateTicket_AssigneeID(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		assert.Equal(t, "991", body["assignee_id"])
+		_, hasAssignment := body["assignment"]
+		assert.False(t, hasAssignment)
+		_, _ = w.Write([]byte(`{"id":"t1"}`))
+	}))
+	defer ts.Close()
+
+	c := &intercom{accessToken: "tok", client: ts.Client(), baseURL: ts.URL}
+	result, err := c.Execute(context.Background(), "intercom_update_ticket", map[string]any{
+		"ticket_id":         "t1",
+		"admin_assignee_id": "991",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
 func TestHealthy(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/me", r.URL.Path)
@@ -423,18 +455,33 @@ func TestCreateTicket(t *testing.T) {
 		assert.Equal(t, "tt1", body["ticket_type_id"])
 		contacts := body["contacts"].([]any)
 		assert.Equal(t, "u1", contacts[0].(map[string]any)["id"])
+		assignment := body["assignment"].(map[string]any)
+		assert.Equal(t, "991", assignment["admin_assignee_id"])
+		_, hasTeam := assignment["team_assignee_id"]
+		assert.False(t, hasTeam)
 		_, _ = w.Write([]byte(`{"id":"t1"}`))
 	}))
 	defer ts.Close()
 
 	c := &intercom{accessToken: "tok", client: ts.Client(), baseURL: ts.URL}
 	result, err := c.Execute(context.Background(), "intercom_create_ticket", map[string]any{
-		"ticket_type_id": "tt1",
-		"contact_id":     "u1",
-		"title":          "Help",
+		"ticket_type_id":    "tt1",
+		"contact_id":        "u1",
+		"title":             "Help",
+		"admin_assignee_id": "991",
 	})
 	require.NoError(t, err)
 	require.False(t, result.IsError)
+}
+
+func TestCreateTicket_MissingContact(t *testing.T) {
+	c := &intercom{accessToken: "tok", client: &http.Client{}, baseURL: "http://localhost"}
+	result, err := c.Execute(context.Background(), "intercom_create_ticket", map[string]any{
+		"ticket_type_id": "tt1",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "provide contact_id or contacts")
 }
 
 func TestListConversations(t *testing.T) {

--- a/integrations/intercom/intercom_test.go
+++ b/integrations/intercom/intercom_test.go
@@ -1,0 +1,453 @@
+package intercom
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	i := New()
+	require.NotNil(t, i)
+	assert.Equal(t, "intercom", i.Name())
+}
+
+func TestConfigure_Success(t *testing.T) {
+	i := New()
+	err := i.Configure(context.Background(), mcp.Credentials{"access_token": "tok"})
+	assert.NoError(t, err)
+}
+
+func TestConfigure_MissingAccessToken(t *testing.T) {
+	i := New()
+	err := i.Configure(context.Background(), mcp.Credentials{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "access_token is required")
+}
+
+func TestConfigure_CustomBaseURL(t *testing.T) {
+	c := &intercom{client: &http.Client{}, baseURL: defaultBaseURL}
+	err := c.Configure(context.Background(), mcp.Credentials{
+		"access_token": "tok",
+		"base_url":     "https://api.eu.intercom.io/",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.eu.intercom.io", c.baseURL)
+}
+
+func TestTools(t *testing.T) {
+	i := New()
+	tls := i.Tools()
+	assert.NotEmpty(t, tls)
+	for _, tool := range tls {
+		assert.NotEmpty(t, tool.Name)
+		assert.NotEmpty(t, tool.Description)
+	}
+}
+
+func TestTools_AllHaveIntercomPrefix(t *testing.T) {
+	i := New()
+	for _, tool := range i.Tools() {
+		assert.Contains(t, string(tool.Name), "intercom_")
+	}
+}
+
+func TestTools_NoDuplicateNames(t *testing.T) {
+	i := New()
+	seen := make(map[mcp.ToolName]bool)
+	for _, tool := range i.Tools() {
+		assert.False(t, seen[tool.Name], "duplicate tool name: %s", tool.Name)
+		seen[tool.Name] = true
+	}
+}
+
+func TestTools_EntryPointHasStartHere(t *testing.T) {
+	i := New()
+	found := false
+	for _, tool := range i.Tools() {
+		if tool.Name == "intercom_search_conversations" {
+			assert.Contains(t, tool.Description, "Start here")
+			found = true
+		}
+	}
+	assert.True(t, found)
+}
+
+func TestExecute_UnknownTool(t *testing.T) {
+	c := &intercom{accessToken: "tok", client: &http.Client{}, baseURL: "http://localhost"}
+	result, err := c.Execute(context.Background(), "intercom_nonexistent", nil)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "unknown tool")
+}
+
+func TestDispatchMap_AllToolsCovered(t *testing.T) {
+	i := New()
+	for _, tool := range i.Tools() {
+		_, ok := dispatch[tool.Name]
+		assert.True(t, ok, "tool %s has no dispatch handler", tool.Name)
+	}
+}
+
+func TestDispatchMap_NoOrphanHandlers(t *testing.T) {
+	i := New()
+	toolNames := make(map[mcp.ToolName]bool)
+	for _, tool := range i.Tools() {
+		toolNames[tool.Name] = true
+	}
+	for name := range dispatch {
+		assert.True(t, toolNames[name], "dispatch handler %s has no tool definition", name)
+	}
+}
+
+func TestDoRequest_BearerAndVersion(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer tok", r.Header.Get("Authorization"))
+		assert.Equal(t, apiVersion, r.Header.Get("Intercom-Version"))
+		assert.Equal(t, "/me", r.URL.Path)
+		_, _ = w.Write([]byte(`{"id":"1","type":"admin"}`))
+	}))
+	defer ts.Close()
+
+	c := &intercom{accessToken: "tok", client: ts.Client(), baseURL: ts.URL}
+	data, err := c.get(context.Background(), "/me")
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"id":"1"`)
+}
+
+func TestDoRequest_APIError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(401)
+		_, _ = w.Write([]byte(`{"type":"error.list","errors":[{"code":"unauthorized"}]}`))
+	}))
+	defer ts.Close()
+
+	c := &intercom{accessToken: "tok", client: ts.Client(), baseURL: ts.URL}
+	_, err := c.get(context.Background(), "/me")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "intercom API error (401)")
+}
+
+func TestDoRequest_Retryable(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "2")
+		w.WriteHeader(429)
+		_, _ = w.Write([]byte(`rate limited`))
+	}))
+	defer ts.Close()
+
+	c := &intercom{accessToken: "tok", client: ts.Client(), baseURL: ts.URL}
+	_, err := c.get(context.Background(), "/me")
+	require.Error(t, err)
+	var re *mcp.RetryableError
+	require.ErrorAs(t, err, &re)
+	assert.Equal(t, 429, re.StatusCode)
+}
+
+func TestDoRequest_204NoContent(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(204)
+	}))
+	defer ts.Close()
+
+	c := &intercom{accessToken: "tok", client: ts.Client(), baseURL: ts.URL}
+	data, err := c.doRequest(context.Background(), "DELETE", "/x", nil)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "success")
+}
+
+func TestSearchConversations_StateFilter(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/conversations/search", r.URL.Path)
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		query := body["query"].(map[string]any)
+		assert.Equal(t, "state", query["field"])
+		assert.Equal(t, "open", query["value"])
+		_, _ = w.Write([]byte(`{"conversations":[{"id":"c1","state":"open"}]}`))
+	}))
+	defer ts.Close()
+
+	c := &intercom{accessToken: "tok", client: ts.Client(), baseURL: ts.URL}
+	result, err := c.Execute(context.Background(), "intercom_search_conversations", map[string]any{"state": "open"})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	assert.Contains(t, result.Data, "c1")
+}
+
+func TestGetConversation(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/conversations/c1", r.URL.Path)
+		assert.Equal(t, "plaintext", r.URL.Query().Get("display_as"))
+		_, _ = w.Write([]byte(`{"id":"c1","state":"open"}`))
+	}))
+	defer ts.Close()
+
+	c := &intercom{accessToken: "tok", client: ts.Client(), baseURL: ts.URL}
+	result, err := c.Execute(context.Background(), "intercom_get_conversation", map[string]any{"conversation_id": "c1"})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	assert.Contains(t, result.Data, "c1")
+}
+
+func TestReplyConversation_AdminComment(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/conversations/c1/reply", r.URL.Path)
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		assert.Equal(t, "comment", body["message_type"])
+		assert.Equal(t, "admin", body["type"])
+		assert.Equal(t, "991", body["admin_id"])
+		assert.Equal(t, "hello", body["body"])
+		_, _ = w.Write([]byte(`{"id":"c1"}`))
+	}))
+	defer ts.Close()
+
+	c := &intercom{accessToken: "tok", client: ts.Client(), baseURL: ts.URL}
+	result, err := c.Execute(context.Background(), "intercom_reply_conversation", map[string]any{
+		"conversation_id": "c1",
+		"admin_id":        "991",
+		"body":            "hello",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestReplyConversation_MissingAdminID(t *testing.T) {
+	c := &intercom{accessToken: "tok", client: &http.Client{}, baseURL: "http://localhost"}
+	result, err := c.Execute(context.Background(), "intercom_reply_conversation", map[string]any{
+		"conversation_id": "c1",
+		"body":            "hello",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "admin_id is required")
+}
+
+func TestCloseConversation(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/conversations/c1/parts", r.URL.Path)
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		assert.Equal(t, "close", body["message_type"])
+		assert.Equal(t, "991", body["admin_id"])
+		_, _ = w.Write([]byte(`{"id":"c1","state":"closed"}`))
+	}))
+	defer ts.Close()
+
+	c := &intercom{accessToken: "tok", client: ts.Client(), baseURL: ts.URL}
+	result, err := c.Execute(context.Background(), "intercom_close_conversation", map[string]any{
+		"conversation_id": "c1",
+		"admin_id":        "991",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	assert.Contains(t, result.Data, "closed")
+}
+
+func TestAssignConversation(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		assert.Equal(t, "assignment", body["message_type"])
+		assert.Equal(t, "992", body["assignee_id"])
+		_, _ = w.Write([]byte(`{"id":"c1"}`))
+	}))
+	defer ts.Close()
+
+	c := &intercom{accessToken: "tok", client: ts.Client(), baseURL: ts.URL}
+	result, err := c.Execute(context.Background(), "intercom_assign_conversation", map[string]any{
+		"conversation_id": "c1",
+		"admin_id":        "991",
+		"assignee_id":     "992",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestSearchContacts_Email(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/contacts/search", r.URL.Path)
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		query := body["query"].(map[string]any)
+		assert.Equal(t, "email", query["field"])
+		assert.Equal(t, "a@b.com", query["value"])
+		_, _ = w.Write([]byte(`{"data":[{"id":"u1","email":"a@b.com"}]}`))
+	}))
+	defer ts.Close()
+
+	c := &intercom{accessToken: "tok", client: ts.Client(), baseURL: ts.URL}
+	result, err := c.Execute(context.Background(), "intercom_search_contacts", map[string]any{"email": "a@b.com"})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	assert.Contains(t, result.Data, "u1")
+}
+
+func TestSearchContacts_MissingFilter(t *testing.T) {
+	c := &intercom{accessToken: "tok", client: &http.Client{}, baseURL: "http://localhost"}
+	result, err := c.Execute(context.Background(), "intercom_search_contacts", map[string]any{})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "provide email or query")
+}
+
+func TestCreateContact(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/contacts", r.URL.Path)
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		assert.Equal(t, "a@b.com", body["email"])
+		assert.Equal(t, "Ada", body["name"])
+		_, _ = w.Write([]byte(`{"id":"u1","email":"a@b.com"}`))
+	}))
+	defer ts.Close()
+
+	c := &intercom{accessToken: "tok", client: ts.Client(), baseURL: ts.URL}
+	result, err := c.Execute(context.Background(), "intercom_create_contact", map[string]any{
+		"email": "a@b.com",
+		"name":  "Ada",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	assert.Contains(t, result.Data, "u1")
+}
+
+func TestSearchArticles(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/articles/search", r.URL.Path)
+		assert.Equal(t, "billing", r.URL.Query().Get("phrase"))
+		_, _ = w.Write([]byte(`{"data":{"articles":[{"id":"a1","title":"Billing"}]}}`))
+	}))
+	defer ts.Close()
+
+	c := &intercom{accessToken: "tok", client: ts.Client(), baseURL: ts.URL}
+	result, err := c.Execute(context.Background(), "intercom_search_articles", map[string]any{"phrase": "billing"})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	assert.Contains(t, result.Data, "Billing")
+}
+
+func TestUpdateTicket_OpenFalse(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/tickets/t1", r.URL.Path)
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		assert.Equal(t, false, body["open"])
+		_, _ = w.Write([]byte(`{"id":"t1","open":false}`))
+	}))
+	defer ts.Close()
+
+	c := &intercom{accessToken: "tok", client: ts.Client(), baseURL: ts.URL}
+	result, err := c.Execute(context.Background(), "intercom_update_ticket", map[string]any{
+		"ticket_id": "t1",
+		"open":      false,
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestHealthy(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/me", r.URL.Path)
+		_, _ = w.Write([]byte(`{"id":"1"}`))
+	}))
+	defer ts.Close()
+
+	c := &intercom{accessToken: "tok", client: ts.Client(), baseURL: ts.URL}
+	assert.True(t, c.Healthy(context.Background()))
+}
+
+func TestHealthy_Unreachable(t *testing.T) {
+	c := &intercom{client: &http.Client{}, baseURL: "http://127.0.0.1:1"}
+	assert.False(t, c.Healthy(context.Background()))
+}
+
+func TestTagConversation(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/conversations/c1/tags", r.URL.Path)
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		assert.Equal(t, "tag1", body["id"])
+		assert.Equal(t, "991", body["admin_id"])
+		_, _ = w.Write([]byte(`{"type":"tag","id":"tag1"}`))
+	}))
+	defer ts.Close()
+
+	c := &intercom{accessToken: "tok", client: ts.Client(), baseURL: ts.URL}
+	result, err := c.Execute(context.Background(), "intercom_tag_conversation", map[string]any{
+		"conversation_id": "c1",
+		"tag_id":          "tag1",
+		"admin_id":        "991",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestSnoozeConversation(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		assert.Equal(t, "snoozed", body["message_type"])
+		assert.Equal(t, float64(1735641600), body["snoozed_until"])
+		_, _ = w.Write([]byte(`{"id":"c1","state":"snoozed"}`))
+	}))
+	defer ts.Close()
+
+	c := &intercom{accessToken: "tok", client: ts.Client(), baseURL: ts.URL}
+	result, err := c.Execute(context.Background(), "intercom_snooze_conversation", map[string]any{
+		"conversation_id": "c1",
+		"admin_id":        "991",
+		"snoozed_until":   1735641600,
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestCreateTicket(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/tickets", r.URL.Path)
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		assert.Equal(t, "tt1", body["ticket_type_id"])
+		contacts := body["contacts"].([]any)
+		assert.Equal(t, "u1", contacts[0].(map[string]any)["id"])
+		_, _ = w.Write([]byte(`{"id":"t1"}`))
+	}))
+	defer ts.Close()
+
+	c := &intercom{accessToken: "tok", client: ts.Client(), baseURL: ts.URL}
+	result, err := c.Execute(context.Background(), "intercom_create_ticket", map[string]any{
+		"ticket_type_id": "tt1",
+		"contact_id":     "u1",
+		"title":          "Help",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestListConversations(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/conversations", r.URL.Path)
+		assert.Equal(t, "20", r.URL.Query().Get("per_page"))
+		_, _ = w.Write([]byte(`{"conversations":[{"id":"c1"}]}`))
+	}))
+	defer ts.Close()
+
+	c := &intercom{accessToken: "tok", client: ts.Client(), baseURL: ts.URL}
+	result, err := c.Execute(context.Background(), "intercom_list_conversations", map[string]any{})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	assert.Contains(t, result.Data, "c1")
+}

--- a/integrations/intercom/intercom_test.go
+++ b/integrations/intercom/intercom_test.go
@@ -244,6 +244,18 @@ func TestReplyConversation_MissingUserID(t *testing.T) {
 	assert.Contains(t, result.Data, "intercom_user_id is required")
 }
 
+func TestReplyConversation_InvalidType(t *testing.T) {
+	c := &intercom{accessToken: "tok", client: &http.Client{}, baseURL: "http://localhost"}
+	result, err := c.Execute(context.Background(), "intercom_reply_conversation", map[string]any{
+		"conversation_id": "c1",
+		"body":            "hello",
+		"type":            "note",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, `type must be admin or user, got "note"`)
+}
+
 func TestCloseConversation(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/conversations/c1/parts", r.URL.Path)
@@ -482,6 +494,38 @@ func TestCreateTicket_MissingContact(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, result.IsError)
 	assert.Contains(t, result.Data, "provide contact_id or contacts")
+}
+
+func TestSearchTickets_StateFilter(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/tickets/search", r.URL.Path)
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		query := body["query"].(map[string]any)
+		assert.Equal(t, "state", query["field"])
+		assert.Equal(t, "submitted", query["value"])
+		_, _ = w.Write([]byte(`{"tickets":[{"id":"t1"}]}`))
+	}))
+	defer ts.Close()
+
+	c := &intercom{accessToken: "tok", client: ts.Client(), baseURL: ts.URL}
+	result, err := c.Execute(context.Background(), "intercom_search_tickets", map[string]any{"state": "submitted"})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestListTicketTypes(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/ticket_types", r.URL.Path)
+		_, _ = w.Write([]byte(`{"data":[{"id":"tt1","name":"Bug"}]}`))
+	}))
+	defer ts.Close()
+
+	c := &intercom{accessToken: "tok", client: ts.Client(), baseURL: ts.URL}
+	result, err := c.Execute(context.Background(), "intercom_list_ticket_types", map[string]any{})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	assert.Contains(t, result.Data, "Bug")
 }
 
 func TestListConversations(t *testing.T) {

--- a/integrations/intercom/intercom_test.go
+++ b/integrations/intercom/intercom_test.go
@@ -346,6 +346,16 @@ func TestCreateContact(t *testing.T) {
 	assert.Contains(t, result.Data, "u1")
 }
 
+func TestCreateContact_MissingIdentifier(t *testing.T) {
+	c := &intercom{accessToken: "tok", client: &http.Client{}, baseURL: "http://localhost"}
+	result, err := c.Execute(context.Background(), "intercom_create_contact", map[string]any{
+		"name": "Ada",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Data, "provide email or external_id")
+}
+
 func TestSearchArticles(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)

--- a/integrations/intercom/markdown.go
+++ b/integrations/intercom/markdown.go
@@ -1,0 +1,286 @@
+package intercom
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/daltoniam/switchboard/markdown"
+)
+
+type renderedConversation struct {
+	ID       string
+	Title    string
+	State    string
+	Priority string
+	Created  string
+	Updated  string
+	Assignee string
+	Contact  string
+	Parts    []renderedPart
+}
+
+type renderedPart struct {
+	Author    string
+	CreatedAt string
+	PartType  string
+	Body      markdown.Markdown
+}
+
+type renderedArticle struct {
+	ID     string
+	Title  string
+	State  string
+	Author string
+	URL    string
+	Body   markdown.Markdown
+}
+
+var markdownRenderers = map[mcp.ToolName]func([]byte) (markdown.Markdown, bool){
+	"intercom_get_conversation": renderConversationMD,
+	"intercom_get_article":      renderArticleMD,
+}
+
+func (c *intercom) RenderMarkdown(toolName mcp.ToolName, data []byte) (markdown.Markdown, bool) {
+	if fn, ok := markdownRenderers[toolName]; ok {
+		return fn(data)
+	}
+	return "", false
+}
+
+type rawConversationResponse struct {
+	ID       any    `json:"id"`
+	Title    string `json:"title"`
+	State    string `json:"state"`
+	Priority string `json:"priority"`
+	Created  int64  `json:"created_at"`
+	Updated  int64  `json:"updated_at"`
+	Source   struct {
+		Subject string `json:"subject"`
+		Body    string `json:"body"`
+		Author  struct {
+			Name  string `json:"name"`
+			Email string `json:"email"`
+			Type  string `json:"type"`
+		} `json:"author"`
+	} `json:"source"`
+	AdminAssigneeID any `json:"admin_assignee_id"`
+	TeamAssigneeID  any `json:"team_assignee_id"`
+	Contacts        struct {
+		Contacts []struct {
+			Name  string `json:"name"`
+			Email string `json:"email"`
+		} `json:"contacts"`
+	} `json:"contacts"`
+	ConversationParts struct {
+		ConversationParts []struct {
+			PartType  string `json:"part_type"`
+			Body      string `json:"body"`
+			CreatedAt int64  `json:"created_at"`
+			Author    struct {
+				Name  string `json:"name"`
+				Email string `json:"email"`
+				Type  string `json:"type"`
+			} `json:"author"`
+		} `json:"conversation_parts"`
+	} `json:"conversation_parts"`
+}
+
+type rawArticleResponse struct {
+	ID     any    `json:"id"`
+	Title  string `json:"title"`
+	State  string `json:"state"`
+	URL    string `json:"url"`
+	Body   string `json:"body"`
+	Author struct {
+		Name  string `json:"name"`
+		Email string `json:"email"`
+	} `json:"author"`
+}
+
+func anyID(v any) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case float64:
+		return strconv.FormatInt(int64(t), 10)
+	case json.Number:
+		return t.String()
+	default:
+		if v == nil {
+			return ""
+		}
+		return fmt.Sprint(v)
+	}
+}
+
+func unixString(ts int64) string {
+	if ts == 0 {
+		return ""
+	}
+	return strconv.FormatInt(ts, 10)
+}
+
+func authorLabel(name, email, typ string) string {
+	label := name
+	if label == "" {
+		label = email
+	}
+	if label == "" {
+		label = typ
+	}
+	if email != "" && name != "" {
+		return name + " <" + email + ">"
+	}
+	return label
+}
+
+func renderConversationMD(data []byte) (markdown.Markdown, bool) {
+	var raw rawConversationResponse
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return "", false
+	}
+	title := raw.Title
+	if title == "" {
+		title = raw.Source.Subject
+	}
+	if title == "" {
+		title = "Conversation " + anyID(raw.ID)
+	}
+	contact := ""
+	if len(raw.Contacts.Contacts) > 0 {
+		c := raw.Contacts.Contacts[0]
+		contact = authorLabel(c.Name, c.Email, "contact")
+	} else if raw.Source.Author.Name != "" || raw.Source.Author.Email != "" {
+		contact = authorLabel(raw.Source.Author.Name, raw.Source.Author.Email, raw.Source.Author.Type)
+	}
+	assignee := anyID(raw.AdminAssigneeID)
+	if assignee == "" {
+		assignee = anyID(raw.TeamAssigneeID)
+	}
+	parts := make([]renderedPart, 0, len(raw.ConversationParts.ConversationParts)+1)
+	if raw.Source.Body != "" {
+		parts = append(parts, renderedPart{
+			Author:    authorLabel(raw.Source.Author.Name, raw.Source.Author.Email, raw.Source.Author.Type),
+			CreatedAt: unixString(raw.Created),
+			PartType:  "source",
+			Body:      markdown.FromHTML(raw.Source.Body),
+		})
+	}
+	for _, p := range raw.ConversationParts.ConversationParts {
+		parts = append(parts, renderedPart{
+			Author:    authorLabel(p.Author.Name, p.Author.Email, p.Author.Type),
+			CreatedAt: unixString(p.CreatedAt),
+			PartType:  p.PartType,
+			Body:      markdown.FromHTML(p.Body),
+		})
+	}
+	conv := renderedConversation{
+		ID:       anyID(raw.ID),
+		Title:    title,
+		State:    raw.State,
+		Priority: raw.Priority,
+		Created:  unixString(raw.Created),
+		Updated:  unixString(raw.Updated),
+		Assignee: assignee,
+		Contact:  contact,
+		Parts:    parts,
+	}
+	return conversationToMarkdown(conv), true
+}
+
+func renderArticleMD(data []byte) (markdown.Markdown, bool) {
+	var raw rawArticleResponse
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return "", false
+	}
+	article := renderedArticle{
+		ID:     anyID(raw.ID),
+		Title:  raw.Title,
+		State:  raw.State,
+		Author: authorLabel(raw.Author.Name, raw.Author.Email, ""),
+		URL:    raw.URL,
+		Body:   markdown.FromHTML(raw.Body),
+	}
+	return articleToMarkdown(article), true
+}
+
+func conversationToMarkdown(conv renderedConversation) markdown.Markdown {
+	b := markdown.NewBuilder()
+	b.Metadata("intercom", "conversation_id", conv.ID, "state", conv.State)
+	b.Heading(1, conv.Title)
+	attrs := []string{}
+	if conv.State != "" {
+		attrs = append(attrs, "State: "+conv.State)
+	}
+	if conv.Priority != "" {
+		attrs = append(attrs, "Priority: "+conv.Priority)
+	}
+	if conv.Contact != "" {
+		attrs = append(attrs, "Contact: "+conv.Contact)
+	}
+	if conv.Assignee != "" {
+		attrs = append(attrs, "Assignee: "+conv.Assignee)
+	}
+	if conv.Created != "" {
+		attrs = append(attrs, "Created: "+conv.Created)
+	}
+	if len(attrs) > 0 {
+		b.Attribution(attrs...)
+	}
+	if len(conv.Parts) == 0 {
+		b.BlankLine()
+		b.Raw("No messages.\n")
+		return b.Build()
+	}
+	b.BlankLine()
+	b.Heading(2, fmt.Sprintf("Messages (%d)", len(conv.Parts)))
+	b.BlankLine()
+	for _, p := range conv.Parts {
+		author := p.Author
+		if author == "" {
+			author = "unknown"
+		}
+		context := p.PartType
+		if p.CreatedAt != "" {
+			if context != "" {
+				context += ", " + p.CreatedAt
+			} else {
+				context = p.CreatedAt
+			}
+		}
+		body := strings.TrimRight(string(p.Body), "\n")
+		if body == "" {
+			body = "(empty)"
+		}
+		b.CommentAttribution(author, context, body)
+	}
+	return b.Build()
+}
+
+func articleToMarkdown(article renderedArticle) markdown.Markdown {
+	b := markdown.NewBuilder()
+	b.Metadata("intercom", "article_id", article.ID, "state", article.State)
+	title := article.Title
+	if title == "" {
+		title = "Article " + article.ID
+	}
+	b.Heading(1, title)
+	attrs := []string{}
+	if article.Author != "" {
+		attrs = append(attrs, "Author: "+article.Author)
+	}
+	if article.URL != "" {
+		attrs = append(attrs, "URL: "+article.URL)
+	}
+	if len(attrs) > 0 {
+		b.Attribution(attrs...)
+	}
+	if article.Body != "" {
+		b.BlankLine()
+		b.WriteMarkdown(article.Body)
+	}
+	return b.Build()
+}

--- a/integrations/intercom/markdown_test.go
+++ b/integrations/intercom/markdown_test.go
@@ -1,0 +1,68 @@
+package intercom
+
+import (
+	"testing"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderMarkdown_Conversation(t *testing.T) {
+	c := &intercom{}
+	data := `{"id":"c1","title":"Billing help","state":"open","priority":"not_priority","created_at":1663597223,"updated_at":1663597260,"admin_assignee_id":"991","source":{"subject":"Billing help","body":"<p>I need help</p>","author":{"name":"Ada","email":"ada@example.com","type":"user"}},"contacts":{"contacts":[{"name":"Ada","email":"ada@example.com"}]},"conversation_parts":{"conversation_parts":[{"part_type":"comment","body":"<p>We can help</p>","created_at":1663597260,"author":{"name":"Sam","email":"sam@example.com","type":"admin"}}]}}`
+
+	md, ok := c.RenderMarkdown("intercom_get_conversation", []byte(data))
+	require.True(t, ok)
+	assert.Contains(t, string(md), "<!-- intercom:conversation_id=c1 state=open -->")
+	assert.Contains(t, string(md), "# Billing help")
+	assert.Contains(t, string(md), "I need help")
+	assert.Contains(t, string(md), "We can help")
+	assert.Contains(t, string(md), "**Ada <ada@example.com>**")
+}
+
+func TestRenderMarkdown_Article(t *testing.T) {
+	c := &intercom{}
+	data := `{"id":"a1","title":"Refunds","state":"published","url":"https://help.example.com/a1","body":"<p>How to get a refund</p>","author":{"name":"Docs","email":"docs@example.com"}}`
+
+	md, ok := c.RenderMarkdown("intercom_get_article", []byte(data))
+	require.True(t, ok)
+	assert.Contains(t, string(md), "<!-- intercom:article_id=a1 state=published -->")
+	assert.Contains(t, string(md), "# Refunds")
+	assert.Contains(t, string(md), "How to get a refund")
+}
+
+func TestRenderMarkdown_UnknownTool(t *testing.T) {
+	c := &intercom{}
+	_, ok := c.RenderMarkdown("intercom_search_conversations", []byte(`{}`))
+	assert.False(t, ok)
+}
+
+func TestRenderMarkdown_InvalidJSON(t *testing.T) {
+	c := &intercom{}
+	_, ok := c.RenderMarkdown("intercom_get_conversation", []byte(`not json`))
+	assert.False(t, ok)
+}
+
+func TestRenderMarkdown_ToolsCovered(t *testing.T) {
+	adapter := New()
+	md, ok := adapter.(mcp.MarkdownIntegration)
+	require.True(t, ok, "adapter should implement MarkdownIntegration")
+
+	toolNames := make(map[mcp.ToolName]bool)
+	for _, tool := range adapter.Tools() {
+		toolNames[tool.Name] = true
+	}
+
+	for name := range toolNames {
+		md.RenderMarkdown(name, []byte("{}"))
+	}
+
+	markdownTools := []mcp.ToolName{
+		"intercom_get_conversation",
+		"intercom_get_article",
+	}
+	for _, name := range markdownTools {
+		assert.True(t, toolNames[name], "RenderMarkdown handles %q but it's not in Tools()", name)
+	}
+}

--- a/integrations/intercom/tools.go
+++ b/integrations/intercom/tools.go
@@ -180,8 +180,9 @@ var tools = []mcp.ToolDefinition{
 		Parameters: map[string]string{
 			"ticket_id":         "Intercom ticket ID",
 			"open":              "true to open, false to close",
-			"admin_assignee_id": "Admin ID to assign",
-			"team_assignee_id":  "Team ID to assign",
+			"assignee_id":       "Admin or team ID to assign (or 0 to unassign). Preferred over admin_assignee_id/team_assignee_id.",
+			"admin_assignee_id": "Admin ID to assign (used when assignee_id is omitted)",
+			"team_assignee_id":  "Team ID to assign (used when assignee_id and admin_assignee_id are omitted)",
 			"ticket_attributes": "JSON object of ticket attributes",
 		},
 		Required: []string{"ticket_id"},

--- a/integrations/intercom/tools.go
+++ b/integrations/intercom/tools.go
@@ -163,7 +163,7 @@ var tools = []mcp.ToolDefinition{
 		Required:   []string{"ticket_id"},
 	},
 	{
-		Name: mcp.ToolName("intercom_create_ticket"), Description: "Create an Intercom ticket for a contact. Requires a ticket type from the workspace.",
+		Name: mcp.ToolName("intercom_create_ticket"), Description: "Create an Intercom ticket for a contact. Use after list_ticket_types to get ticket_type_id.",
 		Parameters: map[string]string{
 			"ticket_type_id":    "Ticket type ID",
 			"contact_id":        "Intercom contact ID to attach (used when contacts is omitted)",
@@ -239,6 +239,10 @@ var tools = []mcp.ToolDefinition{
 	},
 	{
 		Name: mcp.ToolName("intercom_list_tags"), Description: "List Intercom tags used to label conversations and contacts",
+		Parameters: map[string]string{},
+	},
+	{
+		Name: mcp.ToolName("intercom_list_ticket_types"), Description: "List Intercom ticket types used when creating helpdesk tickets. Use before create_ticket to get ticket_type_id.",
 		Parameters: map[string]string{},
 	},
 }

--- a/integrations/intercom/tools.go
+++ b/integrations/intercom/tools.go
@@ -1,0 +1,243 @@
+package intercom
+
+import mcp "github.com/daltoniam/switchboard"
+
+var tools = []mcp.ToolDefinition{
+	{
+		Name: mcp.ToolName("intercom_search_conversations"), Description: "Search Intercom inbox conversations, customer chats, messenger threads, and support messages. Start here for customer support, helpdesk triage, open conversations, and unread inbox work.",
+		Parameters: map[string]string{
+			"query":          `Intercom search query JSON object (e.g. {"field":"state","operator":"=","value":"open"}). Overrides state when set.`,
+			"state":          "Conversation state filter: open, closed, or snoozed. Used when query is omitted.",
+			"per_page":       "Results per page (default 20, max 150)",
+			"starting_after": "Pagination cursor from pages.next.starting_after",
+			"sort_field":     "Sort field (e.g. updated_at, created_at)",
+			"sort_order":     "Sort order: ascending or descending",
+		},
+	},
+	{
+		Name: mcp.ToolName("intercom_list_conversations"), Description: "List Intercom inbox conversations in reverse chronological order. Prefer search_conversations when filtering by state, assignee, or contact.",
+		Parameters: map[string]string{
+			"per_page":       "Results per page (default 20, max 150)",
+			"starting_after": "Pagination cursor from pages.next.starting_after",
+		},
+	},
+	{
+		Name: mcp.ToolName("intercom_get_conversation"), Description: "Get an Intercom conversation including message parts, customer replies, and assignment. Use after search_conversations or list_conversations.",
+		Parameters: map[string]string{
+			"conversation_id": "Intercom conversation ID",
+			"display_as":      "Set to plaintext to strip HTML from message bodies (default plaintext)",
+		},
+		Required: []string{"conversation_id"},
+	},
+	{
+		Name: mcp.ToolName("intercom_reply_conversation"), Description: "Reply to an Intercom conversation as an admin comment or add an internal note. Use after get_conversation.",
+		Parameters: map[string]string{
+			"conversation_id":  "Intercom conversation ID",
+			"body":             "Reply or note HTML/text body",
+			"admin_id":         "Admin ID sending the reply (required for admin replies and notes)",
+			"message_type":     "comment (customer-visible reply, default) or note (internal note)",
+			"type":             "admin (default) or user",
+			"intercom_user_id": "Contact ID when type is user",
+			"attachment_urls":  "Optional comma-separated public attachment URLs",
+		},
+		Required: []string{"conversation_id", "body"},
+	},
+	{
+		Name: mcp.ToolName("intercom_close_conversation"), Description: "Close an Intercom conversation after it is resolved. Use after get_conversation or reply_conversation.",
+		Parameters: map[string]string{
+			"conversation_id": "Intercom conversation ID",
+			"admin_id":        "Admin ID performing the close",
+			"body":            "Optional closing message",
+		},
+		Required: []string{"conversation_id", "admin_id"},
+	},
+	{
+		Name: mcp.ToolName("intercom_reopen_conversation"), Description: "Reopen a closed Intercom conversation. Use after get_conversation.",
+		Parameters: map[string]string{
+			"conversation_id": "Intercom conversation ID",
+			"admin_id":        "Admin ID performing the reopen",
+			"body":            "Optional reopen message",
+		},
+		Required: []string{"conversation_id", "admin_id"},
+	},
+	{
+		Name: mcp.ToolName("intercom_snooze_conversation"), Description: "Snooze an Intercom conversation until a unix timestamp. Use after get_conversation.",
+		Parameters: map[string]string{
+			"conversation_id": "Intercom conversation ID",
+			"admin_id":        "Admin ID performing the snooze",
+			"snoozed_until":   "Unix timestamp when the conversation should reopen",
+		},
+		Required: []string{"conversation_id", "admin_id", "snoozed_until"},
+	},
+	{
+		Name: mcp.ToolName("intercom_assign_conversation"), Description: "Assign an Intercom conversation to an admin teammate or team inbox. Use after list_admins or list_teams.",
+		Parameters: map[string]string{
+			"conversation_id": "Intercom conversation ID",
+			"admin_id":        "Admin ID performing the assignment",
+			"assignee_id":     "Admin or team ID to assign the conversation to",
+			"body":            "Optional assignment note",
+		},
+		Required: []string{"conversation_id", "admin_id", "assignee_id"},
+	},
+	{
+		Name: mcp.ToolName("intercom_tag_conversation"), Description: "Add a tag to an Intercom conversation for routing and reporting. Use after list_tags.",
+		Parameters: map[string]string{
+			"conversation_id": "Intercom conversation ID",
+			"tag_id":          "Tag ID from list_tags",
+			"admin_id":        "Admin ID applying the tag",
+		},
+		Required: []string{"conversation_id", "tag_id", "admin_id"},
+	},
+	{
+		Name: mcp.ToolName("intercom_search_contacts"), Description: "Search Intercom contacts, leads, and users by email or a search query. Use to find customers before opening conversations.",
+		Parameters: map[string]string{
+			"email":          "Contact email address (builds an email equality query when query is omitted)",
+			"query":          `Intercom search query JSON object. Overrides email when set.`,
+			"per_page":       "Results per page (default 20, max 150)",
+			"starting_after": "Pagination cursor from pages.next.starting_after",
+		},
+	},
+	{
+		Name: mcp.ToolName("intercom_list_contacts"), Description: "List Intercom contacts, leads, and users. Prefer search_contacts when looking up a specific email.",
+		Parameters: map[string]string{
+			"per_page":       "Results per page (default 20, max 150)",
+			"starting_after": "Pagination cursor from pages.next.starting_after",
+		},
+	},
+	{
+		Name: mcp.ToolName("intercom_get_contact"), Description: "Get an Intercom contact, lead, or user by ID including email, name, and custom attributes. Use after search_contacts.",
+		Parameters: map[string]string{"contact_id": "Intercom contact ID"},
+		Required:   []string{"contact_id"},
+	},
+	{
+		Name: mcp.ToolName("intercom_create_contact"), Description: "Create an Intercom contact, lead, or user. Provide email and/or external_id.",
+		Parameters: map[string]string{
+			"email":             "Contact email address",
+			"external_id":       "Your system's user ID",
+			"name":              "Contact name",
+			"phone":             "Contact phone number",
+			"role":              "user or lead",
+			"custom_attributes": "JSON object of custom attributes",
+		},
+	},
+	{
+		Name: mcp.ToolName("intercom_update_contact"), Description: "Update an Intercom contact's name, email, phone, or custom attributes. Use after get_contact.",
+		Parameters: map[string]string{
+			"contact_id":        "Intercom contact ID",
+			"email":             "Contact email address",
+			"external_id":       "Your system's user ID",
+			"name":              "Contact name",
+			"phone":             "Contact phone number",
+			"role":              "user or lead",
+			"custom_attributes": "JSON object of custom attributes",
+		},
+		Required: []string{"contact_id"},
+	},
+	{
+		Name: mcp.ToolName("intercom_list_companies"), Description: "List Intercom companies and accounts linked to contacts",
+		Parameters: map[string]string{
+			"name":           "Optional company name filter",
+			"company_id":     "Optional external company_id filter",
+			"per_page":       "Results per page (default 20)",
+			"page":           "Page number (companies use page pagination)",
+			"starting_after": "Pagination cursor when provided by a previous response",
+		},
+	},
+	{
+		Name: mcp.ToolName("intercom_get_company"), Description: "Get an Intercom company by Intercom ID. Use after list_companies.",
+		Parameters: map[string]string{"id": "Intercom company ID (not the external company_id)"},
+		Required:   []string{"id"},
+	},
+	{
+		Name: mcp.ToolName("intercom_search_tickets"), Description: "Search Intercom tickets and helpdesk ticket requests by state or query. Use for ticket tracking alongside inbox conversations.",
+		Parameters: map[string]string{
+			"query":          `Intercom search query JSON object. Overrides state when set.`,
+			"state":          "Ticket state filter (e.g. submitted, in_progress, waiting_on_customer, resolved). Used when query is omitted.",
+			"per_page":       "Results per page (default 20, max 150)",
+			"starting_after": "Pagination cursor from pages.next.starting_after",
+		},
+	},
+	{
+		Name: mcp.ToolName("intercom_get_ticket"), Description: "Get an Intercom ticket including attributes, contacts, and assignment. Use after search_tickets.",
+		Parameters: map[string]string{"ticket_id": "Intercom ticket ID"},
+		Required:   []string{"ticket_id"},
+	},
+	{
+		Name: mcp.ToolName("intercom_create_ticket"), Description: "Create an Intercom ticket for a contact. Requires a ticket type from the workspace.",
+		Parameters: map[string]string{
+			"ticket_type_id":    "Ticket type ID",
+			"contact_id":        "Intercom contact ID to attach (used when contacts is omitted)",
+			"contacts":          `JSON array of contacts (e.g. [{"id":"abc"}])`,
+			"title":             "Ticket title",
+			"description":       "Ticket description",
+			"admin_assignee_id": "Admin ID to assign",
+			"team_assignee_id":  "Team ID to assign",
+		},
+		Required: []string{"ticket_type_id"},
+	},
+	{
+		Name: mcp.ToolName("intercom_update_ticket"), Description: "Update an Intercom ticket state or assignment. Use after get_ticket.",
+		Parameters: map[string]string{
+			"ticket_id":         "Intercom ticket ID",
+			"open":              "true to open, false to close",
+			"admin_assignee_id": "Admin ID to assign",
+			"team_assignee_id":  "Team ID to assign",
+			"ticket_attributes": "JSON object of ticket attributes",
+		},
+		Required: []string{"ticket_id"},
+	},
+	{
+		Name: mcp.ToolName("intercom_reply_ticket"), Description: "Reply to an Intercom ticket as an admin comment or internal note. Use after get_ticket.",
+		Parameters: map[string]string{
+			"ticket_id":        "Intercom ticket ID",
+			"body":             "Reply or note body",
+			"admin_id":         "Admin ID sending the reply (required for admin replies and notes)",
+			"message_type":     "comment (default) or note",
+			"type":             "admin (default) or user",
+			"intercom_user_id": "Contact ID when type is user",
+		},
+		Required: []string{"ticket_id", "body"},
+	},
+	{
+		Name: mcp.ToolName("intercom_search_articles"), Description: "Search Intercom help center articles and knowledge base docs by phrase",
+		Parameters: map[string]string{
+			"phrase":         "Search phrase",
+			"per_page":       "Results per page (default 20)",
+			"starting_after": "Pagination cursor from pages.next.starting_after",
+		},
+		Required: []string{"phrase"},
+	},
+	{
+		Name: mcp.ToolName("intercom_list_articles"), Description: "List Intercom help center articles and knowledge base docs",
+		Parameters: map[string]string{
+			"per_page":       "Results per page (default 20)",
+			"starting_after": "Pagination cursor from pages.next.starting_after",
+		},
+	},
+	{
+		Name: mcp.ToolName("intercom_get_article"), Description: "Get an Intercom help center article body. Use after search_articles or list_articles.",
+		Parameters: map[string]string{"article_id": "Intercom article ID"},
+		Required:   []string{"article_id"},
+	},
+	{
+		Name: mcp.ToolName("intercom_list_admins"), Description: "List Intercom admins, teammates, and inbox agents. Use to resolve admin_id for replies and assignment.",
+		Parameters: map[string]string{},
+	},
+	{
+		Name: mcp.ToolName("intercom_get_me"), Description: "Get the Intercom admin and workspace for the current access token",
+		Parameters: map[string]string{},
+	},
+	{
+		Name: mcp.ToolName("intercom_list_teams"), Description: "List Intercom inbox teams used for conversation assignment",
+		Parameters: map[string]string{},
+	},
+	{
+		Name: mcp.ToolName("intercom_get_team"), Description: "Get an Intercom team by ID including admin members. Use after list_teams.",
+		Parameters: map[string]string{"team_id": "Intercom team ID"},
+		Required:   []string{"team_id"},
+	},
+	{
+		Name: mcp.ToolName("intercom_list_tags"), Description: "List Intercom tags used to label conversations and contacts",
+		Parameters: map[string]string{},
+	},
+}

--- a/integrations/intercom/tools.go
+++ b/integrations/intercom/tools.go
@@ -163,17 +163,17 @@ var tools = []mcp.ToolDefinition{
 		Required:   []string{"ticket_id"},
 	},
 	{
-		Name: mcp.ToolName("intercom_create_ticket"), Description: "Create an Intercom ticket for a contact. Use after list_ticket_types to get ticket_type_id.",
+		Name: mcp.ToolName("intercom_create_ticket"), Description: "Create an Intercom ticket for a contact. Use after list_ticket_types to get ticket_type_id. Provide contact_id, or contacts as an alternate.",
 		Parameters: map[string]string{
 			"ticket_type_id":    "Ticket type ID",
 			"contact_id":        "Intercom contact ID to attach (used when contacts is omitted)",
-			"contacts":          `JSON array of contacts (e.g. [{"id":"abc"}])`,
+			"contacts":          `JSON array of contacts (e.g. [{"id":"abc"}]). Alternate to contact_id.`,
 			"title":             "Ticket title",
 			"description":       "Ticket description",
 			"admin_assignee_id": "Admin ID to assign",
 			"team_assignee_id":  "Team ID to assign",
 		},
-		Required: []string{"ticket_type_id"},
+		Required: []string{"ticket_type_id", "contact_id"},
 	},
 	{
 		Name: mcp.ToolName("intercom_update_ticket"), Description: "Update an Intercom ticket state or assignment. Use after get_ticket.",


### PR DESCRIPTION
## Summary
- Add an Intercom adapter so inbox conversations, contacts, tickets, and help-center articles are available through search and execute.
- Support Bearer token auth with optional EU/AU base URLs, plus markdown rendering for conversation and article bodies.

## Test plan
- [ ] `go test ./integrations/intercom/ ./config/`
- [ ] Enable Intercom with `INTERCOM_ACCESS_TOKEN` and search for `intercom conversations`
- [ ] Execute `intercom_search_conversations` then `intercom_get_conversation` on a real inbox thread

💘 Generated with Crush