### PR TITLE
Add native OAuth login and refresh for WASM integrations

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -554,9 +554,10 @@ func runServer(stdioMode bool, port int, listenHost, grpcSocket string, discover
 				LatestVersion: ip.LatestVersion,
 			})
 		}
-		cfgNow := cfgMgr.Get()
-		cfgNow.Marketplace = mc
-		return cfgMgr.Update(cfgNow)
+		return mcp.UpdateConfig(cfgMgr, func(cfg *mcp.Config) error {
+			cfg.Marketplace = mc
+			return nil
+		})
 	}, marketplace.WithTokenFunc(marketplace.GitHubTokenFunc(func() string {
 		ic, ok := cfgMgr.GetIntegration("github")
 		if !ok || ic == nil {

--- a/config/atomic.go
+++ b/config/atomic.go
@@ -1,0 +1,43 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func atomicWriteConfig(path string, data []byte) error {
+	if info, err := os.Lstat(path); err == nil {
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("config target is not a regular file")
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	dir, err := os.Open(filepath.Dir(path))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = dir.Close() }()
+	file, err := os.CreateTemp(filepath.Dir(path), ".config-*")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close(); _ = os.Remove(file.Name()) }()
+	if err := file.Chmod(0600); err != nil {
+		return err
+	}
+	if _, err := file.Write(data); err != nil {
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(file.Name(), path); err != nil {
+		return err
+	}
+	return dir.Sync()
+}

--- a/config/atomic_test.go
+++ b/config/atomic_test.go
@@ -1,0 +1,75 @@
+package config
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSaveReplacesFileAtomicallyAndRestrictsPermissions(t *testing.T) {
+	m, path := newTestManager(t)
+	require.NoError(t, m.Load())
+	old, err := os.Open(path)
+	require.NoError(t, err)
+	defer func() { _ = old.Close() }()
+	before, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.NoError(t, os.Chmod(path, 0644))
+	require.NoError(t, m.SetIntegration("primer", &mcp.IntegrationConfig{Credentials: mcp.Credentials{"marker": "updated"}}))
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+	oldInfo, err := old.Stat()
+	require.NoError(t, err)
+	assert.False(t, os.SameFile(info, oldInfo))
+	data := make([]byte, len(before))
+	_, err = old.ReadAt(data, 0)
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(before, data))
+}
+
+func TestSaveRejectsSymlinkAndRollsBack(t *testing.T) {
+	m, path := newTestManager(t)
+	require.NoError(t, m.Load())
+	before := m.Get()
+	target := filepath.Join(filepath.Dir(path), "target.json")
+	require.NoError(t, os.Rename(path, target))
+	require.NoError(t, os.Symlink(target, path))
+	data, err := os.ReadFile(target)
+	require.NoError(t, err)
+	require.Error(t, m.SetIntegration("primer", &mcp.IntegrationConfig{Credentials: mcp.Credentials{"marker": "updated"}}))
+	assert.Equal(t, before, m.Get())
+	after, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, data, after)
+	files, err := os.ReadDir(filepath.Dir(path))
+	require.NoError(t, err)
+	assert.Len(t, files, 2)
+}
+
+func TestAtomicIntegrationUpdateUsesCurrentCopyAndRollsBack(t *testing.T) {
+	m, _ := newTestManager(t)
+	require.NoError(t, m.Load())
+	updater, ok := any(m).(interface {
+		UpdateIntegration(string, func(*mcp.IntegrationConfig) error) error
+	})
+	require.True(t, ok, "configuration must support an in-lock update")
+	require.NoError(t, m.SetIntegration("primer", &mcp.IntegrationConfig{Credentials: mcp.Credentials{"rotation": "current"}}))
+	require.NoError(t, updater.UpdateIntegration("primer", func(ic *mcp.IntegrationConfig) error {
+		assert.Equal(t, "current", ic.Credentials["rotation"])
+		ic.Credentials["unrelated"] = "updated"
+		return nil
+	}))
+	before := m.Get()
+	require.Error(t, updater.UpdateIntegration("primer", func(ic *mcp.IntegrationConfig) error {
+		ic.Credentials["rotation"] = "discard"
+		return errors.New("abort")
+	}))
+	assert.Equal(t, before, m.Get())
+}

--- a/config/config.go
+++ b/config/config.go
@@ -686,7 +686,7 @@ func (m *manager) saveLocked() error {
 		return fmt.Errorf("marshal config: %w", err)
 	}
 
-	if err := os.WriteFile(m.filePath, data, 0600); err != nil {
+	if err := atomicWriteConfig(m.filePath, data); err != nil {
 		return fmt.Errorf("write config: %w", err)
 	}
 	return nil
@@ -719,6 +719,22 @@ func (m *manager) durableConfigFromRuntime(cfg *mcp.Config) *mcp.Config {
 }
 
 func (m *manager) Update(cfg *mcp.Config) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.updateLocked(cloneConfig(cfg))
+}
+
+func (m *manager) UpdateConfig(update func(*mcp.Config) error) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cfg := cloneConfig(m.cfg)
+	if err := update(cfg); err != nil {
+		return err
+	}
+	return m.updateLocked(cloneConfig(cfg))
+}
+
+func (m *manager) updateLocked(cfg *mcp.Config) error {
 	for name, ic := range cfg.Integrations {
 		if err := mcp.ValidateToolGlobs(ic.ToolGlobs); err != nil {
 			return fmt.Errorf("integration %q: %w", name, err)
@@ -727,8 +743,6 @@ func (m *manager) Update(cfg *mcp.Config) error {
 	if err := mcp.ValidateProjectCatalogConfig(cfg.ProjectCatalog); err != nil {
 		return err
 	}
-	m.mu.Lock()
-	defer m.mu.Unlock()
 	previousRuntime := m.cfg
 	previousPersisted := m.persisted
 	m.cfg = cfg
@@ -749,11 +763,28 @@ func (m *manager) GetIntegration(name string) (*mcp.IntegrationConfig, bool) {
 }
 
 func (m *manager) SetIntegration(name string, ic *mcp.IntegrationConfig) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.setIntegrationLocked(name, ic)
+}
+
+func (m *manager) UpdateIntegration(name string, update func(*mcp.IntegrationConfig) error) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ic := cloneIntegrationConfig(m.cfg.Integrations[name])
+	if ic == nil {
+		ic = &mcp.IntegrationConfig{Credentials: mcp.Credentials{}}
+	}
+	if err := update(ic); err != nil {
+		return err
+	}
+	return m.setIntegrationLocked(name, ic)
+}
+
+func (m *manager) setIntegrationLocked(name string, ic *mcp.IntegrationConfig) error {
 	if err := mcp.ValidateToolGlobs(ic.ToolGlobs); err != nil {
 		return fmt.Errorf("integration %q: %w", name, err)
 	}
-	m.mu.Lock()
-	defer m.mu.Unlock()
 	previous, existed := m.cfg.Integrations[name]
 	if m.persisted == nil {
 		m.persisted = cloneConfig(m.cfg)
@@ -768,7 +799,7 @@ func (m *manager) SetIntegration(name string, ic *mcp.IntegrationConfig) error {
 			durable.Credentials[credentialKey] = previousPersisted.Credentials[credentialKey]
 		}
 	}
-	m.cfg.Integrations[name] = ic
+	m.cfg.Integrations[name] = cloneIntegrationConfig(ic)
 	m.persisted.Integrations[name] = durable
 	if err := m.saveLocked(); err != nil {
 		if existed {

--- a/config/plugin_oauth_test.go
+++ b/config/plugin_oauth_test.go
@@ -1,0 +1,70 @@
+package config
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/daltoniam/switchboard/pluginoauth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPluginOAuthRotatedTokensSurviveDiskReload(t *testing.T) {
+	var refreshes atomic.Int32
+	var issuer *httptest.Server
+	issuer = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]string{"issuer": issuer.URL, "authorization_endpoint": issuer.URL + "/authorize", "token_endpoint": issuer.URL + "/token", "userinfo_endpoint": issuer.URL + "/userinfo", "jwks_uri": issuer.URL + "/jwks"}))
+		case "/token":
+			refreshes.Add(1)
+			require.NoError(t, r.ParseForm())
+			assert.Equal(t, "refresh-before", r.Form.Get("refresh_token"))
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"access_token": "access-after", "refresh_token": "refresh-after", "expires_in": 3600, "token_type": "Bearer"}))
+		case "/userinfo":
+			assert.Equal(t, "Bearer access-after", r.Header.Get("Authorization"))
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]string{"sub": "expected", "email": "expected@example.com"}))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer issuer.Close()
+	previousTransport := http.DefaultTransport
+	http.DefaultTransport = issuer.Client().Transport
+	defer func() { http.DefaultTransport = previousTransport }()
+	store, path := newTestManager(t)
+	require.NoError(t, store.Load())
+	creds := mcp.Credentials{"oauth_issuer": issuer.URL, "oauth_client_id": "public", "oauth_token_key": "tasks_api_key", "oauth_subject": "expected", "oauth_email": "expected@example.com", "oauth_refresh_token": "refresh-before", "oauth_expires_at": time.Now().Format(time.RFC3339), "unrelated": "preserved"}
+	ic := &mcp.IntegrationConfig{Enabled: false, Credentials: creds, ToolGlobs: []string{"primer_read_*"}, Identities: map[string]mcp.IntegrationIdentity{"work": {Credentials: mcp.Credentials{"key": "identity-key"}}}}
+	require.NoError(t, store.SetIntegration("primer", ic))
+	oauth := pluginoauth.New("primer", store)
+	require.NoError(t, oauth.Load(creds))
+	guest, err := oauth.Credentials(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "access-after", guest["tasks_api_key"])
+	durable := &manager{filePath: path, envLookup: noEnv}
+	require.NoError(t, durable.Load())
+	saved, ok := durable.GetIntegration("primer")
+	require.True(t, ok)
+	assert.False(t, saved.Enabled)
+	assert.Equal(t, ic.ToolGlobs, saved.ToolGlobs)
+	assert.Equal(t, ic.Identities, saved.Identities)
+	assert.Equal(t, "preserved", saved.Credentials["unrelated"])
+	assert.Equal(t, "refresh-after", saved.Credentials["oauth_refresh_token"])
+	assert.Equal(t, "access-after", saved.Credentials["oauth_access_token"])
+	restarted := pluginoauth.New("primer", durable)
+	require.NoError(t, restarted.Load(saved.Credentials))
+	guest, err = restarted.Credentials(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "access-after", guest["tasks_api_key"])
+	assert.Equal(t, int32(1), refreshes.Load())
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+}

--- a/config/update_test.go
+++ b/config/update_test.go
@@ -1,0 +1,53 @@
+package config
+
+import (
+	"errors"
+	"testing"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateConfigUsesFreshCopy(t *testing.T) {
+	m, _ := newTestManager(t)
+	require.NoError(t, m.Load())
+	require.NoError(t, m.SetIntegration("primer", &mcp.IntegrationConfig{Enabled: true, Credentials: mcp.Credentials{"oauth_refresh_token": "before"}}))
+	updater, ok := any(m).(interface {
+		UpdateConfig(func(*mcp.Config) error) error
+	})
+	require.True(t, ok, "whole-config edits must support atomic fresh-copy updates")
+	stale := m.Get()
+	entered, release, done := make(chan struct{}), make(chan struct{}), make(chan error, 1)
+	go func() {
+		close(entered)
+		<-release
+		done <- updater.UpdateConfig(func(cfg *mcp.Config) error {
+			cfg.SessionStore = "file"
+			cfg.Marketplace = &mcp.MarketplaceConfig{AutoUpdate: true}
+			return nil
+		})
+	}()
+	<-entered
+	err := m.UpdateIntegration("primer", func(ic *mcp.IntegrationConfig) error {
+		ic.Credentials["oauth_refresh_token"] = "after"
+		ic.ToolGlobs = []string{"primer_*"}
+		return nil
+	})
+	close(release)
+	require.NoError(t, err)
+	require.NoError(t, <-done)
+	require.NoError(t, m.Load())
+	got := m.Get()
+	assert.Equal(t, "after", got.Integrations["primer"].Credentials["oauth_refresh_token"])
+	assert.Equal(t, []string{"primer_*"}, got.Integrations["primer"].ToolGlobs)
+	assert.Equal(t, "file", got.SessionStore)
+	assert.True(t, got.Marketplace.AutoUpdate)
+	assert.Equal(t, "before", stale.Integrations["primer"].Credentials["oauth_refresh_token"])
+	before := m.Get()
+	require.Error(t, updater.UpdateConfig(func(cfg *mcp.Config) error {
+		cfg.Integrations["primer"].Credentials["oauth_refresh_token"] = "discard"
+		return errors.New("cancel edit")
+	}))
+	assert.Equal(t, before, m.Get())
+}

--- a/docs/plugin-oauth.md
+++ b/docs/plugin-oauth.md
@@ -1,0 +1,102 @@
+# Native OAuth for WASM integrations
+
+Switchboard owns the authorization-code S256 PKCE exchange, user verification, token refresh, and credential persistence in-process. A browser is needed only for initial login or explicit reauthorization. There is no companion service, CDP connection, browser token extraction, client secret, or browser-based refresh.
+
+## Configuration
+
+OAuth settings live in the owning integration's `credentials` map, alongside the plugin's existing settings. For Primer:
+
+```json
+{
+  "oauth_issuer": "https://clerk.primerlms.com",
+  "oauth_client_id": "YOUR_REGISTERED_PUBLIC_CLIENT_ID",
+  "oauth_scopes": "openid profile email offline_access",
+  "oauth_token_key": "tasks_api_key",
+  "oauth_subject": "EXPECTED_USER_SUBJECT",
+  "oauth_email": "expected@example.com"
+}
+```
+
+| Credential | Meaning |
+| --- | --- |
+| `oauth_issuer` | HTTPS authorization server issuer; no userinfo, query, or fragment in the URL |
+| `oauth_client_id` | Registered **public** OAuth application's client ID |
+| `oauth_scopes` | Space-separated scopes; defaults to `openid profile email offline_access` |
+| `oauth_token_key` | Plugin credential receiving the access token, such as `tasks_api_key`; cannot start with `oauth_` |
+| `oauth_subject` | Required expected userinfo `sub`; exact match |
+| `oauth_email` | Required expected userinfo `email`; exact match |
+| `oauth_access_token` | Host-managed access token |
+| `oauth_refresh_token` | Host-managed refresh token, replaced when the issuer rotates it |
+| `oauth_expires_at` | Host-managed access expiry in RFC3339 UTC |
+| `oauth_settings_binding` | Host-managed fingerprint binding tokens to their OAuth settings |
+
+Configure permits valid OAuth settings without tokens. Until authorization completes, Execute fails with an authorization-required result and Healthy returns false. Partial nonempty OAuth settings fail closed. Empty optional OAuth fields do not change ordinary credential handling.
+
+The Loader injects ConfigService before Configure, including the startup path. Tokens are saved through that service into the integration's normal configuration entry. Enabled state, tool restrictions, identities, and unrelated credentials are preserved. Connecting **does not enable** a disabled integration.
+
+All `oauth_*` values, including refresh tokens, are excluded from guest configuration. Only the access token is copied to `oauth_token_key`; other plugin credentials remain available. The guest then makes its ordinary HTTP requests. Access tokens may be opaque: Switchboard does not decode JWT claims, use an ID token as an access token, or synthesize a session ID.
+
+## Public client registration and discovery
+
+Register an application with authorization-code and refresh-token grants, public-client authentication (`none`), and S256 PKCE. For an integration named `primer` on port 3847, register this exact redirect:
+
+```text
+http://127.0.0.1:3847/api/integrations/primer/oauth/callback
+```
+
+Switchboard derives the redirect from its configured port, not request Host or forwarded headers. Change the registered redirect when changing ports or the integration's configured name.
+
+Discovery begins at `<issuer>/.well-known/oauth-authorization-server`. If userinfo or JWKS metadata is absent, Switchboard also reads `<issuer>/.well-known/openid-configuration`, requiring matching issuer, authorization endpoint, and token endpoint. Clerk's production issuer above currently needs this OIDC fallback for userinfo. Authorization, token, userinfo, and JWKS URLs must be HTTPS and on the issuer's exact host/port. Provider redirects are refused, requests have a 15-second timeout, and response bodies are capped at 1 MiB.
+
+Userinfo is called with each newly exchanged access token, including refreshes and tokens first loaded after restart. Both configured identity pins must match before a token is persisted or sent to the guest. JWKS is discovered and its URL validated, but no JWKS fetch or ID-token verification is needed because identity is checked directly at authenticated userinfo. Token responses must contain a Bearer access token and a positive integer `expires_in`. The initial authorization-code exchange must also return a nonempty refresh token; otherwise authorization fails. Later refresh responses may omit it and retain the current refresh token.
+
+The configured issuer is a **trusted-operator-only setting**. HTTPS private-network and loopback issuers are supported for self-hosted deployments, not blocked as a class. Discovery and authenticated userinfo intentionally contact that issuer. Only a trusted operator may choose it or the plugin API destination; HTTPS and same-host endpoint checks are not a substitute for trusting those services.
+
+## Initial browser setup
+
+Use the local UI through **`http://127.0.0.1:<port>`**, not `localhost`, a proxy hostname, or a forwarded endpoint. OAuth endpoints require a loopback peer and the exact loopback Host; start and credential mutations additionally reject foreign Origin and non-same-origin browser fetch requests. The same guard applies to generic form saves and credential PUTs, even before OAuth settings are present. No CORS permission is granted.
+
+If OAuth settings are already saved, the integration detail page offers **Connect OAuth**. It POSTs to start and navigates the same browser to the returned authorization URL.
+
+For programmatic setup, open Switchboard in the intended browser and issue a same-origin request from that page:
+
+```javascript
+const response = await fetch('/api/integrations/primer/oauth/start', {
+  method: 'POST',
+  credentials: 'same-origin',
+  headers: {'Content-Type': 'application/json'},
+  body: JSON.stringify({credentials: {
+    oauth_issuer: 'https://clerk.primerlms.com',
+    oauth_client_id: 'YOUR_REGISTERED_PUBLIC_CLIENT_ID',
+    oauth_scopes: 'openid profile email offline_access',
+    oauth_token_key: 'tasks_api_key',
+    oauth_subject: 'EXPECTED_USER_SUBJECT',
+    oauth_email: 'expected@example.com'
+  }})
+});
+if (!response.ok) throw new Error('OAuth start failed');
+const {authorize_url} = await response.json();
+window.location.assign(authorize_url);
+```
+
+An empty body or `{}` uses current saved credentials. Supplied credentials overlay the saved settings for this attempt only; they are not persisted until identity verification succeeds. The start API refuses supplied managed token fields, client secrets, unknown OAuth keys, non-JSON bodies, bodies larger than 64 KiB, and trailing JSON. Keep other required plugin settings in its existing configuration, or include them in the credentials overlay.
+
+### API contract
+
+- `POST /api/integrations/{name}/oauth/start`: returns only `{"authorize_url":"https://..."}` and sets a random, path-scoped HttpOnly SameSite=Lax cookie with a ten-minute lifetime. GET never starts authorization.
+- `GET /api/integrations/{name}/oauth/callback`: consumes the matching one-shot state, cookie binding, and authorization code; checks an `iss` response parameter when present; exchanges with the native PKCE verifier; verifies userinfo; persists tokens; then redirects to `/integrations/{name}` without tokens or error details in the URL.
+- Unsupported integrations return 404. Bad local-origin checks return 403. Invalid configuration, state, identity, provider, or persistence failures return generic errors without raw provider responses.
+
+There is at most one pending login per module. Starting another replaces the previous attempt. State is integration-specific, expires after ten minutes, is not persisted, and is consumed before exchange. A callback must arrive in the browser that received the cookie; opening a URL returned to an unrelated command-line HTTP client will not work. Callback responses use no-store and no-referrer. The authorization protocol necessarily delivers the short-lived code and state in the incoming callback query; Switchboard does not echo or log that query, and the successful redirect strips it. Do not configure external request logging to capture callback query strings.
+
+## Refresh and failure recovery
+
+Before Execute or Healthy, the module serializes token acquisition and guest configuration with its guest-call lock. An access token with less than 60 seconds remaining is refreshed. A rotated refresh token is retained in memory immediately, checked through userinfo, and persisted before any guest call. There is no automatic retry of API calls on 401, including mutations.
+
+If persistence fails, the operation reports an error and no guest call runs. Keep Switchboard running, repair storage, and retry Execute or Healthy: it retries the save with the retained rotated token, not the old refresh token. The same applies to initial callback save failures. Module close, reload, and uninstall first flush retained rotations and refuse replacement if verification or saving fails. Replacement reads fresh configuration only after the old module has finished. Do not restart the process until saving succeeds: unsaved token rotations cannot survive a process exit.
+
+`invalid_grant` or an identity mismatch blocks the manager until explicit reauthorization. Raw token endpoint errors and storage errors are not exposed or logged. A transient userinfo failure quarantines the new token in memory for verification retry instead of replaying the previous refresh token. If that access token expires, Switchboard refreshes using the quarantined refresh token and still requires identity validation before publishing anything. **Connect OAuth intentionally abandons a quarantined rotation** after validating settings and completing discovery; use it only when you intend to replace that authorization. Abandoning the new browser login does not reactivate discarded tokens. A provider exchange interrupted before a complete response may already have rotated its token; if a subsequent attempt gets `invalid_grant`, reconnect.
+
+The integration form hides host-managed tokens. Form saves and credential PUTs serialize with token refresh, ignore supplied managed tokens, and preserve the authoritative current tokens for unchanged settings. Changing issuer, client, scopes, identity pins, or token destination clears old tokens and both old/new guest token slots; reconnect afterwards. Persisted tokens carry a settings fingerprint checked on load, including after restart. Existing unbound configurations are accepted as trusted legacy input and acquire a binding on the next successful exchange. Do not manually transplant tokens or remove their binding.
+
+Configuration saves create a same-directory mode-0600 temporary file, sync it, atomically rename it, and sync the directory. Existing symlink/nonregular config targets are rejected; use a regular file in an operator-controlled directory. A failure before rename leaves the old file intact. A directory-sync failure after rename reports failure although the new complete file may already be visible; keep the process running and retry to establish durability. Tokens remain sensitive native configuration data, not an encrypted vault. Protect the normal config file and backups. Only install trusted WASM plugins: the access token intentionally becomes available to the guest at its normal credential key.

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -18,6 +18,7 @@
   - `POST /integrations/{name}` — Save integration credentials
   - `POST /integrations/{name}/identities` — Add or update a named identity (secret fields stay write-only)
   - `POST /integrations/{name}/identities/{identity}/delete` — Remove a named identity
+- Native WASM OAuth: `POST /api/integrations/{name}/oauth/start` and `GET /api/integrations/{name}/oauth/callback`; see [plugin-oauth.md](plugin-oauth.md) for public-client PKCE setup and native refresh.
 - **OAuth/Setup pages** (guided credential flows):
   - `GET /integrations/github/setup` — GitHub Device Flow OAuth
   - `GET /integrations/linear/setup` — Linear OAuth (PKCE)

--- a/integrations/switchboard/oauth_config_concurrent_test.go
+++ b/integrations/switchboard/oauth_config_concurrent_test.go
@@ -1,0 +1,117 @@
+package switchboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/daltoniam/switchboard/config"
+	"github.com/daltoniam/switchboard/registry"
+	"github.com/daltoniam/switchboard/wasm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type credentialSnapshotBarrier struct {
+	mcp.ConfigService
+	once    sync.Once
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (s *credentialSnapshotBarrier) GetIntegration(name string) (*mcp.IntegrationConfig, bool) {
+	ic, ok := s.ConfigService.GetIntegration(name)
+	s.once.Do(func() { close(s.entered); <-s.release })
+	return ic, ok
+}
+
+func TestConfigureIntegrationConcurrentRotation(t *testing.T) {
+	for _, tc := range []struct {
+		name                  string
+		enabled, changeIssuer bool
+	}{
+		{name: "enabled", enabled: true},
+		{name: "disabled"},
+		{name: "issuer changed", enabled: true, changeIssuer: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			store, err := config.NewManager()
+			require.NoError(t, err)
+			var refreshes atomic.Int32
+			var issuer *httptest.Server
+			issuer = httptest.NewTLSServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/.well-known/oauth-authorization-server":
+					_ = json.NewEncoder(rw).Encode(map[string]string{"issuer": issuer.URL, "authorization_endpoint": issuer.URL + "/authorize", "token_endpoint": issuer.URL + "/token", "userinfo_endpoint": issuer.URL + "/userinfo", "jwks_uri": issuer.URL + "/jwks"})
+				case "/token":
+					refreshes.Add(1)
+					_ = json.NewEncoder(rw).Encode(map[string]any{"access_token": "access-after", "refresh_token": "rotation-after", "token_type": "Bearer", "expires_in": 3600})
+				case "/userinfo":
+					_ = json.NewEncoder(rw).Encode(map[string]string{"sub": "expected-user", "email": "expected@example.com"})
+				default:
+					http.NotFound(rw, r)
+				}
+			}))
+			t.Cleanup(issuer.Close)
+			previous := http.DefaultTransport
+			http.DefaultTransport = issuer.Client().Transport
+			t.Cleanup(func() { http.DefaultTransport = previous })
+			rt, err := wasm.NewRuntime(t.Context())
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = rt.Close(t.Context()) })
+			data, err := os.ReadFile("../../wasm/testdata/example.wasm")
+			require.NoError(t, err)
+			mod, err := rt.LoadModule(t.Context(), data)
+			require.NoError(t, err)
+			mod.SetName("primer")
+			mod.SetConfigService(store)
+			creds := mcp.Credentials{"oauth_issuer": issuer.URL, "oauth_client_id": "public", "oauth_subject": "expected-user", "oauth_email": "expected@example.com", "oauth_token_key": "api_key", "oauth_refresh_token": "rotation-before", "base_url": "https://api.example"}
+			require.NoError(t, store.SetIntegration("primer", &mcp.IntegrationConfig{Enabled: true, Credentials: creds, ToolGlobs: []string{"example_echo"}}))
+			require.NoError(t, mod.Configure(t.Context(), creds))
+			barrier := &credentialSnapshotBarrier{ConfigService: store, entered: make(chan struct{}), release: make(chan struct{})}
+			var release sync.Once
+			unblock := func() { release.Do(func() { close(barrier.release) }) }
+			defer unblock()
+			reg := registry.New()
+			require.NoError(t, reg.Register(mod))
+			s := &switchboardInt{services: &mcp.Services{Config: barrier, Registry: reg}}
+			updates := map[string]any{"unrelated": "updated", "oauth_refresh_token": "rotation-before"}
+			if tc.changeIssuer {
+				updates["oauth_issuer"] = "https://new.example"
+			}
+			done := make(chan *mcp.ToolResult, 1)
+			go func() {
+				result, err := configureIntegration(t.Context(), s, map[string]any{"name": "primer", "enabled": tc.enabled, "credentials": updates})
+				assert.NoError(t, err)
+				done <- result
+			}()
+			<-barrier.entered
+			result, err := mod.Execute(t.Context(), "example_echo", map[string]any{"message": "ready"})
+			unblock()
+			require.NoError(t, err)
+			require.False(t, result.IsError)
+			result = <-done
+			require.False(t, result.IsError, result.Data)
+			require.NoError(t, store.Load())
+			saved, _ := store.GetIntegration("primer")
+			if tc.changeIssuer {
+				assert.Equal(t, "https://new.example", saved.Credentials["oauth_issuer"])
+				assert.Empty(t, saved.Credentials["oauth_refresh_token"])
+				assert.Empty(t, saved.Credentials["oauth_access_token"])
+			} else {
+				assert.Equal(t, "rotation-after", saved.Credentials["oauth_refresh_token"])
+				assert.Equal(t, "access-after", saved.Credentials["oauth_access_token"])
+			}
+			assert.Equal(t, tc.enabled, saved.Enabled)
+			assert.Equal(t, "updated", saved.Credentials["unrelated"])
+			assert.Equal(t, []string{"example_echo"}, saved.ToolGlobs)
+			assert.Equal(t, int32(1), refreshes.Load())
+		})
+	}
+}

--- a/integrations/switchboard/oauth_config_test.go
+++ b/integrations/switchboard/oauth_config_test.go
@@ -1,0 +1,78 @@
+package switchboard
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/daltoniam/switchboard/config"
+	"github.com/daltoniam/switchboard/pluginoauth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type credentialEditingIntegration struct {
+	fakeIntegration
+	edit func(context.Context, mcp.Credentials, bool) error
+}
+
+func (i *credentialEditingIntegration) EditCredentials(ctx context.Context, updates mcp.Credentials, enabled bool) error {
+	return i.edit(ctx, updates, enabled)
+}
+
+func TestConfigureIntegrationUsesCredentialEditor(t *testing.T) {
+	for _, enabled := range []bool{true, false} {
+		t.Run(map[bool]string{true: "enabled", false: "disabled"}[enabled], func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			store, err := config.NewManager()
+			require.NoError(t, err)
+			require.NoError(t, store.SetIntegration("primer", &mcp.IntegrationConfig{
+				Enabled:     true,
+				Credentials: mcp.Credentials{"oauth_refresh_token": "rotated", "base_url": "original"},
+				ToolGlobs:   []string{"primer_*"},
+				Identities:  map[string]mcp.IntegrationIdentity{"existing": {Metadata: map[string]string{"label": "keep"}}},
+			}))
+			services := newTestServices()
+			services.Config = store
+			called := false
+			integration := &credentialEditingIntegration{fakeIntegration: fakeIntegration{name: "primer", configErr: errors.New("must not configure a stale snapshot")}}
+			integration.edit = func(ctx context.Context, updates mcp.Credentials, gotEnabled bool) error {
+				called = true
+				assert.Equal(t, enabled, gotEnabled)
+				assert.Equal(t, mcp.Credentials{"base_url": "updated", "oauth_refresh_token": "stale"}, updates)
+				return pluginoauth.New("primer", store).EditCredentials(ctx, updates, gotEnabled)
+			}
+			require.NoError(t, services.Registry.Register(integration))
+			result, err := configureIntegration(t.Context(), &switchboardInt{services: services}, map[string]any{
+				"name": "primer", "enabled": enabled,
+				"credentials": map[string]any{"base_url": "updated", "oauth_refresh_token": "stale"},
+				"identities":  map[string]any{"new": map[string]any{"metadata": map[string]any{"label": "added"}}},
+			})
+			require.NoError(t, err)
+			require.False(t, result.IsError, result.Data)
+			assert.True(t, called)
+			require.NoError(t, store.Load())
+			saved, _ := store.GetIntegration("primer")
+			assert.Equal(t, "rotated", saved.Credentials["oauth_refresh_token"])
+			assert.Equal(t, "updated", saved.Credentials["base_url"])
+			assert.Equal(t, enabled, saved.Enabled)
+			assert.Equal(t, []string{"primer_*"}, saved.ToolGlobs)
+			assert.Equal(t, "keep", saved.Identities["existing"].Metadata["label"])
+			assert.Equal(t, "added", saved.Identities["new"].Metadata["label"])
+		})
+	}
+}
+
+func TestConfigureIntegrationCredentialEditorFailure(t *testing.T) {
+	services := newTestServices()
+	integration := &credentialEditingIntegration{fakeIntegration: fakeIntegration{name: "primer"}, edit: func(context.Context, mcp.Credentials, bool) error {
+		return pluginoauth.ErrPersistence
+	}}
+	require.NoError(t, services.Registry.Register(integration))
+	result, err := configureIntegration(t.Context(), &switchboardInt{services: services}, map[string]any{"name": "primer"})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	_, exists := services.Config.GetIntegration("primer")
+	assert.False(t, exists)
+}

--- a/integrations/switchboard/switchboard.go
+++ b/integrations/switchboard/switchboard.go
@@ -238,11 +238,13 @@ func configureIntegration(ctx context.Context, s *switchboardInt, args map[strin
 	}
 
 	// Merge credentials if provided.
+	updates := mcp.Credentials{}
 	if credsRaw, ok := args["credentials"]; ok {
 		if credsMap, ok := credsRaw.(map[string]any); ok {
 			for k, v := range credsMap {
 				if vs, ok := v.(string); ok {
 					ic.Credentials[k] = vs
+					updates[k] = vs
 				}
 			}
 		}
@@ -264,7 +266,8 @@ func configureIntegration(ctx context.Context, s *switchboardInt, args map[strin
 	ic.Enabled = enabled
 
 	// Attempt to configure the integration to validate credentials.
-	if enabled {
+	editor, editable := a.(mcp.CredentialEditor)
+	if enabled && !editable {
 		if err := mcp.ConfigureIntegration(ctx, a, ic); err != nil {
 			return &mcp.ToolResult{
 				Data:    "configure failed: " + err.Error(),
@@ -273,7 +276,17 @@ func configureIntegration(ctx context.Context, s *switchboardInt, args map[strin
 		}
 	}
 
-	if err := s.services.Config.SetIntegration(name, ic); err != nil {
+	if editable {
+		err = editor.EditCredentials(ctx, updates, enabled)
+		if err == nil {
+			if identities, ok := args["identities"]; ok {
+				err = updateIntegrationIdentities(s.services.Config, name, identities)
+			}
+		}
+	} else {
+		err = s.services.Config.SetIntegration(name, ic)
+	}
+	if err != nil {
 		return &mcp.ToolResult{
 			Data:    "save config failed: " + err.Error(),
 			IsError: true,
@@ -289,6 +302,19 @@ func configureIntegration(ctx context.Context, s *switchboardInt, args map[strin
 		"status":      "ok",
 		"integration": name,
 		"state":       status,
+	})
+}
+
+func updateIntegrationIdentities(store mcp.ConfigService, name string, identities any) error {
+	updater, ok := store.(mcp.IntegrationConfigUpdater)
+	if !ok {
+		return fmt.Errorf("config service does not support atomic identity updates")
+	}
+	return updater.UpdateIntegration(name, func(ic *mcp.IntegrationConfig) error {
+		if ic.Identities == nil {
+			ic.Identities = map[string]mcp.IntegrationIdentity{}
+		}
+		return mergeIntegrationIdentities(ic.Identities, identities)
 	})
 }
 

--- a/marketplace/marketplace_e2e_test.go
+++ b/marketplace/marketplace_e2e_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"mime/multipart"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -148,8 +149,10 @@ func webServer(t *testing.T, mp *marketplace.Manager) *httptest.Server {
 	reg := registry.New()
 	cfgSvc := newStubConfigService()
 	services := &mcp.Services{Config: cfgSvc, Registry: reg}
-	ws := web.New(services, 0, mp, nil)
-	srv := httptest.NewServer(ws.Handler())
+	srv := httptest.NewUnstartedServer(nil)
+	ws := web.New(services, srv.Listener.Addr().(*net.TCPAddr).Port, mp, nil)
+	srv.Config.Handler = ws.Handler()
+	srv.Start()
 	t.Cleanup(srv.Close)
 	return srv
 }

--- a/mcp.go
+++ b/mcp.go
@@ -340,6 +340,11 @@ type Integration interface {
 	Healthy(ctx context.Context) bool
 }
 
+type OAuthIntegration interface {
+	StartOAuth(ctx context.Context, creds Credentials, redirectURI, browser string) (string, error)
+	CompleteOAuth(ctx context.Context, code, state, browser, issuer string) error
+}
+
 // MultiIdentityIntegration is an optional interface for integrations that
 // support multiple named credential identities (e.g. one Slack user token per
 // workspace). Existing single-identity adapters remain source-compatible.
@@ -500,6 +505,26 @@ type OptionalCredentials interface {
 // credential state cannot be inferred from non-empty config values alone.
 type CredentialDetector interface {
 	HasCredentials(creds Credentials) bool
+}
+
+type ConfigUpdater interface {
+	UpdateConfig(update func(*Config) error) error
+}
+
+func UpdateConfig(store ConfigService, update func(*Config) error) error {
+	updater, ok := store.(ConfigUpdater)
+	if !ok {
+		return fmt.Errorf("config service does not support atomic updates")
+	}
+	return updater.UpdateConfig(update)
+}
+
+type IntegrationConfigUpdater interface {
+	UpdateIntegration(name string, update func(*IntegrationConfig) error) error
+}
+
+type CredentialEditor interface {
+	EditCredentials(ctx context.Context, credentials Credentials, enabled bool) error
 }
 
 // ConfigService manages loading and saving configuration.

--- a/pluginoauth/edit_test.go
+++ b/pluginoauth/edit_test.go
@@ -1,0 +1,63 @@
+package pluginoauth
+
+import (
+	"context"
+	"maps"
+	"testing"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCredentialEditWaitsForRotationAndPreservesAuthoritativeTokens(t *testing.T) {
+	m, p, store := setupManager(t)
+	q := start(t, m, p)
+	require.NoError(t, m.Callback(t.Context(), "code", q.Get("state"), "browser-cookie", ""))
+	editor, ok := any(m).(interface {
+		EditCredentials(context.Context, mcp.Credentials, bool) error
+	})
+	require.True(t, ok, "manager must serialize credential edits")
+	stale := maps.Clone(store.ic.Credentials)
+	m.mu.Lock()
+	started, done := make(chan struct{}), make(chan error, 1)
+	go func() {
+		close(started)
+		done <- editor.EditCredentials(t.Context(), mcp.Credentials{"base_url": "https://updated.example", "oauth_refresh_token": stale["oauth_refresh_token"]}, true)
+	}()
+	<-started
+	m.creds["oauth_refresh_token"] = "latest-rotation"
+	m.dirty, m.verified = true, true
+	m.mu.Unlock()
+	require.NoError(t, <-done)
+	assert.Equal(t, "latest-rotation", store.ic.Credentials["oauth_refresh_token"])
+	assert.Equal(t, "https://updated.example", store.ic.Credentials["base_url"])
+	assert.Equal(t, []string{"primer_read_*"}, store.ic.ToolGlobs)
+}
+
+type updatingStore struct {
+	*memoryStore
+	before func(*mcp.IntegrationConfig)
+}
+
+func (s *updatingStore) UpdateIntegration(name string, update func(*mcp.IntegrationConfig) error) error {
+	s.before(s.ic)
+	ic := *s.ic
+	ic.Credentials = maps.Clone(s.ic.Credentials)
+	if err := update(&ic); err != nil {
+		return err
+	}
+	return s.SetIntegration(name, &ic)
+}
+
+func TestPersistenceCannotOverwriteConcurrentSettingsChange(t *testing.T) {
+	m, p, store := setupManager(t)
+	store.ic.Credentials = p.credentials()
+	q := start(t, m, p)
+	m.store = &updatingStore{memoryStore: store, before: func(ic *mcp.IntegrationConfig) {
+		ic.Credentials["oauth_issuer"] = "https://new.example"
+	}}
+	require.Error(t, m.Callback(t.Context(), "code", q.Get("state"), "browser-cookie", ""))
+	assert.Equal(t, "https://new.example", store.ic.Credentials["oauth_issuer"])
+	assert.Empty(t, store.ic.Credentials["oauth_refresh_token"])
+}

--- a/pluginoauth/http.go
+++ b/pluginoauth/http.go
@@ -1,0 +1,135 @@
+package pluginoauth
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const maxBody = 1 << 20
+
+type metadata struct {
+	Issuer                string `json:"issuer"`
+	AuthorizationEndpoint string `json:"authorization_endpoint"`
+	TokenEndpoint         string `json:"token_endpoint"`
+	UserinfoEndpoint      string `json:"userinfo_endpoint"`
+	JWKSURI               string `json:"jwks_uri"`
+}
+
+type tokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int64  `json:"expires_in"`
+}
+
+func secureURL(raw string) (*url.URL, error) {
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme != "https" || u.Hostname() == "" || u.User != nil || u.RawQuery != "" || u.ForceQuery || u.Fragment != "" || u.Opaque != "" {
+		return nil, ErrConfiguration
+	}
+	return u, nil
+}
+
+func (m *Manager) discover(ctx context.Context, issuer string) (*metadata, error) {
+	var md metadata
+	base := strings.TrimRight(issuer, "/")
+	if err := m.request(ctx, http.MethodGet, base+"/.well-known/oauth-authorization-server", nil, "", &md); err != nil {
+		return nil, ErrDiscovery
+	}
+	if err := validateMetadata(issuer, md, false); err != nil {
+		return nil, err
+	}
+	if md.UserinfoEndpoint == "" || md.JWKSURI == "" {
+		var oidc metadata
+		if err := m.request(ctx, http.MethodGet, base+"/.well-known/openid-configuration", nil, "", &oidc); err != nil {
+			return nil, ErrDiscovery
+		}
+		if err := validateMetadata(issuer, oidc, true); err != nil {
+			return nil, err
+		}
+		if oidc.AuthorizationEndpoint != md.AuthorizationEndpoint || oidc.TokenEndpoint != md.TokenEndpoint {
+			return nil, ErrDiscovery
+		}
+		md.UserinfoEndpoint, md.JWKSURI = oidc.UserinfoEndpoint, oidc.JWKSURI
+	}
+	return &md, validateMetadata(issuer, md, true)
+}
+
+func validateMetadata(issuer string, md metadata, complete bool) error {
+	base, err := secureURL(issuer)
+	if err != nil || md.Issuer != issuer {
+		return ErrDiscovery
+	}
+	endpoints := []string{md.AuthorizationEndpoint, md.TokenEndpoint}
+	for _, endpoint := range []string{md.UserinfoEndpoint, md.JWKSURI} {
+		if endpoint != "" || complete {
+			endpoints = append(endpoints, endpoint)
+		}
+	}
+	for _, endpoint := range endpoints {
+		u, err := secureURL(endpoint)
+		if err != nil || !strings.EqualFold(u.Host, base.Host) {
+			return ErrDiscovery
+		}
+	}
+	return nil
+}
+
+func (m *Manager) exchange(ctx context.Context, endpoint string, form url.Values) (tokenResponse, error) {
+	var token tokenResponse
+	err := m.request(ctx, http.MethodPost, endpoint, form, "", &token)
+	if err != nil {
+		return tokenResponse{}, err
+	}
+	if token.AccessToken == "" || !strings.EqualFold(token.TokenType, "Bearer") || token.ExpiresIn <= 0 || token.ExpiresIn > (1<<63-1)/1_000_000_000 {
+		return tokenResponse{}, ErrRequest
+	}
+	return token, nil
+}
+
+func (m *Manager) request(ctx context.Context, method, endpoint string, form url.Values, bearer string, result any) error {
+	if _, err := secureURL(endpoint); err != nil {
+		return ErrRequest
+	}
+	var body io.Reader
+	if form != nil {
+		body = strings.NewReader(form.Encode())
+	}
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, body)
+	if err != nil {
+		return ErrRequest
+	}
+	req.Header.Set("Accept", "application/json")
+	if form != nil {
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	}
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	resp, err := m.client.Do(req)
+	if err != nil {
+		return ErrRequest
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxBody+1))
+	if err != nil || len(data) > maxBody {
+		return ErrRequest
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		var failure struct {
+			Error string `json:"error"`
+		}
+		if method == http.MethodPost && json.Unmarshal(data, &failure) == nil && failure.Error == "invalid_grant" {
+			return ErrReauthorization
+		}
+		return ErrRequest
+	}
+	if err := json.Unmarshal(data, result); err != nil {
+		return ErrRequest
+	}
+	return nil
+}

--- a/pluginoauth/http_test.go
+++ b/pluginoauth/http_test.go
@@ -1,0 +1,98 @@
+package pluginoauth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProviderResponseBounds(t *testing.T) {
+	for _, name := range []string{"redirect", "oversize", "malformed", "timeout", "id-token-only", "missing-expiry"} {
+		t.Run(name, func(t *testing.T) {
+			var calls atomic.Int32
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls.Add(1)
+				switch name {
+				case "redirect":
+					http.Redirect(w, r, "/redirected", http.StatusTemporaryRedirect)
+				case "oversize":
+					_, _ = w.Write([]byte(strings.Repeat("x", maxBody+1)))
+				case "malformed":
+					_, _ = w.Write([]byte("secret-invalid-json"))
+				case "timeout":
+					time.Sleep(150 * time.Millisecond)
+				case "id-token-only":
+					require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"id_token": "secret-id-token", "token_type": "Bearer", "expires_in": 3600}))
+				case "missing-expiry":
+					require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"access_token": "secret-access-token", "token_type": "Bearer"}))
+				}
+			}))
+			defer server.Close()
+			m := New("primer", nil)
+			m.client.Transport = server.Client().Transport
+			ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+			defer cancel()
+			_, err := m.exchange(ctx, server.URL+"/token", url.Values{"grant_type": {"refresh_token"}})
+			require.ErrorIs(t, err, ErrRequest)
+			assert.NotContains(t, err.Error(), "secret")
+			assert.Equal(t, int32(1), calls.Load())
+		})
+	}
+}
+
+func TestMetadataValidation(t *testing.T) {
+	for _, field := range []string{"issuer", "authorization", "token", "userinfo", "jwks"} {
+		t.Run(field, func(t *testing.T) {
+			md := metadata{Issuer: "https://issuer.example", AuthorizationEndpoint: "https://issuer.example/authorize", TokenEndpoint: "https://issuer.example/token", UserinfoEndpoint: "https://issuer.example/userinfo", JWKSURI: "https://issuer.example/jwks"}
+			switch field {
+			case "issuer":
+				md.Issuer = "https://other.example"
+			case "authorization":
+				md.AuthorizationEndpoint = "https://other.example/authorize"
+			case "token":
+				md.TokenEndpoint = "https://issuer.example:8443/token"
+			case "userinfo":
+				md.UserinfoEndpoint = "http://issuer.example/userinfo"
+			case "jwks":
+				md.JWKSURI = "https://issuer.example/jwks?secret=x"
+			}
+			assert.ErrorIs(t, validateMetadata("https://issuer.example", md, true), ErrDiscovery)
+		})
+	}
+}
+
+func TestStateIsolationAndReplacement(t *testing.T) {
+	m, p, store := setupManager(t)
+	first := start(t, m, p)
+	second := start(t, m, p)
+	require.ErrorIs(t, m.Callback(t.Context(), "code", first.Get("state"), "browser-cookie", ""), ErrState)
+	other := New("other", store)
+	assert.ErrorIs(t, other.Callback(t.Context(), "code", second.Get("state"), "browser-cookie", ""), ErrState)
+	require.NoError(t, m.Callback(t.Context(), "code", second.Get("state"), "browser-cookie", ""))
+	assert.Equal(t, 1, p.tokens)
+}
+
+func TestPendingAuthorizationSurvivesInitialLoad(t *testing.T) {
+	m, p, _ := setupManager(t)
+	q := start(t, m, p)
+	require.NoError(t, m.Load(p.credentials()))
+	require.NoError(t, m.Callback(t.Context(), "code", q.Get("state"), "browser-cookie", ""))
+}
+
+func TestAuthorizationPreservesConcurrentUnrelatedCredentialUpdate(t *testing.T) {
+	m, p, store := setupManager(t)
+	store.ic.Credentials["base_url"] = "https://api.example.com"
+	q := start(t, m, p)
+	store.ic.Credentials["base_url"] = "https://updated.example.com"
+	require.NoError(t, m.Callback(t.Context(), "code", q.Get("state"), "browser-cookie", ""))
+	assert.Equal(t, "https://updated.example.com", store.ic.Credentials["base_url"])
+}

--- a/pluginoauth/manager.go
+++ b/pluginoauth/manager.go
@@ -7,6 +7,8 @@ import (
 	"crypto/subtle"
 	"encoding/base64"
 	"errors"
+	"fmt"
+	"io"
 	"maps"
 	"net/http"
 	"net/url"
@@ -44,24 +46,25 @@ type authorization struct {
 }
 
 type Manager struct {
-	mu       sync.Mutex
-	name     string
-	store    Store
-	client   *http.Client
-	now      func() time.Time
-	creds    mcp.Credentials
-	metadata *metadata
-	pending  *authorization
-	dirty    bool
-	verified bool
-	blocked  bool
-	updates  mcp.Credentials
-	previous mcp.Credentials
-	baseline mcp.Credentials
+	mu         sync.Mutex
+	name       string
+	store      Store
+	client     *http.Client
+	randReader io.Reader
+	now        func() time.Time
+	creds      mcp.Credentials
+	metadata   *metadata
+	pending    *authorization
+	dirty      bool
+	verified   bool
+	blocked    bool
+	updates    mcp.Credentials
+	previous   mcp.Credentials
+	baseline   mcp.Credentials
 }
 
 func New(name string, store Store) *Manager {
-	return &Manager{name: name, store: store, now: time.Now, client: &http.Client{
+	return &Manager{name: name, store: store, now: time.Now, randReader: rand.Reader, client: &http.Client{
 		Timeout:       15 * time.Second,
 		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
 	}}
@@ -169,7 +172,14 @@ func (m *Manager) Start(ctx context.Context, creds mcp.Credentials, redirect, br
 		return "", err
 	}
 	creds = maps.Clone(creds)
-	state, verifier := randomValue(), randomValue()
+	state, err := randomValue(m.randReader)
+	if err != nil {
+		return "", fmt.Errorf("oauth: generate state: %w", err)
+	}
+	verifier, err := randomValue(m.randReader)
+	if err != nil {
+		return "", fmt.Errorf("oauth: generate PKCE verifier: %w", err)
+	}
 	hash := sha256.Sum256([]byte(verifier))
 	u, _ = url.Parse(md.AuthorizationEndpoint)
 	q := u.Query()
@@ -206,10 +216,12 @@ func (m *Manager) Start(ctx context.Context, creds mcp.Credentials, redirect, br
 	return u.String(), nil
 }
 
-func randomValue() string {
+func randomValue(reader io.Reader) (string, error) {
 	value := make([]byte, 32)
-	_, _ = rand.Read(value)
-	return base64.RawURLEncoding.EncodeToString(value)
+	if _, err := io.ReadFull(reader, value); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(value), nil
 }
 
 func (m *Manager) Callback(ctx context.Context, code, state, browser, issuer string) error {

--- a/pluginoauth/manager.go
+++ b/pluginoauth/manager.go
@@ -1,0 +1,405 @@
+package pluginoauth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"maps"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+var (
+	ErrConfiguration   = errors.New("oauth: invalid configuration")
+	ErrDiscovery       = errors.New("oauth: issuer discovery failed")
+	ErrState           = errors.New("oauth: invalid or expired authorization session")
+	ErrReauthorization = errors.New("oauth: authorization required; connect again")
+	ErrRequest         = errors.New("oauth: provider request failed")
+	ErrPersistence     = errors.New("oauth: token persistence failed; retry before restarting")
+)
+
+type Store interface {
+	GetIntegration(string) (*mcp.IntegrationConfig, bool)
+	SetIntegration(string, *mcp.IntegrationConfig) error
+}
+
+type authorization struct {
+	state    string
+	browser  [32]byte
+	verifier string
+	redirect string
+	expires  time.Time
+	creds    mcp.Credentials
+	metadata metadata
+	updates  mcp.Credentials
+	baseline mcp.Credentials
+}
+
+type Manager struct {
+	mu       sync.Mutex
+	name     string
+	store    Store
+	client   *http.Client
+	now      func() time.Time
+	creds    mcp.Credentials
+	metadata *metadata
+	pending  *authorization
+	dirty    bool
+	verified bool
+	blocked  bool
+	updates  mcp.Credentials
+	previous mcp.Credentials
+	baseline mcp.Credentials
+}
+
+func New(name string, store Store) *Manager {
+	return &Manager{name: name, store: store, now: time.Now, client: &http.Client{
+		Timeout:       15 * time.Second,
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}}
+}
+
+func Configured(creds mcp.Credentials) bool {
+	for key, value := range creds {
+		if strings.HasPrefix(key, "oauth_") && value != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func validate(creds mcp.Credentials) error {
+	if _, err := secureURL(creds["oauth_issuer"]); err != nil {
+		return ErrConfiguration
+	}
+	for _, key := range []string{"oauth_client_id", "oauth_token_key", "oauth_subject", "oauth_email"} {
+		if strings.TrimSpace(creds[key]) == "" {
+			return ErrConfiguration
+		}
+	}
+	if strings.HasPrefix(creds["oauth_token_key"], "oauth_") || creds["oauth_client_secret"] != "" {
+		return ErrConfiguration
+	}
+	if raw := creds["oauth_expires_at"]; raw != "" {
+		if _, err := time.Parse(time.RFC3339, raw); err != nil {
+			return ErrConfiguration
+		}
+	}
+	return nil
+}
+
+func sameSettings(a, b mcp.Credentials) bool {
+	for _, key := range settingsKeys {
+		if a[key] != b[key] {
+			return false
+		}
+	}
+	return true
+}
+
+func (m *Manager) Load(creds mcp.Credentials) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.load(creds)
+}
+
+func (m *Manager) load(creds mcp.Credentials) error {
+	if err := validate(creds); err != nil {
+		return err
+	}
+	if m.dirty && m.previous != nil && sameSettings(m.previous, creds) {
+		return nil
+	}
+	if m.creds != nil && sameSettings(m.creds, creds) {
+		if m.creds["oauth_settings_binding"] != "" && m.creds["oauth_settings_binding"] != settingsBinding(m.creds) {
+			clearTokens(m.creds)
+			m.verified = false
+		}
+		for key, value := range creds {
+			if !strings.HasPrefix(key, "oauth_") && !ManagedCredential(key, m.creds) {
+				m.creds[key] = value
+			}
+		}
+		return nil
+	}
+	if m.dirty {
+		return ErrPersistence
+	}
+	if m.creds != nil {
+		m.pending = nil
+	}
+	next := maps.Clone(creds)
+	if (m.creds != nil && !sameSettings(m.creds, creds)) || (creds["oauth_settings_binding"] != "" && creds["oauth_settings_binding"] != settingsBinding(creds)) {
+		clearTokens(next)
+	}
+	m.creds = next
+	if m.store != nil {
+		if ic, ok := m.store.GetIntegration(m.name); ok && ic != nil {
+			m.baseline = maps.Clone(ic.Credentials)
+		}
+	}
+	m.metadata = nil
+	m.verified, m.blocked = false, false
+	return nil
+}
+
+func (m *Manager) Start(ctx context.Context, creds mcp.Credentials, redirect, browser string) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.store == nil {
+		return "", ErrPersistence
+	}
+	if err := validate(creds); err != nil {
+		return "", err
+	}
+	u, err := url.Parse(redirect)
+	if err != nil || u.Scheme != "http" || u.Hostname() != "127.0.0.1" || u.Port() == "" || u.User != nil || u.RawQuery != "" || u.Fragment != "" || u.Path != "/api/integrations/"+m.name+"/oauth/callback" || browser == "" {
+		return "", ErrConfiguration
+	}
+	md, err := m.discover(ctx, creds["oauth_issuer"])
+	if err != nil {
+		return "", err
+	}
+	creds = maps.Clone(creds)
+	state, verifier := randomValue(), randomValue()
+	hash := sha256.Sum256([]byte(verifier))
+	u, _ = url.Parse(md.AuthorizationEndpoint)
+	q := u.Query()
+	q.Set("response_type", "code")
+	q.Set("client_id", creds["oauth_client_id"])
+	q.Set("redirect_uri", redirect)
+	q.Set("state", state)
+	q.Set("code_challenge", base64.RawURLEncoding.EncodeToString(hash[:]))
+	q.Set("code_challenge_method", "S256")
+	scopes := creds["oauth_scopes"]
+	if scopes == "" {
+		scopes = "openid profile email offline_access"
+	}
+	q.Set("scope", scopes)
+	u.RawQuery = q.Encode()
+	updates := mcp.Credentials{}
+	existing, ok := m.store.GetIntegration(m.name)
+	for key, value := range creds {
+		if !ManagedCredential(key, creds) && (!ok || existing == nil || existing.Credentials[key] != value) {
+			updates[key] = value
+		}
+	}
+	baseline := mcp.Credentials{}
+	if ok && existing != nil {
+		baseline = maps.Clone(existing.Credentials)
+	}
+	if m.dirty {
+		m.dirty, m.verified, m.blocked = false, false, true
+		clearTokens(m.creds)
+		m.previous, m.updates = nil, nil
+	}
+	clearTokens(creds)
+	m.pending = &authorization{baseline: baseline, updates: updates, state: state, browser: sha256.Sum256([]byte(browser)), verifier: verifier, redirect: redirect, expires: m.now().Add(10 * time.Minute), creds: maps.Clone(creds), metadata: *md}
+	return u.String(), nil
+}
+
+func randomValue() string {
+	value := make([]byte, 32)
+	_, _ = rand.Read(value)
+	return base64.RawURLEncoding.EncodeToString(value)
+}
+
+func (m *Manager) Callback(ctx context.Context, code, state, browser, issuer string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	p := m.pending
+	if p == nil || subtle.ConstantTimeCompare([]byte(state), []byte(p.state)) != 1 {
+		return ErrState
+	}
+	browserHash := sha256.Sum256([]byte(browser))
+	if !m.now().Before(p.expires) || subtle.ConstantTimeCompare(browserHash[:], p.browser[:]) != 1 || (issuer != "" && issuer != p.metadata.Issuer) {
+		return ErrState
+	}
+	m.pending = nil
+	if code == "" {
+		return ErrReauthorization
+	}
+	token, err := m.exchange(ctx, p.metadata.TokenEndpoint, url.Values{
+		"grant_type": {"authorization_code"}, "client_id": {p.creds["oauth_client_id"]},
+		"code": {code}, "code_verifier": {p.verifier}, "redirect_uri": {p.redirect},
+	})
+	if err != nil {
+		return err
+	}
+	if token.RefreshToken == "" {
+		return ErrRequest
+	}
+	m.previous = m.creds
+	m.creds, m.metadata = p.creds, &p.metadata
+	m.updates, m.baseline = p.updates, p.baseline
+	m.blocked = false
+	m.accept(token, "")
+	return m.finish(ctx)
+}
+
+func (m *Manager) Credentials(ctx context.Context) (mcp.Credentials, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.blocked || m.creds == nil {
+		return nil, ErrReauthorization
+	}
+	if m.dirty {
+		if err := m.finish(ctx); err != nil {
+			return nil, err
+		}
+	}
+	expiry, _ := time.Parse(time.RFC3339, m.creds["oauth_expires_at"])
+	if m.creds["oauth_access_token"] == "" || expiry.Before(m.now().Add(time.Minute)) {
+		if err := m.refresh(ctx); err != nil {
+			return nil, err
+		}
+	} else if !m.verified {
+		if err := m.verify(ctx); err != nil {
+			return nil, err
+		}
+	}
+	guest := make(mcp.Credentials, len(m.creds))
+	for key, value := range m.creds {
+		if !strings.HasPrefix(key, "oauth_") {
+			guest[key] = value
+		}
+	}
+	guest[m.creds["oauth_token_key"]] = m.creds["oauth_access_token"]
+	return guest, nil
+}
+
+func (m *Manager) refresh(ctx context.Context) error {
+	if m.creds["oauth_refresh_token"] == "" {
+		return ErrReauthorization
+	}
+	if err := m.ensureMetadata(ctx); err != nil {
+		return err
+	}
+	token, err := m.exchange(ctx, m.metadata.TokenEndpoint, url.Values{
+		"grant_type": {"refresh_token"}, "client_id": {m.creds["oauth_client_id"]}, "refresh_token": {m.creds["oauth_refresh_token"]},
+	})
+	if err != nil {
+		if errors.Is(err, ErrReauthorization) {
+			m.blocked = true
+		}
+		return err
+	}
+	m.accept(token, m.creds["oauth_refresh_token"])
+	return m.finish(ctx)
+}
+
+func (m *Manager) accept(token tokenResponse, previousRefresh string) {
+	if token.RefreshToken == "" {
+		token.RefreshToken = previousRefresh
+	}
+	m.creds["oauth_access_token"] = token.AccessToken
+	m.creds["oauth_refresh_token"] = token.RefreshToken
+	m.creds["oauth_expires_at"] = m.now().Add(time.Duration(token.ExpiresIn) * time.Second).UTC().Format(time.RFC3339)
+	m.creds["oauth_settings_binding"] = settingsBinding(m.creds)
+	m.dirty, m.verified = true, false
+}
+
+func (m *Manager) finish(ctx context.Context) error {
+	if m.blocked {
+		return ErrReauthorization
+	}
+	expiry, _ := time.Parse(time.RFC3339, m.creds["oauth_expires_at"])
+	if !m.verified && !m.now().Before(expiry) {
+		return m.refresh(ctx)
+	}
+	if !m.verified {
+		if err := m.verify(ctx); err != nil {
+			return err
+		}
+	}
+	return m.persist()
+}
+
+func (m *Manager) ensureMetadata(ctx context.Context) error {
+	if m.metadata != nil {
+		return nil
+	}
+	md, err := m.discover(ctx, m.creds["oauth_issuer"])
+	if err != nil {
+		return err
+	}
+	m.metadata = md
+	return nil
+}
+
+func (m *Manager) verify(ctx context.Context) error {
+	if err := m.ensureMetadata(ctx); err != nil {
+		return err
+	}
+	var user struct {
+		Subject string `json:"sub"`
+		Email   string `json:"email"`
+	}
+	if err := m.request(ctx, http.MethodGet, m.metadata.UserinfoEndpoint, nil, m.creds["oauth_access_token"], &user); err != nil {
+		return ErrRequest
+	}
+	if user.Subject != m.creds["oauth_subject"] || user.Email != m.creds["oauth_email"] {
+		m.blocked = true
+		m.dirty = false
+		return ErrReauthorization
+	}
+	m.verified = true
+	return nil
+}
+
+func (m *Manager) persist() error {
+	if m.store == nil {
+		return ErrPersistence
+	}
+	var saved mcp.Credentials
+	err := updateIntegration(m.store, m.name, func(ic *mcp.IntegrationConfig) error {
+		if m.baseline != nil && !sameSettings(m.baseline, ic.Credentials) {
+			return ErrConfiguration
+		}
+		if ic.Credentials == nil {
+			ic.Credentials = mcp.Credentials{}
+		}
+		if !sameSettings(ic.Credentials, m.creds) {
+			clearTokens(ic.Credentials)
+			delete(ic.Credentials, m.creds["oauth_token_key"])
+		}
+		maps.Copy(ic.Credentials, m.updates)
+		for key, value := range m.creds {
+			if strings.HasPrefix(key, "oauth_") {
+				ic.Credentials[key] = value
+			}
+		}
+		saved = maps.Clone(ic.Credentials)
+		return nil
+	})
+	if err != nil {
+		return ErrPersistence
+	}
+	m.creds = saved
+	m.baseline = maps.Clone(saved)
+	m.dirty, m.updates, m.previous = false, nil, nil
+	return nil
+}
+
+func (m *Manager) Flush(ctx context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if !m.dirty {
+		return nil
+	}
+	return m.finish(ctx)
+}
+
+func (m *Manager) Active() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.creds != nil
+}

--- a/pluginoauth/manager_test.go
+++ b/pluginoauth/manager_test.go
@@ -1,0 +1,311 @@
+package pluginoauth
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type memoryStore struct {
+	ic    *mcp.IntegrationConfig
+	err   error
+	saves int
+	name  string
+}
+
+func (s *memoryStore) GetIntegration(name string) (*mcp.IntegrationConfig, bool) {
+	s.name = name
+	return s.ic, s.ic != nil
+}
+
+func (s *memoryStore) SetIntegration(name string, ic *mcp.IntegrationConfig) error {
+	s.name = name
+	s.saves++
+	if s.err != nil {
+		return s.err
+	}
+	s.ic = ic
+	return nil
+}
+
+type provider struct {
+	server          *httptest.Server
+	tokens          int
+	refreshes       int
+	user            string
+	email           string
+	tokenError      string
+	badEndpoint     string
+	userinfoMissing bool
+	challenge       string
+}
+
+func newProvider(t *testing.T) *provider {
+	t.Helper()
+	p := &provider{user: "expected-user", email: "expected@example.com"}
+	p.server = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server", "/.well-known/openid-configuration":
+			userinfo := p.server.URL + "/userinfo"
+			if p.userinfoMissing && r.URL.Path == "/.well-known/oauth-authorization-server" {
+				userinfo = ""
+			}
+			token := p.server.URL + "/token"
+			if p.badEndpoint != "" {
+				token = p.badEndpoint
+			}
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+				"issuer": p.server.URL, "authorization_endpoint": p.server.URL + "/authorize",
+				"token_endpoint": token, "userinfo_endpoint": userinfo, "jwks_uri": p.server.URL + "/jwks",
+				"code_challenge_methods_supported": []string{"S256"}, "token_endpoint_auth_methods_supported": []string{"none"},
+			}))
+		case "/token":
+			p.tokens++
+			require.NoError(t, r.ParseForm())
+			assert.Empty(t, r.Form.Get("client_secret"))
+			assert.Empty(t, r.Header.Get("Authorization"))
+			assert.Equal(t, "public-client", r.Form.Get("client_id"))
+			if r.Form.Get("grant_type") == "refresh_token" {
+				p.refreshes++
+				assert.Equal(t, "refresh-original", r.Form.Get("refresh_token"))
+			} else {
+				hash := sha256.Sum256([]byte(r.Form.Get("code_verifier")))
+				assert.Equal(t, p.challenge, base64.RawURLEncoding.EncodeToString(hash[:]))
+				assert.Equal(t, "http://127.0.0.1:3847/api/integrations/primer/oauth/callback", r.Form.Get("redirect_uri"))
+			}
+			if p.tokenError != "" {
+				w.WriteHeader(http.StatusBadRequest)
+				require.NoError(t, json.NewEncoder(w).Encode(map[string]string{"error": p.tokenError, "error_description": "secret-provider-details"}))
+				return
+			}
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"access_token": "opaque-access", "refresh_token": "refresh-rotated", "token_type": "Bearer", "expires_in": 3600, "id_token": "not-an-access-token"}))
+		case "/userinfo":
+			assert.Contains(t, []string{"Bearer opaque-access", "Bearer loaded-access"}, r.Header.Get("Authorization"))
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"sub": p.user, "email": p.email}))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(p.server.Close)
+	return p
+}
+
+func (p *provider) credentials() mcp.Credentials {
+	return mcp.Credentials{"oauth_issuer": p.server.URL, "oauth_client_id": "public-client", "oauth_token_key": "tasks_api_key", "oauth_subject": "expected-user", "oauth_email": "expected@example.com", "base_url": "https://api.example.com"}
+}
+
+func setupManager(t *testing.T) (*Manager, *provider, *memoryStore) {
+	t.Helper()
+	p := newProvider(t)
+	store := &memoryStore{ic: &mcp.IntegrationConfig{Enabled: false, Credentials: mcp.Credentials{"unrelated": "keep"}, ToolGlobs: []string{"primer_read_*"}, Identities: map[string]mcp.IntegrationIdentity{"work": {Credentials: mcp.Credentials{"key": "keep"}}}}}
+	m := New("primer", store)
+	m.client.Transport = p.server.Client().Transport
+	return m, p, store
+}
+
+func start(t *testing.T, m *Manager, p *provider) url.Values {
+	t.Helper()
+	raw, err := m.Start(t.Context(), p.credentials(), "http://127.0.0.1:3847/api/integrations/primer/oauth/callback", "browser-cookie")
+	require.NoError(t, err)
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	q := u.Query()
+	p.challenge = q.Get("code_challenge")
+	assert.Equal(t, "S256", q.Get("code_challenge_method"))
+	assert.Equal(t, "code", q.Get("response_type"))
+	assert.Contains(t, q.Get("scope"), "offline_access")
+	assert.Empty(t, q.Get("code_verifier"))
+	return q
+}
+
+func TestAuthorizationCode(t *testing.T) {
+	m, p, store := setupManager(t)
+	p.userinfoMissing = true
+	q := start(t, m, p)
+	assert.Zero(t, store.saves)
+	require.NoError(t, m.Callback(t.Context(), "code", q.Get("state"), "browser-cookie", p.server.URL))
+	assert.Equal(t, "primer", store.name)
+	assert.False(t, store.ic.Enabled)
+	assert.Equal(t, []string{"primer_read_*"}, store.ic.ToolGlobs)
+	assert.Equal(t, "keep", store.ic.Credentials["unrelated"])
+	assert.Equal(t, "keep", store.ic.Identities["work"].Credentials["key"])
+	assert.Equal(t, "refresh-rotated", store.ic.Credentials["oauth_refresh_token"])
+	guest, err := m.Credentials(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "opaque-access", guest["tasks_api_key"])
+	for key := range guest {
+		assert.False(t, strings.HasPrefix(key, "oauth_"))
+	}
+	assert.ErrorIs(t, m.Callback(t.Context(), "code", q.Get("state"), "browser-cookie", p.server.URL), ErrState)
+	assert.Equal(t, 1, p.tokens)
+}
+
+func TestStateValidation(t *testing.T) {
+	for _, name := range []string{"mismatch", "browser", "expired", "issuer", "denied"} {
+		t.Run(name, func(t *testing.T) {
+			m, p, store := setupManager(t)
+			q := start(t, m, p)
+			state, browser, issuer, code := q.Get("state"), "browser-cookie", p.server.URL, "code"
+			switch name {
+			case "mismatch":
+				state = "other"
+			case "browser":
+				browser = "other"
+			case "expired":
+				m.now = func() time.Time { return time.Now().Add(11 * time.Minute) }
+			case "issuer":
+				issuer = "https://evil.example"
+			case "denied":
+				code = ""
+			}
+			require.Error(t, m.Callback(t.Context(), code, state, browser, issuer))
+			assert.Zero(t, store.saves)
+			assert.Zero(t, p.tokens)
+		})
+	}
+}
+
+func TestRefreshRotationPersistenceRetryAndRestart(t *testing.T) {
+	m, p, store := setupManager(t)
+	creds := p.credentials()
+	creds["oauth_access_token"] = "loaded-access"
+	creds["oauth_refresh_token"] = "refresh-original"
+	creds["oauth_expires_at"] = time.Now().Add(30 * time.Second).Format(time.RFC3339)
+	require.NoError(t, m.Load(creds))
+	store.err = errors.New("secret-storage-details")
+	_, err := m.Credentials(t.Context())
+	require.ErrorIs(t, err, ErrPersistence)
+	assert.NotContains(t, err.Error(), "secret")
+	assert.Equal(t, 1, p.refreshes)
+	_, err = m.Credentials(t.Context())
+	require.ErrorIs(t, err, ErrPersistence)
+	assert.Equal(t, 1, p.refreshes)
+	store.err = nil
+	require.NoError(t, m.Load(creds))
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Go(func() {
+			guest, err := m.Credentials(context.Background())
+			assert.NoError(t, err)
+			assert.Equal(t, "opaque-access", guest["tasks_api_key"])
+		})
+	}
+	wg.Wait()
+	assert.Equal(t, 1, p.refreshes)
+	assert.Equal(t, "refresh-rotated", store.ic.Credentials["oauth_refresh_token"])
+	restarted := New("primer", store)
+	restarted.client.Transport = p.server.Client().Transport
+	require.NoError(t, restarted.Load(store.ic.Credentials))
+	guest, err := restarted.Credentials(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "opaque-access", guest["tasks_api_key"])
+	assert.Equal(t, 1, p.refreshes)
+}
+
+func TestWrongUserNeverPersists(t *testing.T) {
+	for _, mode := range []string{"initial-subject", "initial-email", "refresh-subject", "refresh-email"} {
+		t.Run(mode, func(t *testing.T) {
+			m, p, store := setupManager(t)
+			before := maps.Clone(store.ic.Credentials)
+			if strings.HasSuffix(mode, "subject") {
+				p.user = "wrong-user"
+			} else {
+				p.email = "wrong@example.com"
+			}
+			var err error
+			if strings.HasPrefix(mode, "initial") {
+				q := start(t, m, p)
+				err = m.Callback(t.Context(), "code", q.Get("state"), "browser-cookie", "")
+			} else {
+				creds := p.credentials()
+				creds["oauth_refresh_token"] = "refresh-original"
+				require.NoError(t, m.Load(creds))
+				_, err = m.Credentials(t.Context())
+			}
+			require.ErrorIs(t, err, ErrReauthorization)
+			assert.Zero(t, store.saves)
+			assert.Equal(t, before, store.ic.Credentials)
+		})
+	}
+}
+
+func TestInvalidGrantFailsClosed(t *testing.T) {
+	m, p, _ := setupManager(t)
+	p.tokenError = "invalid_grant"
+	creds := p.credentials()
+	creds["oauth_refresh_token"] = "refresh-original"
+	require.NoError(t, m.Load(creds))
+	for range 2 {
+		_, err := m.Credentials(t.Context())
+		require.ErrorIs(t, err, ErrReauthorization)
+		assert.NotContains(t, err.Error(), "secret-provider-details")
+		require.NoError(t, m.Load(creds))
+	}
+	assert.Equal(t, 1, p.refreshes)
+}
+
+func TestUnsafeConfiguration(t *testing.T) {
+	for _, issuer := range []string{"http://issuer.example", "https://user:secret@issuer.example", "https://issuer.example?secret=x", "https://issuer.example/#fragment"} {
+		t.Run(issuer, func(t *testing.T) {
+			m, p, _ := setupManager(t)
+			creds := p.credentials()
+			creds["oauth_issuer"] = issuer
+			require.ErrorIs(t, m.Load(creds), ErrConfiguration)
+		})
+	}
+	for _, endpoint := range []string{"http://issuer.example/token", "https://other.example/token", "https://secret@other.example/token"} {
+		t.Run(endpoint, func(t *testing.T) {
+			m, p, _ := setupManager(t)
+			p.badEndpoint = endpoint
+			_, err := m.Start(t.Context(), p.credentials(), "http://127.0.0.1:3847/api/integrations/primer/oauth/callback", "cookie")
+			require.ErrorIs(t, err, ErrDiscovery)
+		})
+	}
+}
+
+func TestInitialPersistenceRetryWithPreviousSettings(t *testing.T) {
+	m, p, store := setupManager(t)
+	previous := p.credentials()
+	previous["oauth_client_id"] = "previous-client"
+	require.NoError(t, m.Load(previous))
+	q := start(t, m, p)
+	store.err = errors.New("disk full")
+	require.ErrorIs(t, m.Callback(t.Context(), "code", q.Get("state"), "browser-cookie", ""), ErrPersistence)
+	require.NoError(t, m.Load(previous))
+	store.err = nil
+	guest, err := m.Credentials(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "opaque-access", guest["tasks_api_key"])
+	assert.Equal(t, "public-client", store.ic.Credentials["oauth_client_id"])
+}
+
+func TestReauthorizeAfterInvalidGrant(t *testing.T) {
+	m, p, store := setupManager(t)
+	creds := p.credentials()
+	creds["oauth_refresh_token"] = "refresh-original"
+	require.NoError(t, m.Load(creds))
+	p.tokenError = "invalid_grant"
+	_, err := m.Credentials(t.Context())
+	require.ErrorIs(t, err, ErrReauthorization)
+	p.tokenError = ""
+	q := start(t, m, p)
+	require.NoError(t, m.Callback(t.Context(), "code", q.Get("state"), "browser-cookie", ""))
+	guest, err := m.Credentials(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "opaque-access", guest["tasks_api_key"])
+	assert.Equal(t, "refresh-rotated", store.ic.Credentials["oauth_refresh_token"])
+}

--- a/pluginoauth/manager_test.go
+++ b/pluginoauth/manager_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"io"
 	"maps"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +14,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/iotest"
 	"time"
 
 	mcp "github.com/daltoniam/switchboard"
@@ -130,6 +132,59 @@ func start(t *testing.T, m *Manager, p *provider) url.Values {
 	assert.Contains(t, q.Get("scope"), "offline_access")
 	assert.Empty(t, q.Get("code_verifier"))
 	return q
+}
+
+func TestRandomValue(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		reader  io.Reader
+		wantErr error
+	}{
+		{name: "full read", reader: strings.NewReader(strings.Repeat("x", 32))},
+		{name: "short reads", reader: iotest.OneByteReader(strings.NewReader(strings.Repeat("x", 32)))},
+		{name: "empty reader", reader: strings.NewReader(""), wantErr: io.EOF},
+		{name: "truncated reader", reader: strings.NewReader("x"), wantErr: io.ErrUnexpectedEOF},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			value, err := randomValue(tt.reader)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				assert.Empty(t, value)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, base64.RawURLEncoding.EncodeToString([]byte(strings.Repeat("x", 32))), value)
+		})
+	}
+}
+
+func TestStartRandomFailureDoesNotIssueState(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		bytes int
+	}{
+		{name: "state"},
+		{name: "partial state", bytes: 16},
+		{name: "verifier", bytes: 32},
+		{name: "partial verifier", bytes: 48},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			m, p, store := setupManager(t)
+			before := maps.Clone(store.ic.Credentials)
+			entropyErr := errors.New("entropy unavailable")
+			m.randReader = io.MultiReader(strings.NewReader(strings.Repeat("x", tt.bytes)), iotest.ErrReader(entropyErr))
+			raw, err := m.Start(t.Context(), p.credentials(), "http://127.0.0.1:3847/api/integrations/primer/oauth/callback", "browser")
+			require.ErrorIs(t, err, entropyErr)
+			assert.Empty(t, raw)
+			assert.Nil(t, m.pending)
+			assert.Nil(t, m.creds)
+			assert.Zero(t, store.saves)
+			assert.Equal(t, before, store.ic.Credentials)
+			assert.False(t, store.ic.Enabled)
+			assert.ErrorIs(t, m.Callback(t.Context(), "code", "", "browser", p.server.URL), ErrState)
+			assert.Zero(t, p.tokens)
+		})
+	}
 }
 
 func TestAuthorizationCode(t *testing.T) {

--- a/pluginoauth/security_test.go
+++ b/pluginoauth/security_test.go
@@ -1,0 +1,169 @@
+package pluginoauth
+
+import (
+	"encoding/json"
+	"errors"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadedTokensCannotFollowChangedSettings(t *testing.T) {
+	for _, key := range []string{"oauth_issuer", "oauth_client_id", "oauth_token_key", "oauth_subject", "oauth_email", "oauth_scopes"} {
+		t.Run(key, func(t *testing.T) {
+			m, p, store := setupManager(t)
+			q := start(t, m, p)
+			require.NoError(t, m.Callback(t.Context(), "code", q.Get("state"), "browser-cookie", ""))
+			changed := maps.Clone(store.ic.Credentials)
+			changed[key] += "/changed"
+			for _, manager := range []*Manager{m, New("primer", store)} {
+				require.NoError(t, manager.Load(changed))
+				assert.Empty(t, manager.creds["oauth_access_token"])
+				assert.Empty(t, manager.creds["oauth_refresh_token"])
+				_, err := manager.Credentials(t.Context())
+				require.ErrorIs(t, err, ErrReauthorization)
+			}
+		})
+	}
+}
+
+func TestInitialExchangeRequiresRefreshToken(t *testing.T) {
+	m, p, store := setupManager(t)
+	transport := p.server.Client().Transport
+	m.client.Transport = roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path != "/token" {
+			return transport.RoundTrip(r)
+		}
+		rr := httptest.NewRecorder()
+		require.NoError(t, json.NewEncoder(rr).Encode(map[string]any{"access_token": "opaque-access", "token_type": "Bearer", "expires_in": 3600}))
+		return rr.Result(), nil
+	})
+	q := start(t, m, p)
+	require.Error(t, m.Callback(t.Context(), "code", q.Get("state"), "browser-cookie", ""))
+	assert.Zero(t, store.saves)
+	assert.False(t, m.dirty)
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestQuarantinedRotationRecoversAfterExpiry(t *testing.T) {
+	m, p, store := setupManager(t)
+	q := start(t, m, p)
+	require.NoError(t, m.Callback(t.Context(), "code", q.Get("state"), "browser-cookie", ""))
+	before := maps.Clone(store.ic.Credentials)
+	now := time.Now().Add(2 * time.Hour)
+	m.now = func() time.Time { return now }
+	refreshes := 0
+	m.client.Transport = roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		rr := httptest.NewRecorder()
+		switch r.URL.Path {
+		case "/token":
+			require.NoError(t, r.ParseForm())
+			refreshes++
+			expected := "refresh-rotated"
+			if refreshes > 1 {
+				expected = "quarantined-refresh"
+			}
+			assert.Equal(t, expected, r.Form.Get("refresh_token"))
+			require.NoError(t, json.NewEncoder(rr).Encode(map[string]any{"access_token": "recovered-access", "refresh_token": "quarantined-refresh", "token_type": "Bearer", "expires_in": 3600}))
+		case "/userinfo":
+			if refreshes == 1 {
+				rr.WriteHeader(http.StatusServiceUnavailable)
+			} else {
+				require.NoError(t, json.NewEncoder(rr).Encode(map[string]string{"sub": p.user, "email": p.email}))
+			}
+		default:
+			t.Fatalf("unexpected endpoint")
+		}
+		return rr.Result(), nil
+	})
+	guest, err := m.Credentials(t.Context())
+	require.ErrorIs(t, err, ErrRequest)
+	assert.Nil(t, guest)
+	assert.Equal(t, before, store.ic.Credentials)
+	now = now.Add(2 * time.Hour)
+	guest, err = m.Credentials(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 2, refreshes)
+	assert.Equal(t, "recovered-access", guest["tasks_api_key"])
+}
+
+func TestExplicitReauthorizationCanReplaceQuarantine(t *testing.T) {
+	m, p, store := setupManager(t)
+	q := start(t, m, p)
+	store.err = errors.New("unavailable")
+	require.ErrorIs(t, m.Callback(t.Context(), "code", q.Get("state"), "browser-cookie", ""), ErrPersistence)
+	store.err = nil
+	raw, err := m.Start(t.Context(), p.credentials(), "http://127.0.0.1:3847/api/integrations/primer/oauth/callback", "browser-cookie")
+	require.NoError(t, err)
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	p.challenge = u.Query().Get("code_challenge")
+	require.NoError(t, m.Callback(t.Context(), "code", u.Query().Get("state"), "browser-cookie", ""))
+	assert.False(t, m.dirty)
+}
+
+func TestInvalidBrowserDoesNotConsumeAuthorization(t *testing.T) {
+	m, p, _ := setupManager(t)
+	q := start(t, m, p)
+	require.ErrorIs(t, m.Callback(t.Context(), "code", q.Get("state"), "other-browser", ""), ErrState)
+	require.NoError(t, m.Callback(t.Context(), "code", q.Get("state"), "browser-cookie", ""))
+}
+
+func TestAbandonedReauthorizationRemainsBlocked(t *testing.T) {
+	m, p, store := setupManager(t)
+	q := start(t, m, p)
+	store.err = errors.New("unavailable")
+	require.ErrorIs(t, m.Callback(t.Context(), "code", q.Get("state"), "browser-cookie", ""), ErrPersistence)
+	start(t, m, p)
+	assert.True(t, m.Active())
+	require.NoError(t, m.Load(p.credentials()))
+	_, err := m.Credentials(t.Context())
+	require.ErrorIs(t, err, ErrReauthorization)
+}
+
+func TestCredentialEditCannotUnblockIdentityMismatch(t *testing.T) {
+	m, p, store := setupManager(t)
+	store.ic.Credentials = p.credentials()
+	q := start(t, m, p)
+	p.user = "different-user"
+	require.ErrorIs(t, m.Callback(t.Context(), "code", q.Get("state"), "browser-cookie", ""), ErrReauthorization)
+	require.NoError(t, m.EditCredentials(t.Context(), nil, true))
+	assert.Empty(t, store.ic.Credentials["oauth_access_token"])
+	assert.Empty(t, store.ic.Credentials["oauth_refresh_token"])
+	p.user = "expected-user"
+	_, err := m.Credentials(t.Context())
+	require.ErrorIs(t, err, ErrReauthorization)
+}
+
+func TestCredentialEditDoesNotBypassLoadedBinding(t *testing.T) {
+	m, p, store := setupManager(t)
+	q := start(t, m, p)
+	require.NoError(t, m.Callback(t.Context(), "code", q.Get("state"), "browser-cookie", ""))
+	store.ic.Credentials["oauth_issuer"] += "/changed"
+	restarted := New("primer", store)
+	require.NoError(t, restarted.EditCredentials(t.Context(), nil, true))
+	require.NoError(t, restarted.Load(store.ic.Credentials))
+	assert.Empty(t, restarted.creds["oauth_access_token"])
+	assert.Empty(t, restarted.creds["oauth_refresh_token"])
+}
+
+func TestReauthorizationSettingsChangeClearsPreviousGuestToken(t *testing.T) {
+	m, p, store := setupManager(t)
+	store.ic.Credentials = p.credentials()
+	store.ic.Credentials["oauth_token_key"] = "old_key"
+	store.ic.Credentials["old_key"] = "old-access"
+	store.ic.Credentials["tasks_api_key"] = "other-access"
+	q := start(t, m, p)
+	require.NoError(t, m.Callback(t.Context(), "code", q.Get("state"), "browser-cookie", ""))
+	assert.Empty(t, store.ic.Credentials["old_key"])
+	assert.Empty(t, store.ic.Credentials["tasks_api_key"])
+}

--- a/pluginoauth/settings.go
+++ b/pluginoauth/settings.go
@@ -1,0 +1,117 @@
+package pluginoauth
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"maps"
+
+	mcp "github.com/daltoniam/switchboard"
+)
+
+var settingsKeys = []string{"oauth_issuer", "oauth_client_id", "oauth_token_key", "oauth_subject", "oauth_email", "oauth_scopes"}
+
+func settingsBinding(creds mcp.Credentials) string {
+	values := make([]string, 0, len(settingsKeys))
+	for _, key := range settingsKeys {
+		values = append(values, creds[key])
+	}
+	data, _ := json.Marshal(values)
+	hash := sha256.Sum256(data)
+	return base64.RawURLEncoding.EncodeToString(hash[:])
+}
+
+func ManagedCredential(key string, creds mcp.Credentials) bool {
+	switch key {
+	case "oauth_access_token", "oauth_refresh_token", "oauth_expires_at", "oauth_settings_binding", "oauth_client_secret":
+		return true
+	}
+	return key != "" && key == creds["oauth_token_key"]
+}
+
+func clearTokens(creds mcp.Credentials) {
+	for key := range creds {
+		if ManagedCredential(key, creds) {
+			delete(creds, key)
+		}
+	}
+}
+
+func MergeCredentials(current, updates mcp.Credentials) mcp.Credentials {
+	next := maps.Clone(current)
+	if next == nil {
+		next = mcp.Credentials{}
+	}
+	for key, value := range updates {
+		if !ManagedCredential(key, current) && !ManagedCredential(key, updates) {
+			next[key] = value
+		}
+	}
+	if !sameSettings(current, next) || (next["oauth_settings_binding"] != "" && next["oauth_settings_binding"] != settingsBinding(next)) {
+		delete(next, current["oauth_token_key"])
+		clearTokens(next)
+	}
+	return next
+}
+
+func updateIntegration(store Store, name string, update func(*mcp.IntegrationConfig) error) error {
+	if store == nil {
+		return ErrPersistence
+	}
+	if atomic, ok := store.(mcp.IntegrationConfigUpdater); ok {
+		return atomic.UpdateIntegration(name, update)
+	}
+	existing, ok := store.GetIntegration(name)
+	if !ok || existing == nil {
+		return ErrPersistence
+	}
+	ic := *existing
+	ic.Credentials = maps.Clone(existing.Credentials)
+	if err := update(&ic); err != nil {
+		return err
+	}
+	return store.SetIntegration(name, &ic)
+}
+
+func (m *Manager) EditCredentials(ctx context.Context, updates mcp.Credentials, enabled bool) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.dirty {
+		if err := m.finish(ctx); err != nil {
+			return err
+		}
+	}
+	var next mcp.Credentials
+	err := updateIntegration(m.store, m.name, func(ic *mcp.IntegrationConfig) error {
+		next = MergeCredentials(ic.Credentials, updates)
+		if m.verified && !m.blocked && m.creds != nil && sameSettings(m.creds, next) {
+			for key := range next {
+				if ManagedCredential(key, next) {
+					delete(next, key)
+				}
+			}
+			for key, value := range m.creds {
+				if ManagedCredential(key, m.creds) {
+					next[key] = value
+				}
+			}
+		}
+		ic.Credentials, ic.Enabled = next, enabled
+		return nil
+	})
+	if err != nil {
+		return ErrPersistence
+	}
+	changed := m.creds == nil || !sameSettings(m.creds, next)
+	m.pending = nil
+	m.creds = maps.Clone(next)
+	m.baseline = maps.Clone(next)
+	if changed {
+		m.metadata, m.verified, m.blocked = nil, false, false
+	}
+	if !Configured(next) {
+		m.creds = nil
+	}
+	return nil
+}

--- a/wasm/loader.go
+++ b/wasm/loader.go
@@ -57,6 +57,20 @@ func (l *Loader) LoadPlugin(ctx context.Context, path string, nameOverride strin
 		mod.SetName(nameOverride)
 	}
 
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	name := mod.Name()
+	if old, ok := l.modules[name]; ok {
+		if err := old.Close(ctx); err != nil {
+			_ = mod.Close(ctx)
+			return fmt.Errorf("close previous WASM module: %w", err)
+		}
+		l.reg.Unregister(name)
+		delete(l.modules, name)
+	}
+
+	mod.SetConfigService(l.cfgMgr)
+
 	mergedCreds := mcp.Credentials{}
 	for _, key := range mod.CredentialKeys() {
 		mergedCreds[key] = ""
@@ -116,49 +130,52 @@ func (l *Loader) LoadPlugin(ctx context.Context, path string, nameOverride strin
 	// credential schema changed. Startup loading must never rewrite unrelated
 	// config state or silently enable a plugin.
 	if !hasExisting || !reflect.DeepEqual(existing, ic) {
-		if err := l.cfgMgr.SetIntegration(mod.Name(), ic); err != nil {
+		if err := l.mergeCredentialSchema(mod.Name(), mod.CredentialKeys(), ic); err != nil {
 			mod.Close(ctx) //nolint:errcheck
 			return fmt.Errorf("persist WASM module %q configuration: %w", path, err)
 		}
 	}
-
-	l.mu.Lock()
-	if old, ok := l.modules[mod.Name()]; ok {
-		l.reg.Unregister(mod.Name())
-		old.Close(ctx) //nolint:errcheck
-		delete(l.modules, mod.Name())
-	}
-	l.mu.Unlock()
 
 	if err := l.reg.Register(mod); err != nil {
 		mod.Close(ctx) //nolint:errcheck
 		return fmt.Errorf("register WASM module %q: %w", path, err)
 	}
 
-	l.mu.Lock()
 	l.modules[mod.Name()] = mod
-	l.mu.Unlock()
 
 	log.Printf("Live-loaded WASM integration %q from %s", mod.Name(), path)
 	return nil
 }
 
+func (l *Loader) mergeCredentialSchema(name string, keys []string, fallback *mcp.IntegrationConfig) error {
+	if updater, ok := l.cfgMgr.(mcp.IntegrationConfigUpdater); ok {
+		return updater.UpdateIntegration(name, func(ic *mcp.IntegrationConfig) error {
+			if ic.Credentials == nil {
+				ic.Credentials = mcp.Credentials{}
+			}
+			for _, key := range keys {
+				if _, exists := ic.Credentials[key]; !exists {
+					ic.Credentials[key] = ""
+				}
+			}
+			return nil
+		})
+	}
+	return l.cfgMgr.SetIntegration(name, fallback)
+}
+
 // UnloadPlugin removes a WASM module from the registry and closes it.
 func (l *Loader) UnloadPlugin(ctx context.Context, name string) error {
 	l.mu.Lock()
-	mod, ok := l.modules[name]
-	if ok {
+	defer l.mu.Unlock()
+	if mod, ok := l.modules[name]; ok {
+		if err := mod.Close(ctx); err != nil {
+			return err
+		}
 		delete(l.modules, name)
 	}
-	l.mu.Unlock()
-
-	if !ok {
-		l.reg.Unregister(name)
-		return nil
-	}
-
 	l.reg.Unregister(name)
-	return mod.Close(ctx)
+	return nil
 }
 
 // Runtime returns the underlying wazero Runtime.

--- a/wasm/loader_config_concurrent_test.go
+++ b/wasm/loader_config_concurrent_test.go
@@ -1,0 +1,58 @@
+package wasm
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/daltoniam/switchboard/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type schemaConfigBarrier struct {
+	mcp.ConfigService
+	once   sync.Once
+	rotate func()
+}
+
+func (s *schemaConfigBarrier) GetIntegration(name string) (*mcp.IntegrationConfig, bool) {
+	ic, ok := s.ConfigService.GetIntegration(name)
+	s.once.Do(s.rotate)
+	return ic, ok
+}
+
+func (s *schemaConfigBarrier) UpdateIntegration(name string, update func(*mcp.IntegrationConfig) error) error {
+	return s.ConfigService.(mcp.IntegrationConfigUpdater).UpdateIntegration(name, update)
+}
+
+func TestLoadPluginSchemaMergePreservesFreshCredentials(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	store, err := config.NewManager()
+	require.NoError(t, err)
+	require.NoError(t, store.SetIntegration("example", &mcp.IntegrationConfig{Credentials: mcp.Credentials{"oauth_refresh_token": "before"}}))
+	barrier := &schemaConfigBarrier{ConfigService: store, rotate: func() {
+		require.NoError(t, store.SetIntegration("example", &mcp.IntegrationConfig{
+			Credentials: mcp.Credentials{"oauth_refresh_token": "after", "unrelated": "updated"},
+			ToolGlobs:   []string{"example_echo"},
+			Identities:  map[string]mcp.IntegrationIdentity{"work": {Metadata: map[string]string{"label": "keep"}}},
+		}))
+	}}
+	rt, err := NewRuntime(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rt.Close(t.Context()) })
+	path := filepath.Join(t.TempDir(), "example.wasm")
+	require.NoError(t, os.WriteFile(path, exampleWasm, 0600))
+	loader := NewLoader(rt, newLoaderRegistry(), barrier)
+	require.NoError(t, loader.LoadPlugin(t.Context(), path, ""))
+	require.NoError(t, store.Load())
+	saved, _ := store.GetIntegration("example")
+	assert.Equal(t, "after", saved.Credentials["oauth_refresh_token"])
+	assert.Equal(t, "updated", saved.Credentials["unrelated"])
+	assert.Contains(t, saved.Credentials, "api_key")
+	assert.Contains(t, saved.Credentials, "base_url")
+	assert.Equal(t, []string{"example_echo"}, saved.ToolGlobs)
+	assert.Equal(t, "keep", saved.Identities["work"].Metadata["label"])
+}

--- a/wasm/module.go
+++ b/wasm/module.go
@@ -7,6 +7,7 @@ import (
 
 	mcp "github.com/daltoniam/switchboard"
 	"github.com/daltoniam/switchboard/marketplace"
+	"github.com/daltoniam/switchboard/pluginoauth"
 )
 
 var _ mcp.FieldCompactionIntegration = (*Module)(nil)
@@ -49,11 +50,7 @@ func (m *Module) Name() string {
 
 // Configure implements mcp.Integration.
 func (m *Module) Configure(ctx context.Context, creds mcp.Credentials) error {
-	credsJSON, err := json.Marshal(creds)
-	if err != nil {
-		return fmt.Errorf("wasm: marshal credentials: %w", err)
-	}
-
+	name := m.Name()
 	if m.closed.Load() {
 		return ErrModuleClosed
 	}
@@ -63,6 +60,28 @@ func (m *Module) Configure(ctx context.Context, creds mcp.Credentials) error {
 		return ErrModuleClosed
 	}
 
+	if pluginoauth.Configured(creds) {
+		if m.oauth == nil {
+			m.oauth = pluginoauth.New(name, m.cfgMgr)
+		}
+		m.oauthErr = m.oauth.Load(creds)
+		return m.oauthErr
+	}
+	if m.oauth != nil && m.oauth.Active() {
+		if err := m.oauth.Flush(ctx); err != nil {
+			return err
+		}
+		m.oauth = nil
+	}
+	m.oauthErr = nil
+	return m.configureGuest(ctx, creds)
+}
+
+func (m *Module) configureGuest(ctx context.Context, creds mcp.Credentials) error {
+	credsJSON, err := json.Marshal(creds)
+	if err != nil {
+		return fmt.Errorf("wasm: marshal credentials: %w", err)
+	}
 	ptr, size, err := writeToGuest(ctx, m.mod, credsJSON)
 	if err != nil {
 		return fmt.Errorf("wasm: write credentials: %w", err)
@@ -149,6 +168,10 @@ func (m *Module) Execute(ctx context.Context, toolName mcp.ToolName, args map[st
 		return &mcp.ToolResult{Data: ErrModuleClosed.Error(), IsError: true}, nil
 	}
 
+	if err := m.prepareOAuth(ctx); err != nil {
+		return mcp.ErrResult(err)
+	}
+
 	ptr, size, err := writeToGuest(ctx, m.mod, reqJSON)
 	if err != nil {
 		return &mcp.ToolResult{Data: err.Error(), IsError: true}, nil
@@ -185,6 +208,9 @@ func (m *Module) Healthy(ctx context.Context) bool {
 	m.callMu.Lock()
 	defer m.callMu.Unlock()
 	if m.closed.Load() {
+		return false
+	}
+	if err := m.prepareOAuth(ctx); err != nil {
 		return false
 	}
 	results, err := m.fnHealthy.Call(ctx)

--- a/wasm/oauth.go
+++ b/wasm/oauth.go
@@ -1,0 +1,91 @@
+package wasm
+
+import (
+	"context"
+	"errors"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/daltoniam/switchboard/pluginoauth"
+)
+
+var _ mcp.OAuthIntegration = (*Module)(nil)
+
+func (m *Module) SetConfigService(cfg mcp.ConfigService) {
+	m.callMu.Lock()
+	defer m.callMu.Unlock()
+	m.cfgMgr = cfg
+}
+
+func (m *Module) StartOAuth(ctx context.Context, creds mcp.Credentials, redirectURI, browser string) (string, error) {
+	name := m.Name()
+	m.callMu.Lock()
+	defer m.callMu.Unlock()
+	if m.closed.Load() {
+		return "", ErrModuleClosed
+	}
+	if m.cfgMgr == nil {
+		return "", pluginoauth.ErrPersistence
+	}
+	if m.oauth == nil {
+		m.oauth = pluginoauth.New(name, m.cfgMgr)
+	}
+	return m.oauth.Start(ctx, creds, redirectURI, browser)
+}
+
+func (m *Module) CompleteOAuth(ctx context.Context, code, state, browser, issuer string) error {
+	m.callMu.Lock()
+	defer m.callMu.Unlock()
+	if m.closed.Load() {
+		return ErrModuleClosed
+	}
+	if m.oauth == nil {
+		return pluginoauth.ErrState
+	}
+	err := m.oauth.Callback(ctx, code, state, browser, issuer)
+	if err == nil {
+		m.oauthErr = nil
+	}
+	return err
+}
+
+func (m *Module) prepareOAuth(ctx context.Context) error {
+	if m.oauthErr != nil {
+		return m.oauthErr
+	}
+	if m.oauth == nil || !m.oauth.Active() {
+		return nil
+	}
+	creds, err := m.oauth.Credentials(ctx)
+	if err != nil {
+		return err
+	}
+	if err := m.configureGuest(ctx, creds); err != nil {
+		return errors.New("oauth: guest configuration failed")
+	}
+	return nil
+}
+
+func (m *Module) EditCredentials(ctx context.Context, updates mcp.Credentials, enabled bool) error {
+	name := m.Name()
+	m.callMu.Lock()
+	defer m.callMu.Unlock()
+	if m.closed.Load() {
+		return ErrModuleClosed
+	}
+	if m.oauth == nil {
+		m.oauth = pluginoauth.New(name, m.cfgMgr)
+	}
+	if err := m.oauth.EditCredentials(ctx, updates, enabled); err != nil {
+		return err
+	}
+	ic, ok := m.cfgMgr.GetIntegration(name)
+	if !ok {
+		return pluginoauth.ErrPersistence
+	}
+	if pluginoauth.Configured(ic.Credentials) {
+		m.oauthErr = m.oauth.Load(ic.Credentials)
+		return nil
+	}
+	m.oauth, m.oauthErr = nil, nil
+	return m.configureGuest(ctx, ic.Credentials)
+}

--- a/wasm/oauth_flow_test.go
+++ b/wasm/oauth_flow_test.go
@@ -1,0 +1,114 @@
+package wasm
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOAuthModuleCodeRefreshAndGuestHTTP(t *testing.T) {
+	var tokens, apiCalls atomic.Int32
+	var challenge string
+	var issuer *httptest.Server
+	issuer = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]string{"issuer": issuer.URL, "authorization_endpoint": issuer.URL + "/authorize", "token_endpoint": issuer.URL + "/token", "userinfo_endpoint": issuer.URL + "/userinfo", "jwks_uri": issuer.URL + "/jwks"}))
+		case "/token":
+			tokens.Add(1)
+			require.NoError(t, r.ParseForm())
+			assert.Empty(t, r.Form.Get("client_secret"))
+			access, refresh, expires := "access-initial", "refresh-initial", 30
+			if r.Form.Get("grant_type") == "refresh_token" {
+				assert.Equal(t, "refresh-initial", r.Form.Get("refresh_token"))
+				access, refresh, expires = "access-refreshed", "refresh-rotated", 3600
+			} else {
+				hash := sha256.Sum256([]byte(r.Form.Get("code_verifier")))
+				assert.Equal(t, challenge, base64.RawURLEncoding.EncodeToString(hash[:]))
+			}
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"access_token": access, "refresh_token": refresh, "expires_in": expires, "token_type": "Bearer"}))
+		case "/userinfo":
+			assert.Contains(t, []string{"Bearer access-initial", "Bearer access-refreshed"}, r.Header.Get("Authorization"))
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]string{"sub": "expected-user", "email": "expected@example.com"}))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer issuer.Close()
+	previousTransport := http.DefaultTransport
+	http.DefaultTransport = issuer.Client().Transport
+	t.Cleanup(func() { http.DefaultTransport = previousTransport })
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiCalls.Add(1)
+		assert.Equal(t, "Bearer access-refreshed", r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+	}))
+	defer api.Close()
+	creds := oauthCredentials()
+	creds["oauth_issuer"], creds["base_url"] = issuer.URL, api.URL
+	cfg := newLoaderConfig(map[string]*mcp.IntegrationConfig{"example": {Enabled: true, Credentials: creds, ToolGlobs: []string{"example_*"}}})
+	mod := loadTestModule(t)
+	mod.SetConfigService(cfg)
+	require.NoError(t, mod.Configure(t.Context(), creds))
+	raw, err := mod.StartOAuth(t.Context(), creds, "http://127.0.0.1:3847/api/integrations/example/oauth/callback", "browser")
+	require.NoError(t, err)
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	challenge = u.Query().Get("code_challenge")
+	cfg.setErr = errors.New("disk full")
+	require.Error(t, mod.CompleteOAuth(t.Context(), "code", u.Query().Get("state"), "browser", issuer.URL))
+	require.NoError(t, mod.Configure(t.Context(), creds))
+	cfg.setErr = nil
+	assert.False(t, mod.Healthy(t.Context()))
+	assert.Equal(t, int32(2), tokens.Load())
+	var wg sync.WaitGroup
+	for range 4 {
+		wg.Go(func() {
+			result, err := mod.Execute(t.Context(), "example_list_items", map[string]any{})
+			assert.NoError(t, err)
+			assert.True(t, result.IsError)
+		})
+	}
+	wg.Wait()
+	assert.Equal(t, int32(2), tokens.Load())
+	assert.Equal(t, int32(5), apiCalls.Load(), "401 responses must not replay API calls")
+	assert.Equal(t, "refresh-rotated", cfg.cfg.Integrations["example"].Credentials["oauth_refresh_token"])
+	memory, ok := mod.mod.Memory().Read(0, mod.mod.Memory().Size())
+	require.True(t, ok)
+	for _, secret := range []string{"refresh-initial", "refresh-rotated", "oauth_refresh_token", "code_verifier"} {
+		assert.False(t, strings.Contains(string(memory), secret))
+	}
+	restarted := loadTestModule(t)
+	restarted.SetConfigService(cfg)
+	require.NoError(t, restarted.Configure(t.Context(), cfg.cfg.Integrations["example"].Credentials))
+	_, err = restarted.Execute(t.Context(), "example_list_items", map[string]any{})
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), tokens.Load())
+	assert.Equal(t, int32(6), apiCalls.Load())
+}
+
+func TestOAuthIncompleteConfigurationFailsClosed(t *testing.T) {
+	mod := loadTestModule(t)
+	require.NoError(t, mod.Configure(t.Context(), mcp.Credentials{"base_url": "https://api.example.com", "api_key": "generic"}))
+	err := mod.Configure(t.Context(), mcp.Credentials{"oauth_refresh_token": "native-secret-without-issuer", "api_key": "generic", "base_url": "https://api.example.com"})
+	require.Error(t, err)
+	result, err := mod.Execute(t.Context(), "example_echo", map[string]any{"message": "must-not-run"})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	memory, ok := mod.mod.Memory().Read(0, mod.mod.Memory().Size())
+	require.True(t, ok)
+	assert.False(t, strings.Contains(string(memory), "native-secret-without-issuer"))
+}

--- a/wasm/oauth_security_test.go
+++ b/wasm/oauth_security_test.go
@@ -1,0 +1,91 @@
+package wasm
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func dirtyOAuthModule(t *testing.T) (*Loader, string, *loaderConfig, *Module) {
+	t.Helper()
+	refreshes := 0
+	t.Cleanup(func() { assert.Equal(t, 1, refreshes) })
+	var issuer *httptest.Server
+	issuer = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]string{"issuer": issuer.URL, "authorization_endpoint": issuer.URL + "/authorize", "token_endpoint": issuer.URL + "/token", "userinfo_endpoint": issuer.URL + "/userinfo", "jwks_uri": issuer.URL + "/jwks"}))
+		case "/token":
+			refreshes++
+			require.NoError(t, r.ParseForm())
+			assert.Equal(t, "rotation-before", r.Form.Get("refresh_token"))
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"access_token": "access-after", "refresh_token": "rotation-after", "token_type": "Bearer", "expires_in": 3600}))
+		case "/userinfo":
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]string{"sub": "expected-user", "email": "expected@example.com"}))
+		default:
+			t.Errorf("unexpected endpoint")
+		}
+	}))
+	t.Cleanup(issuer.Close)
+	previous := http.DefaultTransport
+	http.DefaultTransport = issuer.Client().Transport
+	t.Cleanup(func() { http.DefaultTransport = previous })
+	creds := oauthCredentials()
+	creds["oauth_issuer"], creds["api_key"] = issuer.URL, ""
+	creds["oauth_refresh_token"], creds["oauth_expires_at"] = "rotation-before", time.Now().Format(time.RFC3339)
+	cfg := newLoaderConfig(map[string]*mcp.IntegrationConfig{"example": {Enabled: true, Credentials: creds}})
+	loader, path := newLoaderForTest(t, cfg)
+	require.NoError(t, loader.LoadPlugin(t.Context(), path, ""))
+	mod := loader.modules["example"]
+	cfg.setErr = errors.New("storage unavailable")
+	_, err := mod.oauth.Credentials(t.Context())
+	require.Error(t, err)
+	return loader, path, cfg, mod
+}
+
+func TestOAuthCloseAndUnloadPreserveUnsavedRotation(t *testing.T) {
+	for _, action := range []string{"close", "unload", "reload"} {
+		t.Run(action, func(t *testing.T) {
+			loader, path, cfg, mod := dirtyOAuthModule(t)
+			var err error
+			switch action {
+			case "close":
+				err = mod.Close(t.Context())
+			case "unload":
+				err = loader.UnloadPlugin(t.Context(), "example")
+			case "reload":
+				err = loader.LoadPlugin(t.Context(), path, "")
+			}
+			require.Error(t, err)
+			assert.False(t, mod.closed.Load())
+			assert.Same(t, mod, loader.modules["example"])
+			registered, ok := loader.reg.Get("example")
+			require.True(t, ok)
+			assert.Same(t, mod, registered)
+			cfg.setErr = nil
+			require.NoError(t, mod.Close(t.Context()))
+			assert.Equal(t, "rotation-after", cfg.cfg.Integrations["example"].Credentials["oauth_refresh_token"])
+		})
+	}
+}
+
+func TestOAuthReloadReadsCredentialsAfterOldFlush(t *testing.T) {
+	loader, path, cfg, old := dirtyOAuthModule(t)
+	cfg.setErr = nil
+	require.NoError(t, loader.LoadPlugin(t.Context(), path, ""))
+	assert.True(t, old.closed.Load())
+	replacement := loader.modules["example"]
+	require.NotSame(t, old, replacement)
+	require.NotNil(t, replacement.oauth)
+	guest, err := replacement.oauth.Credentials(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "access-after", guest["api_key"])
+	assert.Equal(t, "rotation-after", cfg.cfg.Integrations["example"].Credentials["oauth_refresh_token"])
+}

--- a/wasm/oauth_test.go
+++ b/wasm/oauth_test.go
@@ -1,0 +1,79 @@
+package wasm
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/daltoniam/switchboard/pluginoauth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func oauthCredentials() mcp.Credentials {
+	return mcp.Credentials{
+		"oauth_issuer":    "https://clerk.primerlms.com",
+		"oauth_client_id": "public-client",
+		"oauth_token_key": "api_key",
+		"oauth_subject":   "expected-user",
+		"oauth_email":     "expected@example.com",
+		"base_url":        "https://api.example.com",
+	}
+}
+
+func TestOAuthModuleAvailabilityAndUnauthorized(t *testing.T) {
+	mod := loadTestModule(t)
+	var integration mcp.Integration = mod
+	_, ok := integration.(mcp.OAuthIntegration)
+	require.True(t, ok)
+	mod.SetConfigService(newLoaderConfig(map[string]*mcp.IntegrationConfig{"example": {Credentials: oauthCredentials()}}))
+	require.NoError(t, mod.Configure(t.Context(), oauthCredentials()))
+	require.NotNil(t, mod.oauth)
+	assert.False(t, mod.Healthy(t.Context()))
+	result, err := mod.Execute(t.Context(), "example_echo", map[string]any{"message": "must-not-run"})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	assert.Equal(t, pluginoauth.ErrReauthorization.Error(), result.Data)
+	require.NoError(t, mod.Configure(t.Context(), mcp.Credentials{"base_url": "https://api.example.com", "api_key": "generic-key"}))
+	assert.Nil(t, mod.oauth)
+	result, err = mod.Execute(t.Context(), "example_echo", map[string]any{"message": "generic-works"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Data, "generic-works")
+}
+
+func TestOAuthNativeSecretsNeverEnterGuestMemory(t *testing.T) {
+	mod := loadTestModule(t)
+	creds := oauthCredentials()
+	creds["oauth_refresh_token"] = "unique-native-refresh-secret"
+	creds["oauth_access_token"] = "unique-native-access-not-yet-verified"
+	mod.SetConfigService(newLoaderConfig(map[string]*mcp.IntegrationConfig{"example": {Credentials: creds}}))
+	require.NoError(t, mod.Configure(t.Context(), creds))
+	memory, ok := mod.mod.Memory().Read(0, mod.mod.Memory().Size())
+	require.True(t, ok)
+	assert.False(t, strings.Contains(string(memory), creds["oauth_refresh_token"]))
+	assert.False(t, strings.Contains(string(memory), creds["oauth_access_token"]))
+}
+
+func TestOAuthLoaderInjectsConfigurationBeforeConfigure(t *testing.T) {
+	creds := oauthCredentials()
+	creds["api_key"] = ""
+	cfg := newLoaderConfig(map[string]*mcp.IntegrationConfig{"custom": {Enabled: true, Credentials: creds, ToolGlobs: []string{"example_echo"}}})
+	loader, path := newLoaderForTest(t, cfg)
+	require.NoError(t, loader.LoadPlugin(context.Background(), path, "custom"))
+	mod := loader.modules["custom"]
+	require.NotNil(t, mod)
+	require.NotNil(t, mod.oauth)
+	assert.Same(t, cfg, mod.cfgMgr)
+	assert.Zero(t, cfg.setCalls)
+	assert.False(t, mod.Healthy(t.Context()))
+}
+
+func TestOAuthClosedModule(t *testing.T) {
+	mod := loadTestModule(t)
+	require.NoError(t, mod.Close(t.Context()))
+	_, err := mod.StartOAuth(t.Context(), oauthCredentials(), "redirect", "cookie")
+	assert.ErrorIs(t, err, ErrModuleClosed)
+	assert.ErrorIs(t, mod.CompleteOAuth(t.Context(), "code", "state", "cookie", ""), ErrModuleClosed)
+}

--- a/wasm/runtime.go
+++ b/wasm/runtime.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 
 	mcp "github.com/daltoniam/switchboard"
+	"github.com/daltoniam/switchboard/pluginoauth"
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
@@ -104,8 +105,11 @@ func (r *Runtime) Close(ctx context.Context) error {
 // touch m.mod or m.fn*. closed is set by Close so racing callers return
 // ErrModuleClosed instead of dereferencing a freed memory instance.
 type Module struct {
-	callMu sync.Mutex
-	closed atomic.Bool
+	callMu   sync.Mutex
+	closed   atomic.Bool
+	cfgMgr   mcp.ConfigService
+	oauth    *pluginoauth.Manager
+	oauthErr error
 
 	mod          api.Module
 	nameOverride string
@@ -210,13 +214,16 @@ func (m *Module) CompactSpec(toolName mcp.ToolName) ([]mcp.CompactField, bool) {
 // nil-returning interface methods, an empty result) without touching the
 // underlying wazero module.
 func (m *Module) Close(ctx context.Context) error {
-	// Set the flag before acquiring the lock so in-flight callers fail fast
-	// when they re-check it. The lock then waits for any active Call to
-	// complete before we hand the module to wazero for teardown.
-	if !m.closed.CompareAndSwap(false, true) {
-		return nil
-	}
 	m.callMu.Lock()
 	defer m.callMu.Unlock()
+	if m.closed.Load() {
+		return nil
+	}
+	if m.oauth != nil {
+		if err := m.oauth.Flush(ctx); err != nil {
+			return err
+		}
+	}
+	m.closed.Store(true)
 	return m.mod.Close(ctx)
 }

--- a/web/marketplace_security_test.go
+++ b/web/marketplace_security_test.go
@@ -1,0 +1,151 @@
+package web
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/daltoniam/switchboard/marketplace"
+	"github.com/daltoniam/switchboard/pluginoauth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mutationLoader struct {
+	loads     int
+	unloads   int
+	unloadErr error
+}
+
+func (l *mutationLoader) LoadPlugin(context.Context, string, string) error {
+	l.loads++
+	return nil
+}
+
+func (l *mutationLoader) UnloadPlugin(context.Context, string) error {
+	l.unloads++
+	return l.unloadErr
+}
+
+func marketplaceRequest(path, form string) *http.Request {
+	r := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:3847"+path, strings.NewReader(form))
+	r.RemoteAddr = "127.0.0.1:12345"
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	return r
+}
+
+func TestMarketplaceMutationsRejectUnsafeRequests(t *testing.T) {
+	var downloads atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		downloads.Add(1)
+		_, _ = rw.Write([]byte("untrusted wasm"))
+	}))
+	defer server.Close()
+	for _, path := range []string{"install", "install-url", "upload", "load-path", "uninstall", "update", "check-updates", "auto-update", "add-manifest", "remove-manifest"} {
+		t.Run(path, func(t *testing.T) {
+			for _, attack := range []struct {
+				name   string
+				origin string
+				site   string
+				host   string
+				peer   string
+			}{
+				{name: "foreign origin", origin: "https://evil.example"},
+				{name: "null origin", origin: "null"},
+				{name: "wrong origin port", origin: "http://127.0.0.1:3848"},
+				{name: "cross site", site: "cross-site"},
+				{name: "same site", site: "same-site"},
+				{name: "matching origin cross site", origin: "http://127.0.0.1:3847", site: "cross-site"},
+				{name: "rebound host", host: "evil.example:3847", origin: "http://evil.example:3847"},
+				{name: "wrong host port", host: "127.0.0.1:3848"},
+				{name: "nonlocal peer", peer: "192.0.2.1:12345"},
+				{name: "localhost mismatched origin", host: "localhost:3847", origin: "http://127.0.0.1:3847"},
+			} {
+				t.Run(attack.name, func(t *testing.T) {
+					w, _, _ := setupTestWeb()
+					w.marketplace = marketplace.NewManager(marketplace.Config{}, t.TempDir(), func(marketplace.Config) error { return nil })
+					ip, err := w.marketplace.InstallFromBytes("primer", []byte("trusted wasm"))
+					require.NoError(t, err)
+					loader := &mutationLoader{}
+					w.wasmLoader = loader
+					before := w.marketplace.Config()
+					r := marketplaceRequest("/plugins/"+path, url.Values{"name": {"primer"}, "url": {server.URL + "/primer.wasm"}, "path": {ip.Path}, "enabled": {"true"}}.Encode())
+					if path == "upload" {
+						r = uploadPlugin(t, "primer", []byte("untrusted wasm"))
+						r.Host, r.RemoteAddr = "127.0.0.1:3847", "127.0.0.1:12345"
+					}
+					r.Header.Set("Origin", attack.origin)
+					r.Header.Set("Sec-Fetch-Site", attack.site)
+					if attack.host != "" {
+						r.Host = attack.host
+					}
+					if attack.peer != "" {
+						r.RemoteAddr = attack.peer
+					}
+					rr := httptest.NewRecorder()
+					w.Handler().ServeHTTP(rr, r)
+					assert.Equal(t, http.StatusForbidden, rr.Code)
+					assert.Zero(t, loader.loads)
+					assert.Zero(t, loader.unloads)
+					assert.Equal(t, before, w.marketplace.Config())
+					data, err := os.ReadFile(ip.Path)
+					require.NoError(t, err)
+					assert.Equal(t, "trusted wasm", string(data))
+				})
+			}
+		})
+	}
+	assert.Zero(t, downloads.Load())
+}
+
+func TestMarketplaceLocalRequestsWork(t *testing.T) {
+	for _, tc := range []struct{ name, host, origin, site, peer string }{
+		{name: "native", host: "127.0.0.1:3847", peer: "127.0.0.1:12345"},
+		{name: "UI", host: "127.0.0.1:3847", origin: "http://127.0.0.1:3847", site: "same-origin", peer: "127.0.0.1:12345"},
+		{name: "localhost UI", host: "localhost:3847", origin: "http://localhost:3847", site: "same-origin", peer: "[::1]:12345"},
+		{name: "native none", host: "localhost:3847", site: "none", peer: "127.0.0.1:12345"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w, _, _ := setupTestWeb()
+			loader := &mutationLoader{}
+			w.wasmLoader = loader
+			r := marketplaceRequest("/plugins/load-path", "path=/tmp/primer.wasm")
+			r.Host, r.RemoteAddr = tc.host, tc.peer
+			r.Header.Set("Origin", tc.origin)
+			r.Header.Set("Sec-Fetch-Site", tc.site)
+			rr := httptest.NewRecorder()
+			w.Handler().ServeHTTP(rr, r)
+			assert.Equal(t, http.StatusSeeOther, rr.Code)
+			assert.Contains(t, rr.Header().Get("Location"), "success=")
+			assert.Equal(t, 1, loader.loads)
+		})
+	}
+}
+
+func TestPluginUninstallPreservesArtifactOnFlushFailure(t *testing.T) {
+	w, _, _ := setupTestWeb()
+	w.marketplace = marketplace.NewManager(marketplace.Config{}, t.TempDir(), func(marketplace.Config) error { return nil })
+	ip, err := w.marketplace.InstallFromBytes("primer", []byte("trusted wasm"))
+	require.NoError(t, err)
+	loader := &mutationLoader{unloadErr: pluginoauth.ErrPersistence}
+	w.wasmLoader = loader
+	rr := httptest.NewRecorder()
+	w.Handler().ServeHTTP(rr, marketplaceRequest("/plugins/uninstall", "name=primer"))
+	require.Equal(t, http.StatusSeeOther, rr.Code)
+	assert.Contains(t, rr.Header().Get("Location"), "error=")
+	assert.NotContains(t, rr.Header().Get("Location"), "success=")
+	assert.FileExists(t, ip.Path)
+	assert.Len(t, w.marketplace.InstalledPlugins(), 1)
+	assert.Equal(t, 1, loader.unloads)
+	loader.unloadErr = nil
+	rr = httptest.NewRecorder()
+	w.Handler().ServeHTTP(rr, marketplaceRequest("/plugins/uninstall", "name=primer"))
+	assert.Contains(t, rr.Header().Get("Location"), "success=")
+	assert.NoFileExists(t, ip.Path)
+	assert.Empty(t, w.marketplace.InstalledPlugins())
+}

--- a/web/plugin_oauth.go
+++ b/web/plugin_oauth.go
@@ -1,7 +1,6 @@
 package web
 
 import (
-	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -79,7 +78,10 @@ func (w *WebServer) handlePluginOAuthStart(rw http.ResponseWriter, r *http.Reque
 		return
 	}
 	secret := make([]byte, 32)
-	_, _ = rand.Read(secret)
+	if _, err := io.ReadFull(w.oauthRandReader, secret); err != nil {
+		http.Error(rw, "OAuth session creation failed; retry connecting", http.StatusInternalServerError)
+		return
+	}
 	browser := base64.RawURLEncoding.EncodeToString(secret)
 	callback := "/api/integrations/" + name + "/oauth/callback"
 	redirect := fmt.Sprintf("http://127.0.0.1:%d%s", w.port, callback)

--- a/web/plugin_oauth.go
+++ b/web/plugin_oauth.go
@@ -1,0 +1,191 @@
+package web
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"mime"
+	"net"
+	"net/http"
+	"strings"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/daltoniam/switchboard/pluginoauth"
+)
+
+func oauthResponseHeaders(rw http.ResponseWriter) {
+	rw.Header().Set("Cache-Control", "no-store")
+	rw.Header().Set("Referrer-Policy", "no-referrer")
+	rw.Header().Set("Content-Security-Policy", "default-src 'none'; frame-ancestors 'none'")
+	rw.Header().Set("X-Content-Type-Options", "nosniff")
+}
+
+func (w *WebServer) localOAuthRequest(r *http.Request, start bool) bool {
+	return w.localRequest(r, start, false)
+}
+
+func (w *WebServer) localRequest(r *http.Request, mutation, allowLocalhost bool) bool {
+	host := fmt.Sprintf("127.0.0.1:%d", w.port)
+	if allowLocalhost && r.Host == fmt.Sprintf("localhost:%d", w.port) {
+		host = r.Host
+	}
+	peer, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil || !net.ParseIP(peer).IsLoopback() || r.Host != host || w.port < 1 || w.port > 65535 {
+		return false
+	}
+	if !mutation {
+		return true
+	}
+	if origin := r.Header.Get("Origin"); origin != "" && origin != "http://"+host {
+		return false
+	}
+	site := r.Header.Get("Sec-Fetch-Site")
+	return site == "" || site == "same-origin" || site == "none"
+}
+
+func (w *WebServer) oauthIntegration(name string) (mcp.OAuthIntegration, bool) {
+	integration, ok := w.services.Registry.Get(name)
+	if !ok {
+		return nil, false
+	}
+	oauth, ok := integration.(mcp.OAuthIntegration)
+	return oauth, ok
+}
+
+func (w *WebServer) handlePluginOAuthStart(rw http.ResponseWriter, r *http.Request) {
+	oauthResponseHeaders(rw)
+	if r.Method != http.MethodPost {
+		rw.Header().Set("Allow", http.MethodPost)
+		http.Error(rw, "POST required", http.StatusMethodNotAllowed)
+		return
+	}
+	if !w.localOAuthRequest(r, true) {
+		http.Error(rw, "Local same-origin request required", http.StatusForbidden)
+		return
+	}
+	name := r.PathValue("name")
+	oauth, ok := w.oauthIntegration(name)
+	if !ok {
+		http.NotFound(rw, r)
+		return
+	}
+	creds, err := w.pluginOAuthCredentials(rw, r, name)
+	if err != nil {
+		http.Error(rw, "Invalid OAuth configuration", http.StatusBadRequest)
+		return
+	}
+	secret := make([]byte, 32)
+	_, _ = rand.Read(secret)
+	browser := base64.RawURLEncoding.EncodeToString(secret)
+	callback := "/api/integrations/" + name + "/oauth/callback"
+	redirect := fmt.Sprintf("http://127.0.0.1:%d%s", w.port, callback)
+	authorizeURL, err := oauth.StartOAuth(r.Context(), creds, redirect, browser)
+	if err != nil {
+		http.Error(rw, "OAuth start failed; check configuration and persistence", http.StatusBadRequest)
+		return
+	}
+	http.SetCookie(rw, &http.Cookie{Name: "switchboard_oauth", Value: browser, Path: callback, HttpOnly: true, SameSite: http.SameSiteLaxMode, MaxAge: 600})
+	rw.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(rw).Encode(map[string]string{"authorize_url": authorizeURL}); err != nil {
+		return
+	}
+}
+
+func (w *WebServer) pluginOAuthCredentials(rw http.ResponseWriter, r *http.Request, name string) (mcp.Credentials, error) {
+	var body struct {
+		Credentials mcp.Credentials `json:"credentials"`
+	}
+	if r.ContentLength != 0 {
+		mediaType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+		if err != nil || mediaType != "application/json" {
+			return nil, errors.New("invalid content type")
+		}
+		decoder := json.NewDecoder(http.MaxBytesReader(rw, r.Body, 64<<10))
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&body); err != nil {
+			return nil, errors.New("invalid body")
+		}
+		if err := decoder.Decode(new(any)); !errors.Is(err, io.EOF) {
+			return nil, errors.New("trailing body")
+		}
+	}
+	ic, ok := w.services.Config.GetIntegration(name)
+	if !ok || ic == nil {
+		return nil, errors.New("missing integration configuration")
+	}
+	creds := maps.Clone(ic.Credentials)
+	if creds == nil {
+		creds = mcp.Credentials{}
+	}
+	for key, value := range body.Credentials {
+		switch key {
+		case "oauth_access_token", "oauth_refresh_token", "oauth_expires_at", "oauth_client_secret":
+			return nil, errors.New("managed credential")
+		}
+		if strings.HasPrefix(key, "oauth_") && key != "oauth_issuer" && key != "oauth_client_id" && key != "oauth_scopes" && key != "oauth_token_key" && key != "oauth_subject" && key != "oauth_email" {
+			return nil, errors.New("unknown OAuth credential")
+		}
+		creds[key] = value
+	}
+	return creds, nil
+}
+
+func (w *WebServer) handlePluginOAuthCallback(rw http.ResponseWriter, r *http.Request) {
+	oauthResponseHeaders(rw)
+	if !w.localOAuthRequest(r, false) {
+		http.Error(rw, "Local request required", http.StatusForbidden)
+		return
+	}
+	name := r.PathValue("name")
+	oauth, ok := w.oauthIntegration(name)
+	if !ok {
+		http.NotFound(rw, r)
+		return
+	}
+	cookie, err := r.Cookie("switchboard_oauth")
+	query := r.URL.Query()
+	if err != nil || cookie.Value == "" || len(query["state"]) != 1 || query.Get("state") == "" || len(query["code"]) > 1 || len(query["iss"]) > 1 || len(r.URL.RawQuery) > 16<<10 {
+		http.Error(rw, "Invalid OAuth callback; connect again", http.StatusBadRequest)
+		return
+	}
+	code := query.Get("code")
+	if query.Has("error") {
+		code = ""
+	}
+	if err := oauth.CompleteOAuth(r.Context(), code, query.Get("state"), cookie.Value, query.Get("iss")); err != nil {
+		http.Error(rw, "OAuth connection failed; retry the integration or connect again", http.StatusBadRequest)
+		return
+	}
+	http.SetCookie(rw, &http.Cookie{Name: "switchboard_oauth", Path: "/api/integrations/" + name + "/oauth/callback", HttpOnly: true, SameSite: http.SameSiteLaxMode, MaxAge: -1})
+	w.notifyConfigChanged()
+	http.Redirect(rw, r, "/integrations/"+name, http.StatusSeeOther)
+}
+
+func managedOAuthCredential(key string, creds mcp.Credentials) bool {
+	return pluginoauth.ManagedCredential(key, creds)
+}
+
+func (w *WebServer) editPluginCredentials(r *http.Request, name string, updates mcp.Credentials, enabled bool) error {
+	integration, _ := w.services.Registry.Get(name)
+	if editor, ok := integration.(mcp.CredentialEditor); ok {
+		return editor.EditCredentials(r.Context(), updates, enabled)
+	}
+	update := func(ic *mcp.IntegrationConfig) error {
+		ic.Credentials = pluginoauth.MergeCredentials(ic.Credentials, updates)
+		ic.Enabled = enabled
+		return nil
+	}
+	if atomic, ok := w.services.Config.(mcp.IntegrationConfigUpdater); ok {
+		return atomic.UpdateIntegration(name, update)
+	}
+	existing, _ := w.services.Config.GetIntegration(name)
+	ic := cloneIntegrationConfig(existing)
+	if err := update(ic); err != nil {
+		return err
+	}
+	return w.services.Config.SetIntegration(name, ic)
+}

--- a/web/plugin_oauth_concurrent_test.go
+++ b/web/plugin_oauth_concurrent_test.go
@@ -1,0 +1,93 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/daltoniam/switchboard/config"
+	"github.com/daltoniam/switchboard/wasm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPluginOAuthConcurrentPUTRetainsRotatedTokensOnDisk(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cfg, err := config.NewManager()
+	require.NoError(t, err)
+	entered, release := make(chan struct{}), make(chan struct{})
+	var once sync.Once
+	unblock := func() { once.Do(func() { close(release) }) }
+	defer unblock()
+	var refreshes atomic.Int32
+	var issuer *httptest.Server
+	issuer = httptest.NewTLSServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			require.NoError(t, json.NewEncoder(rw).Encode(map[string]string{"issuer": issuer.URL, "authorization_endpoint": issuer.URL + "/authorize", "token_endpoint": issuer.URL + "/token", "userinfo_endpoint": issuer.URL + "/userinfo", "jwks_uri": issuer.URL + "/jwks"}))
+		case "/token":
+			if refreshes.Add(1) == 1 {
+				close(entered)
+				<-release
+			}
+			require.NoError(t, r.ParseForm())
+			assert.Equal(t, "rotation-before", r.Form.Get("refresh_token"))
+			require.NoError(t, json.NewEncoder(rw).Encode(map[string]any{"access_token": "access-after", "refresh_token": "rotation-after", "token_type": "Bearer", "expires_in": 3600}))
+		case "/userinfo":
+			require.NoError(t, json.NewEncoder(rw).Encode(map[string]string{"sub": "expected-user", "email": "expected@example.com"}))
+		default:
+			t.Errorf("unexpected endpoint")
+		}
+	}))
+	t.Cleanup(issuer.Close)
+	previous := http.DefaultTransport
+	http.DefaultTransport = issuer.Client().Transport
+	t.Cleanup(func() { http.DefaultTransport = previous })
+	rt, err := wasm.NewRuntime(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rt.Close(t.Context()) })
+	data, err := os.ReadFile("../wasm/testdata/example.wasm")
+	require.NoError(t, err)
+	mod, err := rt.LoadModule(t.Context(), data)
+	require.NoError(t, err)
+	mod.SetName("primer")
+	mod.SetConfigService(cfg)
+	creds := mcp.Credentials{"oauth_issuer": issuer.URL, "oauth_client_id": "public", "oauth_subject": "expected-user", "oauth_email": "expected@example.com", "oauth_token_key": "api_key", "oauth_refresh_token": "rotation-before", "base_url": "https://api.example"}
+	require.NoError(t, cfg.SetIntegration("primer", &mcp.IntegrationConfig{Enabled: true, Credentials: creds, ToolGlobs: []string{"example_echo"}}))
+	require.NoError(t, mod.Configure(t.Context(), creds))
+	w, reg, _ := setupTestWeb()
+	w.services.Config = cfg
+	require.NoError(t, reg.Register(mod))
+	executed := make(chan error, 1)
+	go func() {
+		result, err := mod.Execute(t.Context(), "example_echo", map[string]any{"message": "ready"})
+		if err == nil {
+			assert.False(t, result.IsError)
+		}
+		executed <- err
+	}()
+	<-entered
+	started, finished := make(chan struct{}), make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		rr := httptest.NewRecorder()
+		close(started)
+		w.Handler().ServeHTTP(rr, localOAuthRequest(http.MethodPut, "/api/integrations/primer/credentials", `{"oauth_refresh_token":"rotation-before","unrelated":"updated"}`))
+		finished <- rr
+	}()
+	<-started
+	unblock()
+	require.NoError(t, <-executed)
+	require.Equal(t, http.StatusOK, (<-finished).Code)
+	require.NoError(t, cfg.Load())
+	saved, ok := cfg.GetIntegration("primer")
+	require.True(t, ok)
+	assert.Equal(t, "rotation-after", saved.Credentials["oauth_refresh_token"])
+	assert.Equal(t, "updated", saved.Credentials["unrelated"])
+	assert.Equal(t, []string{"example_echo"}, saved.ToolGlobs)
+	assert.Equal(t, int32(1), refreshes.Load())
+}

--- a/web/plugin_oauth_security_test.go
+++ b/web/plugin_oauth_security_test.go
@@ -1,0 +1,94 @@
+package web
+
+import (
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/daltoniam/switchboard/pluginoauth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPluginOAuthCredentialMutationRequiresLocalOrigin(t *testing.T) {
+	for _, method := range []string{http.MethodPost, http.MethodPut} {
+		for _, mode := range []string{"origin", "host", "remote", "fetch-site", "same-site"} {
+			t.Run(method+"/"+mode, func(t *testing.T) {
+				w, _, cfg := pluginOAuthWeb(t)
+				before := maps.Clone(cfg.cfg.Integrations["primer"].Credentials)
+				path, body := "/integrations/primer", "cred_oauth_issuer=https%3A%2F%2Fevil.example"
+				if method == http.MethodPut {
+					path, body = "/api/integrations/primer/credentials", `{"oauth_issuer":"https://evil.example"}`
+				}
+				r := localOAuthRequest(method, path, body)
+				if method == http.MethodPost {
+					r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+				}
+				switch mode {
+				case "origin":
+					r.Header.Set("Origin", "https://evil.example")
+				case "host":
+					r.Host = "evil.example:3847"
+				case "remote":
+					r.RemoteAddr = "192.0.2.1:54321"
+				case "fetch-site":
+					r.Header.Set("Sec-Fetch-Site", "cross-site")
+				case "same-site":
+					r.Header.Set("Sec-Fetch-Site", "same-site")
+				}
+				rr := httptest.NewRecorder()
+				w.Handler().ServeHTTP(rr, r)
+				assert.Equal(t, http.StatusForbidden, rr.Code)
+				assert.Equal(t, before, cfg.cfg.Integrations["primer"].Credentials)
+			})
+		}
+	}
+}
+
+func TestPluginOAuthSettingsEditsClearTokens(t *testing.T) {
+	for _, method := range []string{http.MethodPost, http.MethodPut} {
+		t.Run(method, func(t *testing.T) {
+			w, _, cfg := pluginOAuthWeb(t)
+			creds := cfg.cfg.Integrations["primer"].Credentials
+			creds["oauth_access_token"], creds["oauth_expires_at"] = "old-access", "2030-01-01T00:00:00Z"
+			creds["oauth_token_key"], creds["tasks_api_key"] = "tasks_api_key", "old-guest-access"
+			path, body := "/integrations/primer", "cred_oauth_issuer=https%3A%2F%2Fnew.example&cred_oauth_token_key=other_key"
+			if method == http.MethodPut {
+				path, body = "/api/integrations/primer/credentials", `{"oauth_issuer":"https://new.example","oauth_token_key":"other_key"}`
+			}
+			r := localOAuthRequest(method, path, body)
+			if method == http.MethodPost {
+				r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			}
+			rr := httptest.NewRecorder()
+			w.Handler().ServeHTTP(rr, r)
+			require.Less(t, rr.Code, 400)
+			saved := cfg.cfg.Integrations["primer"].Credentials
+			assert.Equal(t, "https://new.example", saved["oauth_issuer"])
+			for _, key := range []string{"oauth_access_token", "oauth_refresh_token", "oauth_expires_at", "tasks_api_key", "other_key"} {
+				assert.Empty(t, saved[key], key)
+			}
+		})
+	}
+}
+
+func TestPluginOAuthPUTCannotSupplyManagedTokens(t *testing.T) {
+	w, _, cfg := pluginOAuthWeb(t)
+	rr := httptest.NewRecorder()
+	w.Handler().ServeHTTP(rr, localOAuthRequest(http.MethodPut, "/api/integrations/primer/credentials", `{"oauth_refresh_token":"injected","oauth_access_token":"injected","base_url":"https://api.example"}`))
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "native-only", cfg.cfg.Integrations["primer"].Credentials["oauth_refresh_token"])
+	assert.Empty(t, cfg.cfg.Integrations["primer"].Credentials["oauth_access_token"])
+}
+
+func TestPluginOAuthInvalidStatePreservesBrowserCookie(t *testing.T) {
+	w, i, _ := pluginOAuthWeb(t)
+	i.err = pluginoauth.ErrState
+	r := localOAuthRequest(http.MethodGet, "/api/integrations/primer/oauth/callback?code=code&state=other", "")
+	r.AddCookie(&http.Cookie{Name: "switchboard_oauth", Value: "browser"})
+	rr := httptest.NewRecorder()
+	w.Handler().ServeHTTP(rr, r)
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Empty(t, rr.Result().Cookies())
+}

--- a/web/plugin_oauth_test.go
+++ b/web/plugin_oauth_test.go
@@ -3,12 +3,16 @@ package web
 import (
 	"context"
 	"errors"
+	"io"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"testing/iotest"
 
 	mcp "github.com/daltoniam/switchboard"
+	"github.com/daltoniam/switchboard/pluginoauth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -34,6 +38,15 @@ func (i *oauthIntegration) CompleteOAuth(_ context.Context, code, state, browser
 	i.code, i.state, i.browser, i.issuer = code, state, browser, issuer
 	i.calls++
 	return i.err
+}
+
+type oauthCredentialEditor struct {
+	*oauthIntegration
+	manager *pluginoauth.Manager
+}
+
+func (i *oauthCredentialEditor) EditCredentials(ctx context.Context, updates mcp.Credentials, enabled bool) error {
+	return i.manager.EditCredentials(ctx, updates, enabled)
 }
 
 func pluginOAuthWeb(t *testing.T) (*WebServer, *oauthIntegration, *mockConfigService) {
@@ -67,7 +80,13 @@ func TestPluginOAuthStart(t *testing.T) {
 			assert.JSONEq(t, `{"authorize_url":"https://issuer.example/authorize?state=random"}`, rr.Body.String())
 			assert.Equal(t, "http://127.0.0.1:3847/api/integrations/primer/oauth/callback", i.redirect)
 			assert.Equal(t, "https://issuer.example", i.lastCreds["oauth_issuer"])
+			wantClient := "saved-client"
+			if strings.Contains(body, "new-client") {
+				wantClient = "new-client"
+			}
+			assert.Equal(t, wantClient, i.lastCreds["oauth_client_id"])
 			assert.Equal(t, "saved-client", cfg.cfg.Integrations["primer"].Credentials["oauth_client_id"])
+			assert.False(t, cfg.cfg.Integrations["primer"].Enabled)
 			cookies := rr.Result().Cookies()
 			require.Len(t, cookies, 1)
 			cookie := cookies[0]
@@ -79,6 +98,78 @@ func TestPluginOAuthStart(t *testing.T) {
 			assert.NotEmpty(t, cookie.Value)
 			assert.NotContains(t, rr.Body.String(), "native-only")
 			assert.Equal(t, "no-store", rr.Header().Get("Cache-Control"))
+		})
+	}
+}
+
+func TestPluginOAuthStartFailureDoesNotIssueCookie(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		bytes      int
+		startFails bool
+	}{
+		{name: "entropy failure"},
+		{name: "partial entropy", bytes: 16},
+		{name: "authorization failure", bytes: 32, startFails: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			w, i, cfg := pluginOAuthWeb(t)
+			before := maps.Clone(cfg.cfg.Integrations["primer"].Credentials)
+			w.oauthRandReader = io.MultiReader(strings.NewReader(strings.Repeat("x", tt.bytes)), iotest.ErrReader(errors.New("secret-entropy-error")))
+			if tt.startFails {
+				i.err = errors.New("secret-start-error")
+			}
+			rr := httptest.NewRecorder()
+			w.Handler().ServeHTTP(rr, localOAuthRequest(http.MethodPost, "/api/integrations/primer/oauth/start", "{}"))
+			assert.GreaterOrEqual(t, rr.Code, 400)
+			assert.Empty(t, rr.Result().Cookies())
+			assert.NotContains(t, rr.Body.String(), "authorize_url")
+			assert.NotContains(t, rr.Body.String(), "secret-")
+			assert.Equal(t, before, cfg.cfg.Integrations["primer"].Credentials)
+			assert.False(t, cfg.cfg.Integrations["primer"].Enabled)
+			if tt.startFails {
+				assert.Equal(t, 1, i.calls)
+			} else {
+				assert.Zero(t, i.calls)
+				assert.Empty(t, i.browser)
+			}
+		})
+	}
+}
+
+func TestPluginOAuthCredentialPUTPreservesEnabled(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		oauth       bool
+		editor      bool
+		enabled     bool
+		wantEnabled bool
+	}{
+		{name: "disabled OAuth", oauth: true},
+		{name: "enabled OAuth", oauth: true, enabled: true, wantEnabled: true},
+		{name: "disabled OAuth editor", oauth: true, editor: true},
+		{name: "enabled OAuth editor", oauth: true, editor: true, enabled: true, wantEnabled: true},
+		{name: "disabled ordinary", wantEnabled: true},
+		{name: "enabled ordinary", enabled: true, wantEnabled: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			w, i, cfg := pluginOAuthWeb(t)
+			if tt.editor {
+				require.NoError(t, w.services.Registry.Register(&oauthCredentialEditor{oauthIntegration: i, manager: pluginoauth.New("primer", cfg)}))
+			}
+			name := "testint"
+			if tt.oauth {
+				name = "primer"
+			}
+			cfg.cfg.Integrations[name].Enabled = tt.enabled
+			rr := httptest.NewRecorder()
+			w.Handler().ServeHTTP(rr, localOAuthRequest(http.MethodPut, "/api/integrations/"+name+"/credentials", `{"base_url":"https://edited.example"}`))
+			require.Equal(t, http.StatusOK, rr.Code)
+			assert.Equal(t, tt.wantEnabled, cfg.cfg.Integrations[name].Enabled)
+			assert.Equal(t, "https://edited.example", cfg.cfg.Integrations[name].Credentials["base_url"])
+			if tt.oauth {
+				assert.Equal(t, "native-only", cfg.cfg.Integrations[name].Credentials["oauth_refresh_token"])
+			}
 		})
 	}
 }
@@ -125,7 +216,7 @@ func TestPluginOAuthStartRejectsUnsafeRequests(t *testing.T) {
 func TestPluginOAuthCallback(t *testing.T) {
 	for _, name := range []string{"success", "provider-error", "missing-cookie", "missing-state", "duplicate-code", "denied"} {
 		t.Run(name, func(t *testing.T) {
-			w, i, _ := pluginOAuthWeb(t)
+			w, i, cfg := pluginOAuthWeb(t)
 			if name == "provider-error" {
 				i.err = errors.New("secret-token-error")
 			}
@@ -152,6 +243,7 @@ func TestPluginOAuthCallback(t *testing.T) {
 				assert.Equal(t, "secret-code", i.code)
 				assert.Equal(t, "secret-state", i.state)
 				assert.Equal(t, "https://issuer.example", i.issuer)
+				assert.False(t, cfg.cfg.Integrations["primer"].Enabled)
 			} else if name == "denied" {
 				assert.Empty(t, i.code)
 			} else if name != "provider-error" {
@@ -178,11 +270,17 @@ func TestPluginOAuthDetailHidesTokensAndOffersConnect(t *testing.T) {
 	ic.Credentials["oauth_access_token"] = "access-secret"
 	ic.Credentials["oauth_token_key"] = "tasks_api_key"
 	ic.Credentials["tasks_api_key"] = "legacy-token-secret"
+	ic.Credentials["oauth_expires_at"] = "2030-01-01T00:00:00Z"
+	ic.Credentials["oauth_settings_binding"] = "binding-secret"
+	ic.Credentials["oauth_client_secret"] = "client-secret"
 	rr := httptest.NewRecorder()
 	w.Handler().ServeHTTP(rr, localOAuthRequest(http.MethodGet, "/integrations/primer", ""))
 	require.Equal(t, http.StatusOK, rr.Code)
 	for _, secret := range []string{"native-only", "access-secret", "legacy-token-secret"} {
 		assert.NotContains(t, rr.Body.String(), secret)
+	}
+	for _, key := range []string{"oauth_access_token", "oauth_refresh_token", "oauth_expires_at", "oauth_settings_binding", "oauth_client_secret", "tasks_api_key"} {
+		assert.NotContains(t, rr.Body.String(), `name="cred_`+key+`"`)
 	}
 	assert.Contains(t, rr.Body.String(), "Connect OAuth")
 }

--- a/web/plugin_oauth_test.go
+++ b/web/plugin_oauth_test.go
@@ -1,0 +1,199 @@
+package web
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type oauthIntegration struct {
+	mockIntegration
+	redirect string
+	browser  string
+	code     string
+	state    string
+	issuer   string
+	calls    int
+	err      error
+}
+
+func (i *oauthIntegration) StartOAuth(_ context.Context, creds mcp.Credentials, redirect, browser string) (string, error) {
+	i.lastCreds, i.redirect, i.browser = creds, redirect, browser
+	i.calls++
+	return "https://issuer.example/authorize?state=random", i.err
+}
+
+func (i *oauthIntegration) CompleteOAuth(_ context.Context, code, state, browser, issuer string) error {
+	i.code, i.state, i.browser, i.issuer = code, state, browser, issuer
+	i.calls++
+	return i.err
+}
+
+func pluginOAuthWeb(t *testing.T) (*WebServer, *oauthIntegration, *mockConfigService) {
+	t.Helper()
+	w, reg, cfg := setupTestWeb()
+	i := &oauthIntegration{mockIntegration: mockIntegration{name: "primer"}}
+	require.NoError(t, reg.Register(i))
+	cfg.cfg.Integrations["primer"] = &mcp.IntegrationConfig{Credentials: mcp.Credentials{"oauth_issuer": "https://issuer.example", "oauth_client_id": "saved-client", "oauth_refresh_token": "native-only"}, ToolGlobs: []string{"primer_read_*"}}
+	return w, i, cfg
+}
+
+func localOAuthRequest(method, path, body string) *http.Request {
+	r := httptest.NewRequest(method, "http://127.0.0.1:3847"+path, strings.NewReader(body))
+	r.RemoteAddr = "127.0.0.1:54321"
+	if body != "" {
+		r.Header.Set("Content-Type", "application/json")
+	}
+	return r
+}
+
+func TestPluginOAuthStart(t *testing.T) {
+	for _, body := range []string{"", "{}", `{"credentials":{"oauth_client_id":"new-client"}}`} {
+		t.Run(body, func(t *testing.T) {
+			w, i, cfg := pluginOAuthWeb(t)
+			r := localOAuthRequest(http.MethodPost, "/api/integrations/primer/oauth/start", body)
+			r.Header.Set("Origin", "http://127.0.0.1:3847")
+			r.Header.Set("X-Forwarded-Host", "evil.example")
+			rr := httptest.NewRecorder()
+			w.Handler().ServeHTTP(rr, r)
+			require.Equal(t, http.StatusOK, rr.Code)
+			assert.JSONEq(t, `{"authorize_url":"https://issuer.example/authorize?state=random"}`, rr.Body.String())
+			assert.Equal(t, "http://127.0.0.1:3847/api/integrations/primer/oauth/callback", i.redirect)
+			assert.Equal(t, "https://issuer.example", i.lastCreds["oauth_issuer"])
+			assert.Equal(t, "saved-client", cfg.cfg.Integrations["primer"].Credentials["oauth_client_id"])
+			cookies := rr.Result().Cookies()
+			require.Len(t, cookies, 1)
+			cookie := cookies[0]
+			assert.True(t, cookie.HttpOnly)
+			assert.Equal(t, http.SameSiteLaxMode, cookie.SameSite)
+			assert.Equal(t, "/api/integrations/primer/oauth/callback", cookie.Path)
+			assert.Equal(t, 600, cookie.MaxAge)
+			assert.Equal(t, i.browser, cookie.Value)
+			assert.NotEmpty(t, cookie.Value)
+			assert.NotContains(t, rr.Body.String(), "native-only")
+			assert.Equal(t, "no-store", rr.Header().Get("Cache-Control"))
+		})
+	}
+}
+
+func TestPluginOAuthStartRejectsUnsafeRequests(t *testing.T) {
+	for _, name := range []string{"get", "origin", "null-origin", "host", "localhost", "remote", "fetch-site", "form", "oversize", "trailing-json", "token-input", "unknown-field"} {
+		t.Run(name, func(t *testing.T) {
+			w, i, _ := pluginOAuthWeb(t)
+			r := localOAuthRequest(http.MethodPost, "/api/integrations/primer/oauth/start", "{}")
+			switch name {
+			case "get":
+				r.Method = http.MethodGet
+			case "origin":
+				r.Header.Set("Origin", "https://evil.example")
+			case "null-origin":
+				r.Header.Set("Origin", "null")
+			case "host":
+				r.Host = "evil.example:3847"
+			case "localhost":
+				r.Host = "localhost:3847"
+			case "remote":
+				r.RemoteAddr = "192.0.2.1:4321"
+			case "fetch-site":
+				r.Header.Set("Sec-Fetch-Site", "cross-site")
+			case "form":
+				r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			case "oversize":
+				r = localOAuthRequest(http.MethodPost, r.URL.Path, `{"credentials":{"x":"`+strings.Repeat("x", 65536)+`"}}`)
+			case "trailing-json":
+				r = localOAuthRequest(http.MethodPost, r.URL.Path, `{} {}`)
+			case "token-input":
+				r = localOAuthRequest(http.MethodPost, r.URL.Path, `{"credentials":{"oauth_refresh_token":"secret"}}`)
+			case "unknown-field":
+				r = localOAuthRequest(http.MethodPost, r.URL.Path, `{"enabled":true}`)
+			}
+			rr := httptest.NewRecorder()
+			w.Handler().ServeHTTP(rr, r)
+			assert.GreaterOrEqual(t, rr.Code, 400)
+			assert.Zero(t, i.calls)
+		})
+	}
+}
+
+func TestPluginOAuthCallback(t *testing.T) {
+	for _, name := range []string{"success", "provider-error", "missing-cookie", "missing-state", "duplicate-code", "denied"} {
+		t.Run(name, func(t *testing.T) {
+			w, i, _ := pluginOAuthWeb(t)
+			if name == "provider-error" {
+				i.err = errors.New("secret-token-error")
+			}
+			r := localOAuthRequest(http.MethodGet, "/api/integrations/primer/oauth/callback?code=secret-code&state=secret-state&iss=https%3A%2F%2Fissuer.example", "")
+			if name != "missing-cookie" {
+				r.AddCookie(&http.Cookie{Name: "switchboard_oauth", Value: "browser"})
+			}
+			if name == "missing-state" {
+				r.URL.RawQuery = "code=secret-code"
+			}
+			if name == "duplicate-code" {
+				r.URL.RawQuery += "&code=other"
+			}
+			if name == "denied" {
+				r.URL.RawQuery += "&error=access_denied&error_description=secret-description"
+			}
+			rr := httptest.NewRecorder()
+			w.Handler().ServeHTTP(rr, r)
+			assert.NotContains(t, rr.Body.String()+rr.Header().Get("Location"), "secret")
+			assert.Equal(t, "no-referrer", rr.Header().Get("Referrer-Policy"))
+			if name == "success" {
+				assert.Equal(t, http.StatusSeeOther, rr.Code)
+				assert.Equal(t, "/integrations/primer", rr.Header().Get("Location"))
+				assert.Equal(t, "secret-code", i.code)
+				assert.Equal(t, "secret-state", i.state)
+				assert.Equal(t, "https://issuer.example", i.issuer)
+			} else if name == "denied" {
+				assert.Empty(t, i.code)
+			} else if name != "provider-error" {
+				assert.Zero(t, i.calls)
+			}
+		})
+	}
+}
+
+func TestPluginOAuthAvailability(t *testing.T) {
+	for _, name := range []string{"missing", "testint"} {
+		t.Run(name, func(t *testing.T) {
+			w, _, _ := setupTestWeb()
+			rr := httptest.NewRecorder()
+			w.Handler().ServeHTTP(rr, localOAuthRequest(http.MethodPost, "/api/integrations/"+name+"/oauth/start", ""))
+			assert.Equal(t, http.StatusNotFound, rr.Code)
+		})
+	}
+}
+
+func TestPluginOAuthDetailHidesTokensAndOffersConnect(t *testing.T) {
+	w, _, cfg := pluginOAuthWeb(t)
+	ic := cfg.cfg.Integrations["primer"]
+	ic.Credentials["oauth_access_token"] = "access-secret"
+	ic.Credentials["oauth_token_key"] = "tasks_api_key"
+	ic.Credentials["tasks_api_key"] = "legacy-token-secret"
+	rr := httptest.NewRecorder()
+	w.Handler().ServeHTTP(rr, localOAuthRequest(http.MethodGet, "/integrations/primer", ""))
+	require.Equal(t, http.StatusOK, rr.Code)
+	for _, secret := range []string{"native-only", "access-secret", "legacy-token-secret"} {
+		assert.NotContains(t, rr.Body.String(), secret)
+	}
+	assert.Contains(t, rr.Body.String(), "Connect OAuth")
+}
+
+func TestPluginOAuthFormSavePreservesNativeTokens(t *testing.T) {
+	w, _, cfg := pluginOAuthWeb(t)
+	r := localOAuthRequest(http.MethodPost, "/integrations/primer", "enabled=true&cred_oauth_issuer=https%3A%2F%2Fissuer.example&cred_oauth_refresh_token=attacker")
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	w.Handler().ServeHTTP(rr, r)
+	require.Equal(t, http.StatusSeeOther, rr.Code)
+	assert.Equal(t, "native-only", cfg.cfg.Integrations["primer"].Credentials["oauth_refresh_token"])
+	assert.Equal(t, []string{"primer_read_*"}, cfg.cfg.Integrations["primer"].ToolGlobs)
+}

--- a/web/settings_concurrent_test.go
+++ b/web/settings_concurrent_test.go
@@ -1,0 +1,71 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	mcp "github.com/daltoniam/switchboard"
+	"github.com/daltoniam/switchboard/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type settingsBarrierConfig struct {
+	mcp.ConfigService
+	once    sync.Once
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (s *settingsBarrierConfig) wait() {
+	s.once.Do(func() { close(s.entered); <-s.release })
+}
+
+func (s *settingsBarrierConfig) Get() *mcp.Config {
+	cfg := s.ConfigService.Get()
+	s.wait()
+	return cfg
+}
+
+func (s *settingsBarrierConfig) UpdateConfig(update func(*mcp.Config) error) error {
+	s.wait()
+	return s.ConfigService.(interface {
+		UpdateConfig(func(*mcp.Config) error) error
+	}).UpdateConfig(update)
+}
+
+func TestSettingsSavePreservesConcurrentRotation(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	store, err := config.NewManager()
+	require.NoError(t, err)
+	require.NoError(t, store.SetIntegration("primer", &mcp.IntegrationConfig{Credentials: mcp.Credentials{"oauth_refresh_token": "before"}}))
+	barrier := &settingsBarrierConfig{ConfigService: store, entered: make(chan struct{}), release: make(chan struct{})}
+	w, _, _ := setupTestWeb()
+	w.services.Config = barrier
+	done := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		r := httptest.NewRequest(http.MethodPost, "/settings", strings.NewReader("session_store=file&show_dollar_estimate=true&dollars_per_mtok_input=2.5"))
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		rr := httptest.NewRecorder()
+		w.Handler().ServeHTTP(rr, r)
+		done <- rr
+	}()
+	<-barrier.entered
+	err = store.SetIntegration("primer", &mcp.IntegrationConfig{Enabled: true, Credentials: mcp.Credentials{"oauth_refresh_token": "after"}, ToolGlobs: []string{"primer_*"}})
+	close(barrier.release)
+	require.NoError(t, err)
+	rr := <-done
+	require.Equal(t, http.StatusSeeOther, rr.Code)
+	require.Contains(t, rr.Header().Get("Location"), "success=")
+	require.NoError(t, store.Load())
+	cfg := store.Get()
+	assert.Equal(t, "after", cfg.Integrations["primer"].Credentials["oauth_refresh_token"])
+	assert.True(t, cfg.Integrations["primer"].Enabled)
+	assert.Equal(t, []string{"primer_*"}, cfg.Integrations["primer"].ToolGlobs)
+	assert.Equal(t, "file", cfg.SessionStore)
+	assert.True(t, cfg.ShowDollarEstimate)
+	assert.Equal(t, 2.5, cfg.DollarsPerMTokInput)
+}

--- a/web/templates/pages/integration.templ
+++ b/web/templates/pages/integration.templ
@@ -111,14 +111,23 @@ templ IntegrationDetail(page layouts.PageData, data IntegrationDetailData) {
 		</div>
 		if data.ConnectOAuth {
 			<div class="card">
-				<button type="button" class="btn" data-oauth-start={ "/api/integrations/" + data.Name + "/oauth/start" } onclick="connectPluginOAuth(this)">Connect OAuth</button>
+				<button type="button" class="btn" form="integration-configuration" data-oauth-start={ "/api/integrations/" + data.Name + "/oauth/start" } onclick="connectPluginOAuth(this)">Connect OAuth</button>
 				<p>Open this page using 127.0.0.1. OAuth tokens stay managed by Switchboard; connecting does not enable the integration.</p>
 			</div>
 			<script>
 				async function connectPluginOAuth(button) {
 					button.disabled = true;
 					try {
-						const response = await fetch(button.dataset.oauthStart, {method: "POST", credentials: "same-origin"});
+						const credentials = {};
+						for (const input of button.form.querySelectorAll('input[name^="cred_"]')) {
+							credentials[input.name.slice(5)] = input.value;
+						}
+						const response = await fetch(button.dataset.oauthStart, {
+							method: "POST",
+							credentials: "same-origin",
+							headers: {"Content-Type": "application/json"},
+							body: JSON.stringify({credentials})
+						});
 						if (!response.ok) throw new Error("OAuth start failed. Check configuration and use the 127.0.0.1 address.");
 						const data = await response.json();
 						window.location.assign(data.authorize_url);
@@ -129,7 +138,7 @@ templ IntegrationDetail(page layouts.PageData, data IntegrationDetailData) {
 				}
 			</script>
 		}
-		<form method="POST" action={ templ.SafeURL("/integrations/" + data.Name) }>
+		<form id="integration-configuration" method="POST" action={ templ.SafeURL("/integrations/" + data.Name) }>
 			<div class="card">
 				<div class="card-header">
 					<div class="card-title">Configuration</div>

--- a/web/templates/pages/integration.templ
+++ b/web/templates/pages/integration.templ
@@ -42,6 +42,7 @@ type IntegrationDetailData struct {
 	PlainTextKeys          map[string]bool
 	Placeholders           map[string]string
 	OptionalKeys           map[string]bool
+	ConnectOAuth           bool
 	SupportsIdentities     bool
 	IdentityCredentialKeys []string
 	IdentityMetadataKeys   []string
@@ -108,6 +109,26 @@ templ IntegrationDetail(page layouts.PageData, data IntegrationDetailData) {
 			<h1 class="page-title" style="margin-bottom: 0; text-transform: capitalize;">{ data.Name }</h1>
 			@components.Badge(healthLabel(data.Enabled, data.Healthy), healthBadge(data.Enabled, data.Healthy))
 		</div>
+		if data.ConnectOAuth {
+			<div class="card">
+				<button type="button" class="btn" data-oauth-start={ "/api/integrations/" + data.Name + "/oauth/start" } onclick="connectPluginOAuth(this)">Connect OAuth</button>
+				<p>Open this page using 127.0.0.1. OAuth tokens stay managed by Switchboard; connecting does not enable the integration.</p>
+			</div>
+			<script>
+				async function connectPluginOAuth(button) {
+					button.disabled = true;
+					try {
+						const response = await fetch(button.dataset.oauthStart, {method: "POST", credentials: "same-origin"});
+						if (!response.ok) throw new Error("OAuth start failed. Check configuration and use the 127.0.0.1 address.");
+						const data = await response.json();
+						window.location.assign(data.authorize_url);
+					} catch (error) {
+						alert(error.message);
+						button.disabled = false;
+					}
+				}
+			</script>
+		}
 		<form method="POST" action={ templ.SafeURL("/integrations/" + data.Name) }>
 			<div class="card">
 				<div class="card-header">

--- a/web/templates/pages/integration_templ.go
+++ b/web/templates/pages/integration_templ.go
@@ -50,6 +50,7 @@ type IntegrationDetailData struct {
 	PlainTextKeys          map[string]bool
 	Placeholders           map[string]string
 	OptionalKeys           map[string]bool
+	ConnectOAuth           bool
 	SupportsIdentities     bool
 	IdentityCredentialKeys []string
 	IdentityMetadataKeys   []string
@@ -149,7 +150,7 @@ func IntegrationDetail(page layouts.PageData, data IntegrationDetailData) templ.
 			var templ_7745c5c3_Var3 string
 			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(data.Name)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 108, Col: 91}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 109, Col: 91}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 			if templ_7745c5c3_Err != nil {
@@ -163,20 +164,43 @@ func IntegrationDetail(page layouts.PageData, data IntegrationDetailData) templ.
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div><form method=\"POST\" action=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var4 templ.SafeURL
-			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("/integrations/" + data.Name))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 111, Col: 74}
+			if data.ConnectOAuth {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<div class=\"card\"><button type=\"button\" class=\"btn\" data-oauth-start=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var4 string
+				templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs("/api/integrations/" + data.Name + "/oauth/start")
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 114, Col: 106}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\" onclick=\"connectPluginOAuth(this)\">Connect OAuth</button><p>Open this page using 127.0.0.1. OAuth tokens stay managed by Switchboard; connecting does not enable the integration.</p></div><script>\n\t\t\t\tasync function connectPluginOAuth(button) {\n\t\t\t\t\tbutton.disabled = true;\n\t\t\t\t\ttry {\n\t\t\t\t\t\tconst response = await fetch(button.dataset.oauthStart, {method: \"POST\", credentials: \"same-origin\"});\n\t\t\t\t\t\tif (!response.ok) throw new Error(\"OAuth start failed. Check configuration and use the 127.0.0.1 address.\");\n\t\t\t\t\t\tconst data = await response.json();\n\t\t\t\t\t\twindow.location.assign(data.authorize_url);\n\t\t\t\t\t} catch (error) {\n\t\t\t\t\t\talert(error.message);\n\t\t\t\t\t\tbutton.disabled = false;\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t</script>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, " <form method=\"POST\" action=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "\"><div class=\"card\"><div class=\"card-header\"><div class=\"card-title\">Configuration</div>")
+			var templ_7745c5c3_Var5 templ.SafeURL
+			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("/integrations/" + data.Name))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 132, Col: 74}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "\"><div class=\"card\"><div class=\"card-header\"><div class=\"card-title\">Configuration</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -184,7 +208,7 @@ func IntegrationDetail(page layouts.PageData, data IntegrationDetailData) templ.
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</div><div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div><div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -194,12 +218,12 @@ func IntegrationDetail(page layouts.PageData, data IntegrationDetailData) templ.
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div><div class=\"identity-form-actions\"><button type=\"submit\" class=\"btn\">Save Configuration</button></div></div></form>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</div><div class=\"identity-form-actions\"><button type=\"submit\" class=\"btn\">Save Configuration</button></div></div></form>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if data.SupportsIdentities {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div class=\"card identity-editor\"><div class=\"card-header identity-editor-header\"><div><div class=\"card-title\">Named identities</div><p class=\"identity-hint\">Each tool call selects one identity by ID. Secret values are never rendered; leave a configured credential blank to keep it.</p></div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<div class=\"card identity-editor\"><div class=\"card-header identity-editor-header\"><div><div class=\"card-title\">Named identities</div><p class=\"identity-hint\">Each tool call selects one identity by ID. Secret values are never rendered; leave a configured credential blank to keep it.</p></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -207,279 +231,279 @@ func IntegrationDetail(page layouts.PageData, data IntegrationDetailData) templ.
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				if len(data.Identities) > 0 {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div class=\"identity-list\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<div class=\"identity-list\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					for _, identity := range data.Identities {
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<div class=\"identity-item\"><div class=\"identity-item-heading\"><div><div class=\"identity-name\">")
-						if templ_7745c5c3_Err != nil {
-							return templ_7745c5c3_Err
-						}
-						var templ_7745c5c3_Var5 string
-						templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(identityTitle(identity))
-						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 142, Col: 62}
-						}
-						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
-						if templ_7745c5c3_Err != nil {
-							return templ_7745c5c3_Err
-						}
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</div><code class=\"identity-id\">")
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<div class=\"identity-item\"><div class=\"identity-item-heading\"><div><div class=\"identity-name\">")
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
 						var templ_7745c5c3_Var6 string
-						templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(identity.ID)
+						templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(identityTitle(identity))
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 143, Col: 49}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 163, Col: 62}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</code></div><form method=\"POST\" action=\"")
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</div><code class=\"identity-id\">")
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
-						var templ_7745c5c3_Var7 templ.SafeURL
-						templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("/integrations/" + data.Name + "/identities/" + url.PathEscape(identity.ID) + "/delete"))
+						var templ_7745c5c3_Var7 string
+						templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(identity.ID)
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 145, Col: 140}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 164, Col: 49}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "\" onsubmit=\"return confirm('Delete this identity?');\"><button type=\"submit\" class=\"btn btn-sm btn-outline identity-delete\">Delete</button></form></div><form method=\"POST\" action=\"")
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "</code></div><form method=\"POST\" action=\"")
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
 						var templ_7745c5c3_Var8 templ.SafeURL
-						templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("/integrations/" + data.Name + "/identities"))
+						templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("/integrations/" + data.Name + "/identities/" + url.PathEscape(identity.ID) + "/delete"))
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 149, Col: 96}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 166, Col: 140}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "\"><input type=\"hidden\" name=\"identity_id\" value=\"")
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "\" onsubmit=\"return confirm('Delete this identity?');\"><button type=\"submit\" class=\"btn btn-sm btn-outline identity-delete\">Delete</button></form></div><form method=\"POST\" action=\"")
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
-						var templ_7745c5c3_Var9 string
-						templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(identity.ID)
+						var templ_7745c5c3_Var9 templ.SafeURL
+						templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("/integrations/" + data.Name + "/identities"))
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 150, Col: 68}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 170, Col: 96}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "\"><div class=\"identity-fields\">")
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "\"><input type=\"hidden\" name=\"identity_id\" value=\"")
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						var templ_7745c5c3_Var10 string
+						templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(identity.ID)
+						if templ_7745c5c3_Err != nil {
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 171, Col: 68}
+						}
+						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "\"><div class=\"identity-fields\">")
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
 						for _, field := range identity.Credentials {
-							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<div class=\"form-group\"><label for=\"")
-							if templ_7745c5c3_Err != nil {
-								return templ_7745c5c3_Err
-							}
-							var templ_7745c5c3_Var10 string
-							templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs("identity-" + identity.ID + "-cred-" + field.Key)
-							if templ_7745c5c3_Err != nil {
-								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 154, Col: 73}
-							}
-							_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
-							if templ_7745c5c3_Err != nil {
-								return templ_7745c5c3_Err
-							}
-							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "\">")
+							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<div class=\"form-group\"><label for=\"")
 							if templ_7745c5c3_Err != nil {
 								return templ_7745c5c3_Err
 							}
 							var templ_7745c5c3_Var11 string
-							templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(identityFieldLabel(field.Key))
+							templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs("identity-" + identity.ID + "-cred-" + field.Key)
 							if templ_7745c5c3_Err != nil {
-								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 154, Col: 107}
+								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 175, Col: 73}
 							}
 							_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 							if templ_7745c5c3_Err != nil {
 								return templ_7745c5c3_Err
 							}
-							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</label> <input class=\"form-input\" id=\"")
+							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "\">")
 							if templ_7745c5c3_Err != nil {
 								return templ_7745c5c3_Err
 							}
 							var templ_7745c5c3_Var12 string
-							templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs("identity-" + identity.ID + "-cred-" + field.Key)
+							templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(identityFieldLabel(field.Key))
 							if templ_7745c5c3_Err != nil {
-								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 155, Col: 91}
+								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 175, Col: 107}
 							}
 							_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 							if templ_7745c5c3_Err != nil {
 								return templ_7745c5c3_Err
 							}
-							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "\" type=\"password\" name=\"")
+							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "</label> <input class=\"form-input\" id=\"")
 							if templ_7745c5c3_Err != nil {
 								return templ_7745c5c3_Err
 							}
 							var templ_7745c5c3_Var13 string
-							templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs("identity_cred_" + field.Key)
+							templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs("identity-" + identity.ID + "-cred-" + field.Key)
 							if templ_7745c5c3_Err != nil {
-								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 155, Col: 145}
+								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 176, Col: 91}
 							}
 							_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 							if templ_7745c5c3_Err != nil {
 								return templ_7745c5c3_Err
 							}
-							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "\" value=\"\" placeholder=\"")
+							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "\" type=\"password\" name=\"")
 							if templ_7745c5c3_Err != nil {
 								return templ_7745c5c3_Err
 							}
 							var templ_7745c5c3_Var14 string
-							templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(identityCredentialPlaceholder(field))
+							templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs("identity_cred_" + field.Key)
 							if templ_7745c5c3_Err != nil {
-								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 155, Col: 207}
+								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 176, Col: 145}
 							}
 							_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 							if templ_7745c5c3_Err != nil {
 								return templ_7745c5c3_Err
 							}
-							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "\" autocomplete=\"off\"> ")
-							if templ_7745c5c3_Err != nil {
-								return templ_7745c5c3_Err
-							}
-							if field.Configured {
-								templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<span class=\"identity-secret-status\">Configured</span>")
-								if templ_7745c5c3_Err != nil {
-									return templ_7745c5c3_Err
-								}
-							}
-							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "</div>")
-							if templ_7745c5c3_Err != nil {
-								return templ_7745c5c3_Err
-							}
-						}
-						for _, field := range identity.Metadata {
-							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "<div class=\"form-group\"><label class=\"form-label\" for=\"")
+							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "\" value=\"\" placeholder=\"")
 							if templ_7745c5c3_Err != nil {
 								return templ_7745c5c3_Err
 							}
 							var templ_7745c5c3_Var15 string
-							templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs("identity-" + identity.ID + "-meta-" + field.Key)
+							templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(identityCredentialPlaceholder(field))
 							if templ_7745c5c3_Err != nil {
-								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 163, Col: 92}
+								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 176, Col: 207}
 							}
 							_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 							if templ_7745c5c3_Err != nil {
 								return templ_7745c5c3_Err
 							}
-							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "\">")
+							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "\" autocomplete=\"off\"> ")
+							if templ_7745c5c3_Err != nil {
+								return templ_7745c5c3_Err
+							}
+							if field.Configured {
+								templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "<span class=\"identity-secret-status\">Configured</span>")
+								if templ_7745c5c3_Err != nil {
+									return templ_7745c5c3_Err
+								}
+							}
+							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "</div>")
+							if templ_7745c5c3_Err != nil {
+								return templ_7745c5c3_Err
+							}
+						}
+						for _, field := range identity.Metadata {
+							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<div class=\"form-group\"><label class=\"form-label\" for=\"")
 							if templ_7745c5c3_Err != nil {
 								return templ_7745c5c3_Err
 							}
 							var templ_7745c5c3_Var16 string
-							templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(identityFieldLabel(field.Key))
+							templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs("identity-" + identity.ID + "-meta-" + field.Key)
 							if templ_7745c5c3_Err != nil {
-								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 163, Col: 126}
+								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 184, Col: 92}
 							}
 							_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 							if templ_7745c5c3_Err != nil {
 								return templ_7745c5c3_Err
 							}
-							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "</label> <input class=\"form-input\" type=\"text\" name=\"")
+							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "\">")
 							if templ_7745c5c3_Err != nil {
 								return templ_7745c5c3_Err
 							}
 							var templ_7745c5c3_Var17 string
-							templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs("identity_meta_" + field.Key)
+							templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(identityFieldLabel(field.Key))
 							if templ_7745c5c3_Err != nil {
-								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 164, Col: 85}
+								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 184, Col: 126}
 							}
 							_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 							if templ_7745c5c3_Err != nil {
 								return templ_7745c5c3_Err
 							}
-							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "\" id=\"")
+							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "</label> <input class=\"form-input\" type=\"text\" name=\"")
 							if templ_7745c5c3_Err != nil {
 								return templ_7745c5c3_Err
 							}
 							var templ_7745c5c3_Var18 string
-							templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs("identity-" + identity.ID + "-meta-" + field.Key)
+							templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs("identity_meta_" + field.Key)
 							if templ_7745c5c3_Err != nil {
-								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 164, Col: 141}
+								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 185, Col: 85}
 							}
 							_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 							if templ_7745c5c3_Err != nil {
 								return templ_7745c5c3_Err
 							}
-							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "\" value=\"")
+							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "\" id=\"")
 							if templ_7745c5c3_Err != nil {
 								return templ_7745c5c3_Err
 							}
 							var templ_7745c5c3_Var19 string
-							templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(field.Value)
+							templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs("identity-" + identity.ID + "-meta-" + field.Key)
 							if templ_7745c5c3_Err != nil {
-								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 164, Col: 163}
+								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 185, Col: 141}
 							}
 							_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 							if templ_7745c5c3_Err != nil {
 								return templ_7745c5c3_Err
 							}
-							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "\" placeholder=\"")
+							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "\" value=\"")
 							if templ_7745c5c3_Err != nil {
 								return templ_7745c5c3_Err
 							}
 							var templ_7745c5c3_Var20 string
-							templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs("Enter " + field.Key)
+							templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(field.Value)
 							if templ_7745c5c3_Err != nil {
-								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 164, Col: 200}
+								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 185, Col: 163}
 							}
 							_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 							if templ_7745c5c3_Err != nil {
 								return templ_7745c5c3_Err
 							}
-							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "\"></div>")
+							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "\" placeholder=\"")
+							if templ_7745c5c3_Err != nil {
+								return templ_7745c5c3_Err
+							}
+							var templ_7745c5c3_Var21 string
+							templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs("Enter " + field.Key)
+							if templ_7745c5c3_Err != nil {
+								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 185, Col: 200}
+							}
+							_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
+							if templ_7745c5c3_Err != nil {
+								return templ_7745c5c3_Err
+							}
+							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "\"></div>")
 							if templ_7745c5c3_Err != nil {
 								return templ_7745c5c3_Err
 							}
 						}
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "</div><div class=\"identity-form-actions\"><button type=\"submit\" class=\"btn btn-sm\">Save identity</button></div></form></div>")
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "</div><div class=\"identity-form-actions\"><button type=\"submit\" class=\"btn btn-sm\">Save identity</button></div></form></div>")
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</div>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "</div>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				} else {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "<p class=\"identity-empty\">No identities configured yet.</p>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "<p class=\"identity-empty\">No identities configured yet.</p>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "<div class=\"identity-item identity-item-new\"><div class=\"identity-item-heading\"><div><div class=\"identity-name\">Add identity</div><p class=\"identity-hint\">Choose a stable, human-readable ID such as <code>work</code> or <code>personal</code>.</p></div></div><form method=\"POST\" action=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "<div class=\"identity-item identity-item-new\"><div class=\"identity-item-heading\"><div><div class=\"identity-name\">Add identity</div><p class=\"identity-hint\">Choose a stable, human-readable ID such as <code>work</code> or <code>personal</code>.</p></div></div><form method=\"POST\" action=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var21 templ.SafeURL
-				templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("/integrations/" + data.Name + "/identities"))
+				var templ_7745c5c3_Var22 templ.SafeURL
+				templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("/integrations/" + data.Name + "/identities"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 185, Col: 93}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 206, Col: 93}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "\"><div class=\"identity-fields\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "\"><div class=\"identity-fields\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -488,7 +512,7 @@ func IntegrationDetail(page layouts.PageData, data IntegrationDetailData) templ.
 					return templ_7745c5c3_Err
 				}
 				if len(data.IdentityCredentialKeys) > 0 {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "<div class=\"identity-fieldset-heading\">Credentials</div>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "<div class=\"identity-fieldset-heading\">Credentials</div>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -500,106 +524,106 @@ func IntegrationDetail(page layouts.PageData, data IntegrationDetailData) templ.
 					}
 				}
 				if len(data.IdentityMetadataKeys) > 0 {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "<div class=\"identity-fieldset-heading\">Metadata (optional)</div>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "<div class=\"identity-fieldset-heading\">Metadata (optional)</div>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
 				for _, key := range data.IdentityMetadataKeys {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "<div class=\"form-group\"><label class=\"form-label\" for=\"")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					var templ_7745c5c3_Var22 string
-					templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs("identity-new-meta-" + key)
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 199, Col: 67}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "<div class=\"form-group\"><label class=\"form-label\" for=\"")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var23 string
-					templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(identityFieldLabel(key))
+					templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs("identity-new-meta-" + key)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 199, Col: 95}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 220, Col: 67}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "</label> <input class=\"form-input\" type=\"text\" name=\"")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var24 string
-					templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs("identity_meta_" + key)
+					templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(identityFieldLabel(key))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 200, Col: 76}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 220, Col: 95}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "\" id=\"")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "</label> <input class=\"form-input\" type=\"text\" name=\"")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var25 string
-					templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs("identity-new-meta-" + key)
+					templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs("identity_meta_" + key)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 200, Col: 110}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 221, Col: 76}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "\" value=\"\" placeholder=\"")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "\" id=\"")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var26 string
-					templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs("Enter " + key)
+					templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs("identity-new-meta-" + key)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 200, Col: 150}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 221, Col: 110}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "\"></div>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "\" value=\"\" placeholder=\"")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var27 string
+					templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs("Enter " + key)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 221, Col: 150}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "\"></div>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "</div><div class=\"identity-form-actions\"><button type=\"submit\" class=\"btn btn-sm\">Add identity</button></div></form></div></div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "</div><div class=\"identity-form-actions\"><button type=\"submit\" class=\"btn btn-sm\">Add identity</button></div></form></div></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, " ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, " ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if len(data.Tools) > 0 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "<div class=\"card\"><div class=\"card-title\" style=\"margin-bottom: 0.5rem;\">Available Tools (")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "<div class=\"card\"><div class=\"card-title\" style=\"margin-bottom: 0.5rem;\">Available Tools (")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var27 string
-				templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprint(len(data.Tools)))
+				var templ_7745c5c3_Var28 string
+				templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprint(len(data.Tools)))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 213, Col: 105}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 234, Col: 105}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, ")</div><div class=\"tools-hint\">Operations this integration exposes through the MCP server.</div><div class=\"tools-rows\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, ")</div><div class=\"tools-hint\">Operations this integration exposes through the MCP server.</div><div class=\"tools-rows\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -609,7 +633,7 @@ func IntegrationDetail(page layouts.PageData, data IntegrationDetailData) templ.
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "</div></div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "</div></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}

--- a/web/templates/pages/integration_templ.go
+++ b/web/templates/pages/integration_templ.go
@@ -169,32 +169,32 @@ func IntegrationDetail(page layouts.PageData, data IntegrationDetailData) templ.
 				return templ_7745c5c3_Err
 			}
 			if data.ConnectOAuth {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<div class=\"card\"><button type=\"button\" class=\"btn\" data-oauth-start=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<div class=\"card\"><button type=\"button\" class=\"btn\" form=\"integration-configuration\" data-oauth-start=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var4 string
 				templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs("/api/integrations/" + data.Name + "/oauth/start")
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 114, Col: 106}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 114, Col: 139}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\" onclick=\"connectPluginOAuth(this)\">Connect OAuth</button><p>Open this page using 127.0.0.1. OAuth tokens stay managed by Switchboard; connecting does not enable the integration.</p></div><script>\n\t\t\t\tasync function connectPluginOAuth(button) {\n\t\t\t\t\tbutton.disabled = true;\n\t\t\t\t\ttry {\n\t\t\t\t\t\tconst response = await fetch(button.dataset.oauthStart, {method: \"POST\", credentials: \"same-origin\"});\n\t\t\t\t\t\tif (!response.ok) throw new Error(\"OAuth start failed. Check configuration and use the 127.0.0.1 address.\");\n\t\t\t\t\t\tconst data = await response.json();\n\t\t\t\t\t\twindow.location.assign(data.authorize_url);\n\t\t\t\t\t} catch (error) {\n\t\t\t\t\t\talert(error.message);\n\t\t\t\t\t\tbutton.disabled = false;\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t</script>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\" onclick=\"connectPluginOAuth(this)\">Connect OAuth</button><p>Open this page using 127.0.0.1. OAuth tokens stay managed by Switchboard; connecting does not enable the integration.</p></div><script>\n\t\t\t\tasync function connectPluginOAuth(button) {\n\t\t\t\t\tbutton.disabled = true;\n\t\t\t\t\ttry {\n\t\t\t\t\t\tconst credentials = {};\n\t\t\t\t\t\tfor (const input of button.form.querySelectorAll('input[name^=\"cred_\"]')) {\n\t\t\t\t\t\t\tcredentials[input.name.slice(5)] = input.value;\n\t\t\t\t\t\t}\n\t\t\t\t\t\tconst response = await fetch(button.dataset.oauthStart, {\n\t\t\t\t\t\t\tmethod: \"POST\",\n\t\t\t\t\t\t\tcredentials: \"same-origin\",\n\t\t\t\t\t\t\theaders: {\"Content-Type\": \"application/json\"},\n\t\t\t\t\t\t\tbody: JSON.stringify({credentials})\n\t\t\t\t\t\t});\n\t\t\t\t\t\tif (!response.ok) throw new Error(\"OAuth start failed. Check configuration and use the 127.0.0.1 address.\");\n\t\t\t\t\t\tconst data = await response.json();\n\t\t\t\t\t\twindow.location.assign(data.authorize_url);\n\t\t\t\t\t} catch (error) {\n\t\t\t\t\t\talert(error.message);\n\t\t\t\t\t\tbutton.disabled = false;\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t</script>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, " <form method=\"POST\" action=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, " <form id=\"integration-configuration\" method=\"POST\" action=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var5 templ.SafeURL
 			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("/integrations/" + data.Name))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 132, Col: 74}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 141, Col: 105}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 			if templ_7745c5c3_Err != nil {
@@ -248,7 +248,7 @@ func IntegrationDetail(page layouts.PageData, data IntegrationDetailData) templ.
 						var templ_7745c5c3_Var6 string
 						templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(identityTitle(identity))
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 163, Col: 62}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 172, Col: 62}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 						if templ_7745c5c3_Err != nil {
@@ -261,7 +261,7 @@ func IntegrationDetail(page layouts.PageData, data IntegrationDetailData) templ.
 						var templ_7745c5c3_Var7 string
 						templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(identity.ID)
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 164, Col: 49}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 173, Col: 49}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 						if templ_7745c5c3_Err != nil {
@@ -274,7 +274,7 @@ func IntegrationDetail(page layouts.PageData, data IntegrationDetailData) templ.
 						var templ_7745c5c3_Var8 templ.SafeURL
 						templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("/integrations/" + data.Name + "/identities/" + url.PathEscape(identity.ID) + "/delete"))
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 166, Col: 140}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 175, Col: 140}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 						if templ_7745c5c3_Err != nil {
@@ -287,7 +287,7 @@ func IntegrationDetail(page layouts.PageData, data IntegrationDetailData) templ.
 						var templ_7745c5c3_Var9 templ.SafeURL
 						templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("/integrations/" + data.Name + "/identities"))
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 170, Col: 96}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 179, Col: 96}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 						if templ_7745c5c3_Err != nil {
@@ -300,7 +300,7 @@ func IntegrationDetail(page layouts.PageData, data IntegrationDetailData) templ.
 						var templ_7745c5c3_Var10 string
 						templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(identity.ID)
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 171, Col: 68}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 180, Col: 68}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 						if templ_7745c5c3_Err != nil {
@@ -318,7 +318,7 @@ func IntegrationDetail(page layouts.PageData, data IntegrationDetailData) templ.
 							var templ_7745c5c3_Var11 string
 							templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs("identity-" + identity.ID + "-cred-" + field.Key)
 							if templ_7745c5c3_Err != nil {
-								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 175, Col: 73}
+								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 184, Col: 73}
 							}
 							_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 							if templ_7745c5c3_Err != nil {
@@ -331,7 +331,7 @@ func IntegrationDetail(page layouts.PageData, data IntegrationDetailData) templ.
 							var templ_7745c5c3_Var12 string
 							templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(identityFieldLabel(field.Key))
 							if templ_7745c5c3_Err != nil {
-								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 175, Col: 107}
+								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 184, Col: 107}
 							}
 							_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 							if templ_7745c5c3_Err != nil {
@@ -344,7 +344,7 @@ func IntegrationDetail(page layouts.PageData, data IntegrationDetailData) templ.
 							var templ_7745c5c3_Var13 string
 							templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs("identity-" + identity.ID + "-cred-" + field.Key)
 							if templ_7745c5c3_Err != nil {
-								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 176, Col: 91}
+								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 185, Col: 91}
 							}
 							_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 							if templ_7745c5c3_Err != nil {
@@ -357,7 +357,7 @@ func IntegrationDetail(page layouts.PageData, data IntegrationDetailData) templ.
 							var templ_7745c5c3_Var14 string
 							templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs("identity_cred_" + field.Key)
 							if templ_7745c5c3_Err != nil {
-								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 176, Col: 145}
+								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 185, Col: 145}
 							}
 							_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 							if templ_7745c5c3_Err != nil {
@@ -370,7 +370,7 @@ func IntegrationDetail(page layouts.PageData, data IntegrationDetailData) templ.
 							var templ_7745c5c3_Var15 string
 							templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(identityCredentialPlaceholder(field))
 							if templ_7745c5c3_Err != nil {
-								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 176, Col: 207}
+								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 185, Col: 207}
 							}
 							_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 							if templ_7745c5c3_Err != nil {
@@ -399,7 +399,7 @@ func IntegrationDetail(page layouts.PageData, data IntegrationDetailData) templ.
 							var templ_7745c5c3_Var16 string
 							templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs("identity-" + identity.ID + "-meta-" + field.Key)
 							if templ_7745c5c3_Err != nil {
-								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 184, Col: 92}
+								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 193, Col: 92}
 							}
 							_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 							if templ_7745c5c3_Err != nil {
@@ -412,7 +412,7 @@ func IntegrationDetail(page layouts.PageData, data IntegrationDetailData) templ.
 							var templ_7745c5c3_Var17 string
 							templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(identityFieldLabel(field.Key))
 							if templ_7745c5c3_Err != nil {
-								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 184, Col: 126}
+								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 193, Col: 126}
 							}
 							_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 							if templ_7745c5c3_Err != nil {
@@ -425,7 +425,7 @@ func IntegrationDetail(page layouts.PageData, data IntegrationDetailData) templ.
 							var templ_7745c5c3_Var18 string
 							templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs("identity_meta_" + field.Key)
 							if templ_7745c5c3_Err != nil {
-								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 185, Col: 85}
+								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 194, Col: 85}
 							}
 							_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 							if templ_7745c5c3_Err != nil {
@@ -438,7 +438,7 @@ func IntegrationDetail(page layouts.PageData, data IntegrationDetailData) templ.
 							var templ_7745c5c3_Var19 string
 							templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs("identity-" + identity.ID + "-meta-" + field.Key)
 							if templ_7745c5c3_Err != nil {
-								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 185, Col: 141}
+								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 194, Col: 141}
 							}
 							_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 							if templ_7745c5c3_Err != nil {
@@ -451,7 +451,7 @@ func IntegrationDetail(page layouts.PageData, data IntegrationDetailData) templ.
 							var templ_7745c5c3_Var20 string
 							templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(field.Value)
 							if templ_7745c5c3_Err != nil {
-								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 185, Col: 163}
+								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 194, Col: 163}
 							}
 							_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 							if templ_7745c5c3_Err != nil {
@@ -464,7 +464,7 @@ func IntegrationDetail(page layouts.PageData, data IntegrationDetailData) templ.
 							var templ_7745c5c3_Var21 string
 							templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs("Enter " + field.Key)
 							if templ_7745c5c3_Err != nil {
-								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 185, Col: 200}
+								return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 194, Col: 200}
 							}
 							_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 							if templ_7745c5c3_Err != nil {
@@ -497,7 +497,7 @@ func IntegrationDetail(page layouts.PageData, data IntegrationDetailData) templ.
 				var templ_7745c5c3_Var22 templ.SafeURL
 				templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("/integrations/" + data.Name + "/identities"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 206, Col: 93}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 215, Col: 93}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 				if templ_7745c5c3_Err != nil {
@@ -537,7 +537,7 @@ func IntegrationDetail(page layouts.PageData, data IntegrationDetailData) templ.
 					var templ_7745c5c3_Var23 string
 					templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs("identity-new-meta-" + key)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 220, Col: 67}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 229, Col: 67}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 					if templ_7745c5c3_Err != nil {
@@ -550,7 +550,7 @@ func IntegrationDetail(page layouts.PageData, data IntegrationDetailData) templ.
 					var templ_7745c5c3_Var24 string
 					templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(identityFieldLabel(key))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 220, Col: 95}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 229, Col: 95}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
 					if templ_7745c5c3_Err != nil {
@@ -563,7 +563,7 @@ func IntegrationDetail(page layouts.PageData, data IntegrationDetailData) templ.
 					var templ_7745c5c3_Var25 string
 					templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs("identity_meta_" + key)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 221, Col: 76}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 230, Col: 76}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 					if templ_7745c5c3_Err != nil {
@@ -576,7 +576,7 @@ func IntegrationDetail(page layouts.PageData, data IntegrationDetailData) templ.
 					var templ_7745c5c3_Var26 string
 					templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs("identity-new-meta-" + key)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 221, Col: 110}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 230, Col: 110}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 					if templ_7745c5c3_Err != nil {
@@ -589,7 +589,7 @@ func IntegrationDetail(page layouts.PageData, data IntegrationDetailData) templ.
 					var templ_7745c5c3_Var27 string
 					templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs("Enter " + key)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 221, Col: 150}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 230, Col: 150}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
 					if templ_7745c5c3_Err != nil {
@@ -617,7 +617,7 @@ func IntegrationDetail(page layouts.PageData, data IntegrationDetailData) templ.
 				var templ_7745c5c3_Var28 string
 				templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprint(len(data.Tools)))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 234, Col: 105}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/pages/integration.templ`, Line: 243, Col: 105}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
 				if templ_7745c5c3_Err != nil {

--- a/web/templates/pages/integration_test.go
+++ b/web/templates/pages/integration_test.go
@@ -6,7 +6,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/PuerkitoBio/goquery"
 	"github.com/daltoniam/switchboard/web/templates/layouts"
+	"github.com/dop251/goja"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -81,6 +83,88 @@ func TestIntegrationDetail_RendersIdentityEditorWithoutSecrets(t *testing.T) {
 	assert.NotContains(t, out, `id="identity_meta_label"`)
 	assert.Contains(t, out, "Add identity")
 	assert.NotContains(t, out, "secret-token-value")
+}
+
+func TestIntegrationDetail_OAuthConnectUsesEditedCredentials(t *testing.T) {
+	out := renderIntegrationDetail(t, IntegrationDetailData{
+		Name:                   "primer",
+		ConnectOAuth:           true,
+		SupportsIdentities:     true,
+		IdentityCredentialKeys: []string{"oauth_client_id"},
+		Credentials: []CredentialField{
+			{Key: "oauth_issuer", Value: "https://saved.example"},
+			{Key: "oauth_client_id", Value: "saved-client"},
+			{Key: "oauth_scopes", Value: "saved-scope"},
+			{Key: "base_url", Value: "https://saved-api.example"},
+		},
+	})
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(out))
+	require.NoError(t, err)
+	doc.Find("body").PrependHtml(`<form><input name="cred_oauth_client_id" value="unrelated-client"><input name="cred_unrelated" value="unrelated-secret"></form>`)
+	button := doc.Find("button[data-oauth-start]")
+	require.Equal(t, 1, button.Length())
+	formID, ok := button.Attr("form")
+	require.True(t, ok, "Connect must be associated with its configuration form")
+	form := doc.Find("form").FilterFunction(func(_ int, s *goquery.Selection) bool {
+		return s.AttrOr("id", "") == formID
+	})
+	require.Equal(t, 1, form.Length())
+	assert.Equal(t, "/integrations/primer", form.AttrOr("action", ""))
+	assert.Zero(t, form.Find(`[name^="identity_"]`).Length())
+	form.Find(`[name="cred_oauth_issuer"]`).SetAttr("value", "https://edited.example")
+	form.Find(`[name="cred_oauth_client_id"]`).SetAttr("value", "edited-client")
+	form.Find(`[name="cred_oauth_scopes"]`).SetAttr("value", "")
+	form.Find(`[name="cred_base_url"]`).SetAttr("value", "https://edited-api.example")
+
+	vm := goja.New()
+	require.NoError(t, vm.Set("button", map[string]any{
+		"disabled": false,
+		"dataset":  map[string]string{"oauthStart": button.AttrOr("data-oauth-start", "")},
+		"form": map[string]any{
+			"querySelectorAll": func(selector string) []map[string]string {
+				var inputs []map[string]string
+				form.Find(selector).Each(func(_ int, input *goquery.Selection) {
+					inputs = append(inputs, map[string]string{"name": input.AttrOr("name", ""), "value": input.AttrOr("value", "")})
+				})
+				return inputs
+			},
+		},
+	}))
+	_, err = vm.RunString(`
+		let request, destination;
+		function fetch(url, options) {
+			request = {url, options};
+			return Promise.resolve({ok: true, json: () => Promise.resolve({authorize_url: "https://edited.example/authorize"})});
+		}
+		const window = {location: {assign: url => {destination = url;}}};
+		function alert(message) { throw new Error(message); }
+	`)
+	require.NoError(t, err)
+	script := doc.Find("script").FilterFunction(func(_ int, s *goquery.Selection) bool {
+		return strings.Contains(s.Text(), "async function connectPluginOAuth")
+	}).Text()
+	require.NotEmpty(t, script)
+	_, err = vm.RunString(script)
+	require.NoError(t, err)
+	result, err := vm.RunString("connectPluginOAuth(button)")
+	require.NoError(t, err)
+	promise, ok := result.Export().(*goja.Promise)
+	require.True(t, ok)
+	require.Equal(t, goja.PromiseStateFulfilled, promise.State(), "%v", promise.Result())
+	for expression, want := range map[string]string{
+		"request.url":                             "/api/integrations/primer/oauth/start",
+		"request.options.method":                  "POST",
+		"request.options.credentials":             "same-origin",
+		`request.options.headers["Content-Type"]`: "application/json",
+		"destination":                             "https://edited.example/authorize",
+	} {
+		value, err := vm.RunString(expression)
+		require.NoError(t, err)
+		assert.Equal(t, want, value.String(), expression)
+	}
+	body, err := vm.RunString("request.options.body")
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"credentials":{"oauth_issuer":"https://edited.example","oauth_client_id":"edited-client","oauth_scopes":"","base_url":"https://edited-api.example"}}`, body.String())
 }
 
 func TestIntegrationDetail_OmitsIdentityEditorWhenUnsupported(t *testing.T) {

--- a/web/web.go
+++ b/web/web.go
@@ -88,6 +88,9 @@ func (w *WebServer) Handler() http.Handler {
 	mux.HandleFunc("GET /integrations", w.handleIntegrationsList)
 	mux.HandleFunc("GET /integrations/{name}", w.handleIntegrationDetail)
 	mux.HandleFunc("POST /integrations/{name}", w.handleIntegrationSave)
+	mux.HandleFunc("POST /api/integrations/{name}/oauth/start", w.handlePluginOAuthStart)
+	mux.HandleFunc("GET /api/integrations/{name}/oauth/start", w.handlePluginOAuthStart)
+	mux.HandleFunc("GET /api/integrations/{name}/oauth/callback", w.handlePluginOAuthCallback)
 	mux.HandleFunc("POST /integrations/{name}/identities", w.handleIntegrationIdentitySave)
 	mux.HandleFunc("POST /integrations/{name}/identities/{identity}/delete", w.handleIntegrationIdentityDelete)
 
@@ -478,6 +481,16 @@ func (w *WebServer) handleIntegrationDetail(rw http.ResponseWriter, r *http.Requ
 		})
 	}
 
+	_, supportsOAuth := integration.(mcp.OAuthIntegration)
+	connectOAuth := supportsOAuth && creds["oauth_issuer"] != ""
+	if supportsOAuth {
+		for key := range creds {
+			if managedOAuthCredential(key, creds) {
+				delete(creds, key)
+			}
+		}
+	}
+
 	page := w.pageData(r, integration.Name(), "/integrations")
 	data := pages.IntegrationDetailData{
 		Name:                   name,
@@ -488,6 +501,7 @@ func (w *WebServer) handleIntegrationDetail(rw http.ResponseWriter, r *http.Requ
 		Placeholders:           placeholders,
 		OptionalKeys:           optionalKeys,
 		SupportsIdentities:     supportsIdentities,
+		ConnectOAuth:           connectOAuth,
 		IdentityCredentialKeys: identityCredentialKeys,
 		IdentityMetadataKeys:   identityMetadataKeys,
 		Identities:             identities,
@@ -509,6 +523,11 @@ func (w *WebServer) handleIntegrationSave(rw http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	_, oauth := w.oauthIntegration(name)
+	if oauth && !w.localOAuthRequest(r, true) {
+		http.Error(rw, "Local same-origin request required", http.StatusForbidden)
+		return
+	}
 	if err := r.ParseForm(); err != nil {
 		http.Redirect(rw, r, "/integrations/"+name+"?error=Invalid+form+data", http.StatusSeeOther)
 		return
@@ -534,7 +553,13 @@ func (w *WebServer) handleIntegrationSave(rw http.ResponseWriter, r *http.Reques
 		ic.Identities = existingIC.Identities
 	}
 
-	if err := w.services.Config.SetIntegration(name, ic); err != nil {
+	var err error
+	if oauth {
+		err = w.editPluginCredentials(r, name, creds, enabled)
+	} else {
+		err = w.services.Config.SetIntegration(name, ic)
+	}
+	if err != nil {
 		redirect := "/integrations/" + name
 		if setupIntegrations[name] {
 			redirect += "/setup"
@@ -804,9 +829,24 @@ func (w *WebServer) handleUpdateCredentials(rw http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	_, oauth := w.oauthIntegration(name)
+	if oauth && !w.localOAuthRequest(r, true) {
+		http.Error(rw, "Local same-origin request required", http.StatusForbidden)
+		return
+	}
 	var creds mcp.Credentials
 	if err := json.NewDecoder(r.Body).Decode(&creds); err != nil {
 		writeJSON(rw, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+		return
+	}
+
+	if oauth {
+		if err := w.editPluginCredentials(r, name, creds, true); err != nil {
+			writeJSON(rw, http.StatusInternalServerError, map[string]string{"error": "OAuth credential update failed"})
+			return
+		}
+		w.notifyConfigChanged()
+		writeJSON(rw, http.StatusOK, map[string]string{"ok": "true"})
 		return
 	}
 
@@ -3697,11 +3737,12 @@ func (w *WebServer) handleSettingsSave(rw http.ResponseWriter, r *http.Request) 
 			dollarsPerMTok = v
 		}
 	}
-	cfg := w.services.Config.Get()
-	cfg.SessionStore = sessionStore
-	cfg.ShowDollarEstimate = showDollar
-	cfg.DollarsPerMTokInput = dollarsPerMTok
-	if err := w.services.Config.Update(cfg); err != nil {
+	if err := mcp.UpdateConfig(w.services.Config, func(cfg *mcp.Config) error {
+		cfg.SessionStore = sessionStore
+		cfg.ShowDollarEstimate = showDollar
+		cfg.DollarsPerMTokInput = dollarsPerMTok
+		return nil
+	}); err != nil {
 		http.Redirect(rw, r, "/settings?error=Failed+to+save:+"+err.Error(), http.StatusSeeOther)
 		return
 	}

--- a/web/web.go
+++ b/web/web.go
@@ -2,8 +2,10 @@ package web
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"sort"
@@ -43,15 +45,16 @@ import (
 
 // WebServer serves the configuration web UI using templ templates.
 type WebServer struct {
-	services       *mcp.Services
-	port           int
-	health         *healthCache
-	marketplace    *marketplace.Manager
-	wasmLoader     pluginLoader
-	catalog        project.Catalog
-	awmStore       *awm.Store
-	onConfigChange func()
-	configMu       sync.Mutex
+	services        *mcp.Services
+	port            int
+	health          *healthCache
+	marketplace     *marketplace.Manager
+	wasmLoader      pluginLoader
+	catalog         project.Catalog
+	awmStore        *awm.Store
+	onConfigChange  func()
+	configMu        sync.Mutex
+	oauthRandReader io.Reader
 }
 
 type Option func(*WebServer)
@@ -63,10 +66,11 @@ func WithConfigChangeHook(fn func()) Option {
 // New returns a WebServer that provides a browser-based config UI.
 func New(services *mcp.Services, port int, mp *marketplace.Manager, wl *wasmmod.Loader, opts ...Option) *WebServer {
 	ws := &WebServer{
-		services:    services,
-		port:        port,
-		health:      newHealthCache(services),
-		marketplace: mp,
+		services:        services,
+		port:            port,
+		health:          newHealthCache(services),
+		marketplace:     mp,
+		oauthRandReader: rand.Reader,
 	}
 	if wl != nil {
 		ws.wasmLoader = wl
@@ -841,7 +845,9 @@ func (w *WebServer) handleUpdateCredentials(rw http.ResponseWriter, r *http.Requ
 	}
 
 	if oauth {
-		if err := w.editPluginCredentials(r, name, creds, true); err != nil {
+		ic, _ := w.services.Config.GetIntegration(name)
+		enabled := ic != nil && ic.Enabled
+		if err := w.editPluginCredentials(r, name, creds, enabled); err != nil {
 			writeJSON(rw, http.StatusInternalServerError, map[string]string{"error": "OAuth credential update failed"})
 			return
 		}

--- a/web/web_marketplace.go
+++ b/web/web_marketplace.go
@@ -84,6 +84,9 @@ func (w *WebServer) handlePluginMarketplace(rw http.ResponseWriter, r *http.Requ
 }
 
 func (w *WebServer) handlePluginInstall(rw http.ResponseWriter, r *http.Request) {
+	if !w.allowMarketplaceMutation(rw, r) {
+		return
+	}
 	if w.marketplace == nil {
 		http.Redirect(rw, r, "/plugins?error=Marketplace+not+configured", http.StatusSeeOther)
 		return
@@ -115,6 +118,9 @@ func (w *WebServer) handlePluginInstall(rw http.ResponseWriter, r *http.Request)
 }
 
 func (w *WebServer) handlePluginInstallURL(rw http.ResponseWriter, r *http.Request) {
+	if !w.allowMarketplaceMutation(rw, r) {
+		return
+	}
 	if w.marketplace == nil {
 		http.Redirect(rw, r, "/plugins?error=Marketplace+not+configured", http.StatusSeeOther)
 		return
@@ -146,6 +152,9 @@ func (w *WebServer) handlePluginInstallURL(rw http.ResponseWriter, r *http.Reque
 }
 
 func (w *WebServer) handlePluginUpload(rw http.ResponseWriter, r *http.Request) {
+	if !w.allowMarketplaceMutation(rw, r) {
+		return
+	}
 	if w.marketplace == nil {
 		http.Redirect(rw, r, "/plugins?error=Marketplace+not+configured", http.StatusSeeOther)
 		return
@@ -184,6 +193,9 @@ func (w *WebServer) handlePluginUpload(rw http.ResponseWriter, r *http.Request) 
 }
 
 func (w *WebServer) handlePluginUninstall(rw http.ResponseWriter, r *http.Request) {
+	if !w.allowMarketplaceMutation(rw, r) {
+		return
+	}
 	if w.marketplace == nil {
 		http.Redirect(rw, r, "/plugins?error=Marketplace+not+configured", http.StatusSeeOther)
 		return
@@ -195,17 +207,23 @@ func (w *WebServer) handlePluginUninstall(rw http.ResponseWriter, r *http.Reques
 
 	name := strings.TrimSpace(r.FormValue("name"))
 
-	w.liveUnloadPlugin(r.Context(), name)
+	if err := w.liveUnloadPlugin(r.Context(), name); err != nil {
+		http.Redirect(rw, r, "/plugins?error=Uninstall+failed:+"+urlEncode(err.Error()), http.StatusSeeOther)
+		return
+	}
 
 	if err := w.marketplace.UninstallPlugin(name); err != nil {
 		http.Redirect(rw, r, "/plugins?error=Uninstall+failed:+"+urlEncode(err.Error()), http.StatusSeeOther)
 		return
 	}
 
-	http.Redirect(rw, r, fmt.Sprintf("/plugins?success=Uninstalled+%s.", name), http.StatusSeeOther)
+	http.Redirect(rw, r, fmt.Sprintf("/plugins?success=Uninstalled+%s.", urlEncode(name)), http.StatusSeeOther)
 }
 
 func (w *WebServer) handlePluginUpdate(rw http.ResponseWriter, r *http.Request) {
+	if !w.allowMarketplaceMutation(rw, r) {
+		return
+	}
 	if w.marketplace == nil {
 		http.Redirect(rw, r, "/plugins?error=Marketplace+not+configured", http.StatusSeeOther)
 		return
@@ -237,6 +255,9 @@ func (w *WebServer) handlePluginUpdate(rw http.ResponseWriter, r *http.Request) 
 }
 
 func (w *WebServer) handlePluginCheckUpdates(rw http.ResponseWriter, r *http.Request) {
+	if !w.allowMarketplaceMutation(rw, r) {
+		return
+	}
 	if w.marketplace == nil {
 		http.Redirect(rw, r, "/plugins?error=Marketplace+not+configured", http.StatusSeeOther)
 		return
@@ -262,6 +283,9 @@ func (w *WebServer) handlePluginCheckUpdates(rw http.ResponseWriter, r *http.Req
 }
 
 func (w *WebServer) handlePluginAutoUpdate(rw http.ResponseWriter, r *http.Request) {
+	if !w.allowMarketplaceMutation(rw, r) {
+		return
+	}
 	if w.marketplace == nil {
 		http.Redirect(rw, r, "/plugins?error=Marketplace+not+configured", http.StatusSeeOther)
 		return
@@ -285,6 +309,9 @@ func (w *WebServer) handlePluginAutoUpdate(rw http.ResponseWriter, r *http.Reque
 }
 
 func (w *WebServer) handlePluginAddManifest(rw http.ResponseWriter, r *http.Request) {
+	if !w.allowMarketplaceMutation(rw, r) {
+		return
+	}
 	if w.marketplace == nil {
 		http.Redirect(rw, r, "/plugins?error=Marketplace+not+configured", http.StatusSeeOther)
 		return
@@ -315,6 +342,9 @@ func (w *WebServer) handlePluginAddManifest(rw http.ResponseWriter, r *http.Requ
 }
 
 func (w *WebServer) handlePluginRemoveManifest(rw http.ResponseWriter, r *http.Request) {
+	if !w.allowMarketplaceMutation(rw, r) {
+		return
+	}
 	if w.marketplace == nil {
 		http.Redirect(rw, r, "/plugins?error=Marketplace+not+configured", http.StatusSeeOther)
 		return
@@ -344,16 +374,21 @@ func (w *WebServer) liveLoadPlugin(ctx context.Context, path, nameOverride strin
 	return nil
 }
 
-func (w *WebServer) liveUnloadPlugin(ctx context.Context, name string) {
+func (w *WebServer) liveUnloadPlugin(ctx context.Context, name string) error {
 	if w.wasmLoader == nil {
-		return
+		return nil
 	}
 	if err := w.wasmLoader.UnloadPlugin(ctx, name); err != nil {
 		log.Printf("WARN: live-unload plugin %q failed: %v", name, err)
+		return err
 	}
+	return nil
 }
 
 func (w *WebServer) handlePluginLoadPath(rw http.ResponseWriter, r *http.Request) {
+	if !w.allowMarketplaceMutation(rw, r) {
+		return
+	}
 	if err := r.ParseForm(); err != nil {
 		http.Redirect(rw, r, "/plugins?error=Invalid+form+data", http.StatusSeeOther)
 		return
@@ -379,6 +414,14 @@ func (w *WebServer) handlePluginLoadPath(rw http.ResponseWriter, r *http.Request
 		return
 	}
 	http.Redirect(rw, r, "/plugins?success=Plugin+loaded+from+local+path.", http.StatusSeeOther)
+}
+
+func (w *WebServer) allowMarketplaceMutation(rw http.ResponseWriter, r *http.Request) bool {
+	if !w.localRequest(r, true, true) {
+		http.Error(rw, "Local same-origin request required", http.StatusForbidden)
+		return false
+	}
+	return true
 }
 
 func urlEncode(s string) string {

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -350,7 +350,8 @@ func TestPluginLoadPath_LoadError(t *testing.T) {
 	handler := ws.Handler()
 
 	form := strings.NewReader("path=/nonexistent/path/plugin.wasm")
-	req := httptest.NewRequest("POST", "/plugins/load-path", form)
+	req := httptest.NewRequest("POST", "http://127.0.0.1:3847/plugins/load-path", form)
+	req.RemoteAddr = "127.0.0.1:12345"
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
@@ -365,7 +366,8 @@ func TestPluginLoadPath_EmptyPath(t *testing.T) {
 	handler := ws.Handler()
 
 	form := strings.NewReader("path=")
-	req := httptest.NewRequest("POST", "/plugins/load-path", form)
+	req := httptest.NewRequest("POST", "http://127.0.0.1:3847/plugins/load-path", form)
+	req.RemoteAddr = "127.0.0.1:12345"
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
@@ -379,7 +381,8 @@ func TestPluginLoadPath_NilLoader(t *testing.T) {
 	handler := ws.Handler()
 
 	form := strings.NewReader("path=/tmp/plugin.wasm")
-	req := httptest.NewRequest("POST", "/plugins/load-path", form)
+	req := httptest.NewRequest("POST", "http://127.0.0.1:3847/plugins/load-path", form)
+	req.RemoteAddr = "127.0.0.1:12345"
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
@@ -394,7 +397,8 @@ func TestPluginLoadPath_InvalidExtension(t *testing.T) {
 	handler := ws.Handler()
 
 	form := strings.NewReader("path=/etc/passwd")
-	req := httptest.NewRequest("POST", "/plugins/load-path", form)
+	req := httptest.NewRequest("POST", "http://127.0.0.1:3847/plugins/load-path", form)
+	req.RemoteAddr = "127.0.0.1:12345"
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
@@ -426,7 +430,8 @@ func uploadPlugin(t *testing.T, name string, body []byte) *http.Request {
 	require.NoError(t, err)
 	require.NoError(t, writer.Close())
 
-	req := httptest.NewRequest("POST", "/plugins/upload", &buf)
+	req := httptest.NewRequest("POST", "http://127.0.0.1:3847/plugins/upload", &buf)
+	req.RemoteAddr = "127.0.0.1:12345"
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	return req
 }


### PR DESCRIPTION
## Summary
- Let WASM integrations use public-client authorization-code PKCE and native refresh after initial browser consent, without a companion or browser-dependent token renewal.
- Keep refresh tokens host-only and protect rotations through atomic config updates, same-origin mutation checks, reload/uninstall failure handling, and exact userinfo identity binding.

## Verification
- Full `make ci` passed, including race tests, lint, gosec and govulncheck.
- Focused OAuth/config/web/WASM race suites and MCP response-shape smoke passed.
- Real production Clerk public-client login completed for the expected user; native refresh exchanged and persisted a new access token without browser automation.
- Primer's deployed Tasks API requires a session ID and rejects delegated OAuth; the separately reviewed Tasks boundary is tracked at https://git.fleet.clark.team/aleksclark/primer/pulls/11. No live API acceptance is claimed yet.

Setup and recovery details: `docs/plugin-oauth.md`.

💘 Generated with Crush